### PR TITLE
Do not require tailwind in addon index, move plugin to root instead

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
         'packages/*/config/**/*.js',
         'packages/*/tests/dummy/config/**/*.js',
         'packages/**/tailwind.config.js',
+        'packages/**/tailwind.js',
         'packages/*/addon/tailwind/*.js',
         'packages/tailwindcss-plugin-helpers/**/*.js'
       ],

--- a/packages/buttons/index.js
+++ b/packages/buttons/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: require('./package').name,
-  tailwind: require('./addon/tailwind')
+  name: require('./package').name
 };

--- a/packages/buttons/tailwind.js
+++ b/packages/buttons/tailwind.js
@@ -5,7 +5,7 @@ module.exports = plugin.withOptions(function (userConfig) {
   return function ({ addComponents, theme }) {
     const { options } = resolve(
       '@frontile/buttons',
-      require('./default-options'),
+      require('./addon/tailwind/default-options'),
       userConfig,
       theme
     );

--- a/packages/buttons/tests/dummy/app/styles/tailwind.config.js
+++ b/packages/buttons/tests/dummy/app/styles/tailwind.config.js
@@ -14,5 +14,5 @@ module.exports = {
     extend: {}
   },
   variants: {},
-  plugins: [require('@frontile/buttons').tailwind]
+  plugins: [require('@frontile/buttons/tailwind')]
 };

--- a/packages/changeset-form/tests/dummy/app/styles/tailwind.config.js
+++ b/packages/changeset-form/tests/dummy/app/styles/tailwind.config.js
@@ -4,5 +4,5 @@ module.exports = {
       default: {}
     }
   },
-  plugins: [require('@frontile/forms').tailwind]
+  plugins: [require('@frontile/forms/tailwind')]
 };

--- a/packages/docs/app/styles/tailwind.config.js
+++ b/packages/docs/app/styles/tailwind.config.js
@@ -5,8 +5,8 @@ module.exports = {
     }
   },
   plugins: [
-    require('@frontile/forms').tailwind,
-    require('@frontile/notifications').tailwind,
-    require('@frontile/buttons').tailwind
+    require('@frontile/forms/tailwind'),
+    require('@frontile/notifications/tailwind'),
+    require('@frontile/buttons/tailwind')
   ]
 };

--- a/packages/forms/index.js
+++ b/packages/forms/index.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   name: require('./package').name,
-  tailwind: require('./addon/tailwind'),
   options: {
     'ember-power-select': {
       theme: false

--- a/packages/forms/tailwind.js
+++ b/packages/forms/tailwind.js
@@ -11,7 +11,7 @@ module.exports = plugin.withOptions(function (userConfig) {
   return function ({ addComponents, theme }) {
     const { config, options } = resolve(
       '@frontile/forms',
-      require('./default-options'),
+      require('./addon/tailwind/default-options'),
       userConfig,
       theme
     );

--- a/packages/forms/tests/dummy/app/styles/tailwind.config.js
+++ b/packages/forms/tests/dummy/app/styles/tailwind.config.js
@@ -15,5 +15,5 @@ module.exports = {
       default: {}
     }
   },
-  plugins: [require('@frontile/forms').tailwind]
+  plugins: [require('@frontile/forms/tailwind')]
 };

--- a/packages/notifications/index.js
+++ b/packages/notifications/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: require('./package').name,
-  tailwind: require('./addon/tailwind')
+  name: require('./package').name
 };

--- a/packages/notifications/tailwind.js
+++ b/packages/notifications/tailwind.js
@@ -10,7 +10,7 @@ module.exports = plugin.withOptions(function (userConfig) {
   return function ({ addComponents, theme }) {
     const { options } = resolve(
       '@frontile/notifications',
-      require('./default-options'),
+      require('./addon/tailwind/default-options'),
       userConfig,
       theme
     );

--- a/packages/notifications/tests/dummy/app/styles/tailwind.config.js
+++ b/packages/notifications/tests/dummy/app/styles/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
   },
   variants: {},
   plugins: [
-    require('@frontile/notifications').tailwind,
-    require('@frontile/forms').tailwind
+    require('@frontile/notifications/tailwind'),
+    require('@frontile/forms/tailwind')
   ]
 };


### PR DESCRIPTION
Instead of requiring tailwind plugin from `require('@frontile/forms').tailwind`, now should be required from `require('@frontile/forms/tailwind')`.

