### PR TITLE
Add ability to pass config options to overlay tailwind plugin & Add option to vertically center the modal

### DIFF
--- a/packages/notifications/addon/tailwind/default-options.js
+++ b/packages/notifications/addon/tailwind/default-options.js
@@ -149,7 +149,7 @@ function defaultOptions({ config }) {
           backgroundRepeat: 'no-repeat',
           iconColor: config.textColor,
           icon: (iconColor) =>
-            `<svg fill="none" viewBox="0 0 24 24" stroke="${iconColor}" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>`
+            `<svg fill="none" stroke="${iconColor}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6 18L18 6M6 6l12 12"></path></svg>`
         },
         customActions: {
           display: 'flex',

--- a/packages/overlays/addon/components/modal/index.hbs
+++ b/packages/overlays/addon/components/modal/index.hbs
@@ -14,7 +14,7 @@
   @contentTransitionName={{if @transitionName @transitionName "overlay--transition--zoom"}}
 >
   <div
-    class="modal"
+    class="modal {{if @isCentered "modal--centered"}}"
     tabindex="0"
     role="dialog"
     aria-labelledby={{this.headerId}}

--- a/packages/overlays/addon/components/modal/index.ts
+++ b/packages/overlays/addon/components/modal/index.ts
@@ -17,6 +17,12 @@ interface ModalArgs extends Omit<OverlayArgs, 'contentTransitionName'> {
    * @defaultValue true
    */
   allowClosing?: boolean;
+
+  /*
+   * If set to true, the modal will be vertically centered
+   * @defaultValue false
+   */
+  isCentered?: boolean;
 }
 
 export default class Modal extends Component<ModalArgs> {

--- a/packages/overlays/addon/tailwind/default-options.js
+++ b/packages/overlays/addon/tailwind/default-options.js
@@ -3,10 +3,21 @@ const defaultTheme = require('tailwindcss/resolveConfig')(
 ).theme;
 
 const defaultConfig = {
-  // empty for now
+  textColor: 'inherit',
+  zIndex: 50,
+  borderRadius: defaultTheme.borderRadius.default,
+  backdropColor: 'rgba(0, 0, 0, 0.45)',
+  modal: {
+    padding: defaultTheme.padding[4],
+    backgroundColor: defaultTheme.colors.white,
+    secondaryBackgroundColor: defaultTheme.colors.gray[100], // Background for footer and close btn applied on hover
+    iconColor: 'currentColor',
+    borderColor: defaultTheme.borderColor.default,
+    maxWidth: defaultTheme.maxWidth['xl']
+  }
 };
 
-function defaultOptions(/*{ config }*/) {
+function defaultOptions({ config }) {
   const inset0 = {
     top: 0,
     bottom: 0,
@@ -17,7 +28,8 @@ function defaultOptions(/*{ config }*/) {
   return {
     default: {
       overlay: {
-        zIndex: 50,
+        color: config.textColor,
+        zIndex: config.zIndex,
         jsIsOpen: {
           overflow: 'hidden'
         },
@@ -25,7 +37,7 @@ function defaultOptions(/*{ config }*/) {
         backdrop: {
           ...inset0,
           position: 'fixed',
-          backgroundColor: 'rgba(0, 0, 0, 0.45)',
+          backgroundColor: config.backdropColor,
           userSelect: 'none'
         },
 
@@ -39,15 +51,15 @@ function defaultOptions(/*{ config }*/) {
         }
       },
       modal: {
-        backgroundColor: defaultTheme.colors.white,
-        borderRadius: defaultTheme.borderRadius.default,
+        backgroundColor: config.modal.backgroundColor,
+        borderRadius: config.borderRadius,
         boxShadow: defaultTheme.boxShadow.default,
         marginBottom: defaultTheme.margin[24],
         marginLeft: 'auto',
         marginRight: 'auto',
         marginTop: defaultTheme.spacing[24],
-        maxWidth: defaultTheme.maxWidth['xl'],
         width: defaultTheme.width.full,
+        maxWidth: config.modal.maxWidth,
         outline: 'none',
         position: 'relative',
 
@@ -67,7 +79,7 @@ function defaultOptions(/*{ config }*/) {
           borderRadius: defaultTheme.borderRadius.full,
 
           '&:hover': {
-            backgroundColor: defaultTheme.colors.gray[200]
+            backgroundColor: config.modal.secondaryBackgroundColor
           },
 
           '&.focus-visible:focus': {
@@ -79,31 +91,30 @@ function defaultOptions(/*{ config }*/) {
             height: '1em',
             width: '1em',
             backgroundRepeat: 'no-repeat',
-            iconColor: 'currentColor',
+            iconColor: config.modal.iconColor,
             icon: (iconColor) =>
               `<svg fill="none" stroke="${iconColor}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6 18L18 6M6 6l12 12"></path></svg>`
           }
         },
-
         header: {
           fontWeight: defaultTheme.fontWeight.bold,
           fontSize: defaultTheme.fontSize.xl,
-          padding: defaultTheme.padding[4],
-          borderTopRightRadius: defaultTheme.borderRadius.default,
-          borderTopLeftRadius: defaultTheme.borderRadius.default
+          padding: config.modal.padding,
+          borderTopRightRadius: config.borderRadius,
+          borderTopLeftRadius: config.borderRadius
         },
         body: {
-          padding: defaultTheme.padding[4]
+          padding: config.modal.padding
         },
         footer: {
           display: 'flex',
           justifyContent: 'flex-end',
-          backgroundColor: defaultTheme.colors.gray[100],
+          backgroundColor: config.modal.secondaryBackgroundColor,
           borderTopWidth: defaultTheme.borderWidth.default,
-          borderTopColor: defaultTheme.borderColor.default,
-          padding: defaultTheme.padding[4],
-          borderBottomRightRadius: defaultTheme.borderRadius.default,
-          borderBottomLeftRadius: defaultTheme.borderRadius.default
+          borderTopColor: config.modal.borderColor,
+          padding: config.modal.padding,
+          borderBottomRightRadius: config.borderRadius,
+          borderBottomLeftRadius: config.borderRadius
         }
       },
       transitions: {

--- a/packages/overlays/addon/tailwind/default-options.js
+++ b/packages/overlays/addon/tailwind/default-options.js
@@ -33,6 +33,8 @@ function defaultOptions(/*{ config }*/) {
           ...inset0,
           position: 'fixed',
           overflow: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
           '-webkit-overflow-scrolling': 'touch'
         }
       },
@@ -45,6 +47,7 @@ function defaultOptions(/*{ config }*/) {
         marginRight: 'auto',
         marginTop: defaultTheme.spacing[24],
         maxWidth: defaultTheme.maxWidth['xl'],
+        width: defaultTheme.width.full,
         outline: 'none',
         position: 'relative',
 
@@ -150,6 +153,12 @@ function defaultOptions(/*{ config }*/) {
         content: {
           position: 'absolute'
         }
+      }
+    },
+    centered: {
+      modal: {
+        marginTop: 'auto',
+        marginBottom: 'auto'
       }
     }
   };

--- a/packages/overlays/addon/tailwind/default-options.js
+++ b/packages/overlays/addon/tailwind/default-options.js
@@ -7,8 +7,102 @@ const defaultConfig = {
 };
 
 function defaultOptions(/*{ config }*/) {
+  const inset0 = {
+    top: 0,
+    bottom: 0,
+    right: 0,
+    left: 0
+  };
+
   return {
     default: {
+      overlay: {
+        zIndex: 50,
+        jsIsOpen: {
+          overflow: 'hidden'
+        },
+
+        backdrop: {
+          ...inset0,
+          position: 'fixed',
+          backgroundColor: 'rgba(0, 0, 0, 0.45)',
+          userSelect: 'none'
+        },
+
+        content: {
+          ...inset0,
+          position: 'fixed',
+          overflow: 'auto',
+          '-webkit-overflow-scrolling': 'touch'
+        }
+      },
+      modal: {
+        backgroundColor: defaultTheme.colors.white,
+        borderRadius: defaultTheme.borderRadius.default,
+        boxShadow: defaultTheme.boxShadow.default,
+        marginBottom: defaultTheme.margin[24],
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        marginTop: defaultTheme.spacing[24],
+        maxWidth: defaultTheme.maxWidth['xl'],
+        outline: 'none',
+        position: 'relative',
+
+        [`@media (max-width: ${defaultTheme.screens.sm})`]: {
+          maxWidth: `calc(100vw - ${defaultTheme.margin[4]})`
+        },
+
+        closeBtn: {
+          display: 'flex',
+          position: 'absolute',
+          fontSize: defaultTheme.fontSize.xl,
+          padding: defaultTheme.spacing[2],
+          top: defaultTheme.padding[2],
+          right: defaultTheme.padding[2],
+          transitionProperty: defaultTheme.transitionProperty.default,
+          transitionDuration: defaultTheme.transitionDuration[200],
+          borderRadius: defaultTheme.borderRadius.full,
+
+          '&:hover': {
+            backgroundColor: defaultTheme.colors.gray[200]
+          },
+
+          '&.focus-visible:focus': {
+            outline: 'none',
+            boxShadow: defaultTheme.boxShadow.outline
+          },
+
+          icon: {
+            height: '1em',
+            width: '1em',
+            backgroundRepeat: 'no-repeat',
+            iconColor: 'currentColor',
+            icon: (iconColor) =>
+              `<svg fill="none" stroke="${iconColor}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6 18L18 6M6 6l12 12"></path></svg>`
+          }
+        },
+
+        header: {
+          fontWeight: defaultTheme.fontWeight.bold,
+          fontSize: defaultTheme.fontSize.xl,
+          padding: defaultTheme.padding[4],
+          borderTopRightRadius: defaultTheme.borderRadius.default,
+          borderTopLeftRadius: defaultTheme.borderRadius.default
+        },
+        body: {
+          padding: defaultTheme.padding[4]
+        },
+        footer: {
+          display: 'flex',
+          justifyContent: 'flex-end',
+          backgroundColor: defaultTheme.colors.gray[100],
+          borderTopWidth: defaultTheme.borderWidth.default,
+          borderTopColor: defaultTheme.borderColor.default,
+          padding: defaultTheme.padding[4],
+          borderBottomRightRadius: defaultTheme.borderRadius.default,
+          borderBottomLeftRadius: defaultTheme.borderRadius.default
+        }
+      },
       transitions: {
         fade: {
           enter: {
@@ -45,108 +139,6 @@ function defaultOptions(/*{ config }*/) {
             transform: 'scale(0.8)',
             transition: 'all 0.2s ease-in-out'
           }
-        }
-      },
-
-      overlay: {
-        zIndex: 50,
-        jsIsOpen: {
-          overflow: 'hidden'
-        },
-
-        backdrop: {
-          position: 'fixed',
-          top: 0,
-          bottom: 0,
-          right: 0,
-          left: 0,
-          backgroundColor: 'rgba(0, 0, 0, 0.45)',
-          userSelect: 'none'
-        },
-
-        content: {
-          position: 'fixed',
-          top: 0,
-          bottom: 0,
-          right: 0,
-          left: 0,
-          overflow: 'auto',
-          '-webkit-overflow-scrolling': 'touch'
-        }
-      },
-      modal: {
-        position: 'relative',
-        backgroundColor: defaultTheme.colors.white,
-        borderRadius: defaultTheme.borderRadius.default,
-        boxShadow: defaultTheme.boxShadow.default,
-        maxWidth: defaultTheme.maxWidth['xl'],
-        marginLeft: 'auto',
-        marginRight: 'auto',
-        outline: 'none',
-        marginTop: defaultTheme.spacing[24],
-        marginBottom: defaultTheme.margin[4],
-
-        [`@media (max-width: ${defaultTheme.screens.sm})`]: {
-          maxWidth: `calc(100vw - ${defaultTheme.margin[4]})`
-        },
-
-        closeBtn: {
-          display: 'flex',
-          position: 'absolute',
-          fontSize: defaultTheme.fontSize.xl,
-          padding: defaultTheme.spacing[2],
-          top: defaultTheme.padding[2],
-          right: defaultTheme.padding[2],
-          transitionProperty: defaultTheme.transitionProperty.default,
-          transitionDuration: defaultTheme.transitionDuration[200],
-          borderRadius: defaultTheme.borderRadius.full,
-
-          '&:hover': {
-            backgroundColor: defaultTheme.colors.gray[200]
-          },
-
-          '&.focus-visible:focus': {
-            outline: 'none',
-            boxShadow: defaultTheme.boxShadow.outline
-          },
-
-          icon: {
-            display: 'inline-block',
-            height: '1em',
-            width: '1em',
-            backgroundRepeat: 'no-repeat',
-            iconColor: 'currentColor',
-            icon: (iconColor) =>
-              `<svg fill="none" viewBox="0 0 24 24" stroke="${iconColor}" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>`
-          }
-        },
-
-        header: {
-          fontWeight: defaultTheme.fontWeight.bold,
-          fontSize: defaultTheme.fontSize.xl,
-          paddingTop: defaultTheme.padding[4],
-          paddingBottom: defaultTheme.padding[4],
-          paddingRight: defaultTheme.padding[4],
-          paddingLeft: defaultTheme.padding[4]
-        },
-        body: {
-          paddingTop: defaultTheme.padding[4],
-          paddingBottom: defaultTheme.padding[8],
-          paddingRight: defaultTheme.padding[4],
-          paddingLeft: defaultTheme.padding[4]
-        },
-        footer: {
-          display: 'flex',
-          justifyContent: 'flex-end',
-          backgroundColor: defaultTheme.colors.gray[100],
-          borderTopWidth: defaultTheme.borderWidth.default,
-          borderTopColor: defaultTheme.borderColor.default,
-          paddingTop: defaultTheme.padding[4],
-          paddingBottom: defaultTheme.padding[4],
-          paddingRight: defaultTheme.padding[4],
-          paddingLeft: defaultTheme.padding[4],
-          borderBottomRightRadius: defaultTheme.borderRadius.default,
-          borderBottomLeftRadius: defaultTheme.borderRadius.default
         }
       }
     },

--- a/packages/overlays/addon/tailwind/default-options.js
+++ b/packages/overlays/addon/tailwind/default-options.js
@@ -50,14 +50,6 @@ function defaultOptions(/*{ config }*/) {
 
       overlay: {
         zIndex: 50,
-        overflow: 'auto',
-        position: 'fixed',
-        top: 0,
-        bottom: 0,
-        right: 0,
-        left: 0,
-        '-webkit-overflow-scrolling': 'touch',
-
         jsIsOpen: {
           overflow: 'hidden'
         },
@@ -68,13 +60,18 @@ function defaultOptions(/*{ config }*/) {
           bottom: 0,
           right: 0,
           left: 0,
-          overflow: 'auto',
           backgroundColor: 'rgba(0, 0, 0, 0.45)',
           userSelect: 'none'
         },
 
         content: {
-          position: 'relative'
+          position: 'fixed',
+          top: 0,
+          bottom: 0,
+          right: 0,
+          left: 0,
+          overflow: 'auto',
+          '-webkit-overflow-scrolling': 'touch'
         }
       },
       modal: {
@@ -86,7 +83,7 @@ function defaultOptions(/*{ config }*/) {
         marginLeft: 'auto',
         marginRight: 'auto',
         outline: 'none',
-        top: defaultTheme.spacing[24],
+        marginTop: defaultTheme.spacing[24],
         marginBottom: defaultTheme.margin[4],
 
         [`@media (max-width: ${defaultTheme.screens.sm})`]: {
@@ -155,8 +152,10 @@ function defaultOptions(/*{ config }*/) {
     },
     'in-place': {
       overlay: {
-        position: 'absolute',
         backdrop: {
+          position: 'absolute'
+        },
+        content: {
           position: 'absolute'
         }
       }

--- a/packages/overlays/ember-cli-build.js
+++ b/packages/overlays/ember-cli-build.js
@@ -11,7 +11,9 @@ module.exports = function (defaults) {
     postcssOptions: {
       compile: {
         enabled: true,
-        cacheInclude: [/.*\.css$/, /.tailwind\.config\.js$/],
+        cacheExclude: [],
+        cacheInclude: [],
+        // cacheInclude: [/.*\.css$/, /.tailwind\.config\.js$/],
         plugins: [
           require('tailwindcss')(
             path.join('tests', 'dummy', 'app', 'styles', 'tailwind.config.js')

--- a/packages/overlays/tailwind.js
+++ b/packages/overlays/tailwind.js
@@ -83,7 +83,7 @@ module.exports = plugin.withOptions(function (userConfig) {
         addComponents({
           [`.modal${modifier} .modal__close-btn`]: closeBtn
         });
-        if (!isEmpty(closeBtn.icon)) {
+        if (!isEmpty(btnIcon)) {
           addComponents(
             replaceIconDeclarations(
               {

--- a/packages/overlays/tailwind.js
+++ b/packages/overlays/tailwind.js
@@ -60,41 +60,58 @@ module.exports = plugin.withOptions(function (userConfig) {
         return;
       }
       const { closeBtn } = options;
-      delete options.closeBtn;
+
+      if (closeBtn) {
+        delete options.closeBtn;
+      }
 
       addComponents({ [`.modal${modifier}`]: options });
-      addComponents({
-        [`.modal${modifier} .modal__header`]: options.header
-      });
 
-      const { icon: btnIcon } = closeBtn;
-      delete closeBtn.icon;
+      if (!isEmpty(options.header)) {
+        addComponents({
+          [`.modal${modifier} .modal__header`]: options.header
+        });
+      }
 
-      addComponents({
-        [`.modal${modifier} .modal__close-btn`]: closeBtn
-      });
+      if (!isEmpty(closeBtn)) {
+        const { icon: btnIcon } = closeBtn;
 
-      addComponents(
-        replaceIconDeclarations(
-          {
-            [`.modal${modifier} .modal__close-btn--icon`]: btnIcon
-          },
-          ({ icon = btnIcon.icon, iconColor = btnIcon.iconColor }) => {
-            return {
-              backgroundImage: `url("${svgToDataUri(
-                typeof icon === 'function' ? icon(iconColor) : icon
-              )}")`
-            };
-          }
-        )
-      );
+        if (btnIcon) {
+          delete closeBtn.icon;
+        }
 
-      addComponents({
-        [`.modal${modifier} .modal__body`]: options.body
-      });
-      addComponents({
-        [`.modal${modifier} .modal__footer`]: options.footer
-      });
+        addComponents({
+          [`.modal${modifier} .modal__close-btn`]: closeBtn
+        });
+        if (!isEmpty(closeBtn.icon)) {
+          addComponents(
+            replaceIconDeclarations(
+              {
+                [`.modal${modifier} .modal__close-btn--icon`]: btnIcon
+              },
+              ({ icon = btnIcon.icon, iconColor = btnIcon.iconColor }) => {
+                return {
+                  backgroundImage: `url("${svgToDataUri(
+                    typeof icon === 'function' ? icon(iconColor) : icon
+                  )}")`
+                };
+              }
+            )
+          );
+        }
+      }
+
+      if (!isEmpty(options.body)) {
+        addComponents({
+          [`.modal${modifier} .modal__body`]: options.body
+        });
+      }
+
+      if (!isEmpty(options.footer)) {
+        addComponents({
+          [`.modal${modifier} .modal__footer`]: options.footer
+        });
+      }
     }
 
     addTransitions(options.default.transitions);

--- a/packages/overlays/tests/dummy/app/components/demo-modal.hbs
+++ b/packages/overlays/tests/dummy/app/components/demo-modal.hbs
@@ -4,11 +4,48 @@
   Open Modal
 </Button>
 
-<div class="relative h-48 w-3xl">
+<Modal
+  @isOpen={{this.isOpen}}
+  @onClose={{this.toggleModal}}
+  @renderInPlace={{false}}
+  as |m|
+>
+  <m.Header>Title</m.Header>
+  <m.Body>
+    <p>Some contents...</p>
+    <p>Some contents...</p>
+    <p>Some contents...</p>
+  </m.Body>
+  <m.Footer>
+    <Button
+      @appearance="minimal"
+      class="mr-4"
+      {{on "click" this.toggleModal}}
+    >
+      Cancel
+    </Button>
+    <Button
+      @intent="primary"
+      disabled={{this.isLoading}}
+      {{on "click" this.save}}
+    >
+      {{if this.isLoading "Loading..." "Save"}}
+    </Button>
+  </m.Footer>
+</Modal>
+
+<Button
+  {{on "click" this.toggleInPlaceModal}}
+>
+  Open In Place Modal
+</Button>
+
+<div class="relative h-64 border w-3xl">
   <Modal
-    @isOpen={{this.isOpen}}
-    @onClose={{this.toggleModal}}
-    @renderInPlace={{false}}
+    @isOpen={{this.isInPlaceOpen}}
+    @onClose={{this.toggleInPlaceModal}}
+    @renderInPlace={{true}}
+    @disableFocusTrap={{true}}
     as |m|
   >
     <m.Header>Title</m.Header>
@@ -19,18 +56,10 @@
     </m.Body>
     <m.Footer>
       <Button
-        @appearance="minimal"
-        class="mr-4"
+        @intent="primary"
         {{on "click" this.toggleModal}}
       >
-        Cancel
-      </Button>
-      <Button
-        @intent="primary"
-        disabled={{this.isLoading}}
-        {{on "click" this.save}}
-      >
-        {{if this.isLoading "Loading..." "Save"}}
+        Save
       </Button>
     </m.Footer>
   </Modal>

--- a/packages/overlays/tests/dummy/app/components/demo-modal.ts
+++ b/packages/overlays/tests/dummy/app/components/demo-modal.ts
@@ -7,10 +7,15 @@ interface DemoModalArgs {}
 
 export default class DemoModal extends Component<DemoModalArgs> {
   @tracked isOpen = false;
+  @tracked isInPlaceOpen = false;
   @tracked isLoading = false;
 
   @action toggleModal(): void {
     this.isOpen = !this.isOpen;
+  }
+
+  @action toggleInPlaceModal(): void {
+    this.isInPlaceOpen = !this.isInPlaceOpen;
   }
 
   @action save(): void {

--- a/packages/overlays/tests/integration/components/modal-test.ts
+++ b/packages/overlays/tests/integration/components/modal-test.ts
@@ -11,6 +11,7 @@ module('Integration | Component | modal', function (hooks) {
     <Modal
       @isOpen={{this.isOpen}}
       @onClose={{this.onClose}}
+      @isCentered={{this.isCentered}}
       @allowClosing={{this.allowClosing}}
       @renderInPlace={{this.renderInPlace}}
       @destinationElementId="my-destination"
@@ -50,6 +51,14 @@ module('Integration | Component | modal', function (hooks) {
     assert
       .dom('[data-test-id="modal"] .modal__header')
       .hasAttribute('id', ariaLablledBy);
+  });
+
+  test('it adds modifier class if @isCentered is set to true', async function (assert) {
+    this.set('isOpen', true);
+    this.set('isCentered', true);
+    await render(template);
+
+    assert.dom('[data-test-id="modal"]').hasClass('modal--centered');
   });
 
   test('it closes modal when close button is clicked', async function (assert) {


### PR DESCRIPTION
Closes #59

Here is an example config for a dark mode modal.
```js
    // tailwind.config.js
    require('@frontile/overlays/tailwind')(({ theme }) => {
      return {
        textColor: theme('colors.gray.100'),
        backdropColor: 'rgba(255,255,255,0.3)',
        modal: {
          backgroundColor: theme('colors.gray.800'),
          secondaryBackgroundColor: theme('colors.gray.700'),
          borderColor: theme('colors.gray.900'),
          iconColor: theme('colors.white')
        }
      };
    })
```

![image](https://user-images.githubusercontent.com/230476/79034955-8a971e80-7b6e-11ea-98b0-f4c2b37ba9c5.png)
