### PR TITLE
Add ability to style forms with namespaces

### DIFF
--- a/packages/forms/addon/tailwind/default-options.js
+++ b/packages/forms/addon/tailwind/default-options.js
@@ -9,6 +9,7 @@ const defaultConfig = {
   hintColor: defaultTheme.colors.gray[500],
   disabledTextColor: defaultTheme.colors.gray[500],
   checkboxAndRadioColor: defaultTheme.colors.blue[500],
+  checkboxAndRadioIconColor: defaultTheme.colors.white,
   invalidColor: defaultTheme.colors.red[600],
   backgroundColor: defaultTheme.colors.white,
   focusBoxShadow: defaultTheme.boxShadow.outline,
@@ -103,7 +104,7 @@ function defaultOptions({ config }) {
         backgroundColor: config.backgroundColor,
         borderColor: config.borderColor,
         borderWidth: defaultTheme.borderWidth.default,
-        iconColor: config.backgroundColor,
+        iconColor: config.checkboxAndRadioIconColor,
         '&:focus': {
           outline: 'none'
         },

--- a/packages/tailwindcss-plugin-helpers/src/index.js
+++ b/packages/tailwindcss-plugin-helpers/src/index.js
@@ -87,7 +87,9 @@ function camelCaseToDash(str) {
 }
 
 module.exports = {
+  map,
   merge,
+  fromPairs,
   isEmpty,
   flattenOptions,
   replaceIconDeclarations,


### PR DESCRIPTION
When it comes to change the icon colors using for example css variables, that doesn't work as we use inline URLs SVGs for the icons.

This PR adds the ability to specify the icon colors + the ability to add styles with a namespace, ultimately allowing us to change the icon color depending on a parent class.

Here is the config example:

```js
{
    namespaced: {
      '.mode-dark': {
        default: {
          textarea: {
            backgroundColor: 'blue'
          },
          'checkbox, radio': {
            iconColor: 'red'
          }
        }
      }
  }
}
```