### PR TITLE
Revert "Add selected class when checked"

### DIFF
--- a/packages/forms/addon/components/form-checkbox.hbs
+++ b/packages/forms/addon/components/form-checkbox.hbs
@@ -4,10 +4,7 @@
   class="form-checkbox-container {{@containerClass}} {{if @isSmall "form-checkbox-container--sm" (if @isLarge "form-checkbox-container--lg")}}"
   as |f|
 >
-  <div
-    data-test-form-checkbox-container
-    class="form-checkbox-container__label-container {{if @checked "is-checked"}}"
-  >
+  <div class="form-checkbox-container__label-container">
     <div class="form-checkbox-container__input-container">
       {{!--  Zero-width space character, used to align checkbox properly --}}
       &#8203;

--- a/packages/forms/addon/components/form-radio.hbs
+++ b/packages/forms/addon/components/form-radio.hbs
@@ -4,10 +4,7 @@
   class="form-radio-container {{@containerClass}} {{if @isSmall "form-radio-container--sm" (if @isLarge "form-radio-container--lg")}}"
   as |f|
 >
-  <div
-    data-test-form-radio-container
-    class="form-radio-container__label-container {{if @checked "is-checked"}}"
-  >
+  <div class="form-radio-container__label-container">
     <div class="form-radio-container__input-container">
       {{!--  Zero-width space character, used to align checkbox properly --}}
       &#8203;

--- a/packages/forms/tests/integration/components/form-checkbox-test.ts
+++ b/packages/forms/tests/integration/components/form-checkbox-test.ts
@@ -186,12 +186,4 @@ module('Integration | Component | FormCheckbox', function (hooks) {
       .dom('[data-test-id="form-field-hint"]')
       .doesNotHaveClass('form__hint--lg');
   });
-
-  test('it adds the "is-checked" class when checked', async function (assert) {
-    await render(
-      hbs`<FormCheckbox data-test-input @checked={{true}}>Checked</FormCheckbox>`
-    );
-
-    assert.dom('[data-test-form-checkbox-container]').hasClass('is-checked');
-  });
 });

--- a/packages/forms/tests/integration/components/form-radio-test.ts
+++ b/packages/forms/tests/integration/components/form-radio-test.ts
@@ -189,12 +189,4 @@ module('Integration | Component | FormRadio', function (hooks) {
       .dom('[data-test-id="form-field-hint"]')
       .doesNotHaveClass('form__hint--lg');
   });
-
-  test('it adds the "is-checked" class when checked', async function (assert) {
-    await render(
-      hbs`<FormRadio data-test-input @checked={{true}}>Checked</FormRadio>`
-    );
-
-    assert.dom('[data-test-form-radio-container]').hasClass('is-checked');
-  });
 });


### PR DESCRIPTION
Reverts josemarluedke/frontile#97

After thinking more about this, this actually doesn't make sense as don't have the info if a radio is checked or not... 

Another approach needs to be done here.

Reverting this for now.