### PR TITLE
fix(overlay): zindex on backdrop and content

### DIFF
--- a/packages/overlays/addon/tailwind/default-options.js
+++ b/packages/overlays/addon/tailwind/default-options.js
@@ -38,7 +38,8 @@ function defaultOptions({ config }) {
           ...inset0,
           position: 'fixed',
           backgroundColor: config.backdropColor,
-          userSelect: 'none'
+          userSelect: 'none',
+          zIndex: 1
         },
 
         content: {
@@ -47,7 +48,8 @@ function defaultOptions({ config }) {
           overflow: 'auto',
           display: 'flex',
           flexDirection: 'column',
-          '-webkit-overflow-scrolling': 'touch'
+          '-webkit-overflow-scrolling': 'touch',
+          zIndex: 2
         }
       },
       modal: {


### PR DESCRIPTION
Not sure why, maybe because the elements are fixed, but the zindex on the parent doesn't promote the children above other elements before and with a lower zindex than the overlay. Saw the issue with ember-leaflet, the map would be over the backdrop and content.