### PR TITLE
Migrate Modal & Drawer to use CloseButton component from core

### DIFF
--- a/packages/core/addon/components/close-button.hbs
+++ b/packages/core/addon/components/close-button.hbs
@@ -1,7 +1,7 @@
 <button
   {{on "click" this.handleClick}}
   type="button"
-  class="close-button {{this.sizeClass}}"
+  class="close-button {{this.sizeClass}} {{@class}}"
   ...attributes
 >
   {{#let (concat "close-button__icon " this.sizeClass "__icon") as |iconClassName|}}

--- a/packages/core/addon/components/close-button.ts
+++ b/packages/core/addon/components/close-button.ts
@@ -1,17 +1,28 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-interface CloseButtonArgs {
+export interface CloseButtonArgs {
+  /*
+   * The icon size
+   *
+   * @defaultValue `lg`
+   */
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+  /*
+   * The function to call when button is clicked
+   */
   onClick?: (event: Event) => void;
 }
 
 export default class CloseButton extends Component<CloseButtonArgs> {
   @action handleClick(event: Event): void {
-    this.args.onClick?.(event);
+    if (typeof this.args.onClick === 'function') {
+      this.args.onClick(event);
+    }
   }
 
   get sizeClass(): string {
-    return `close-button--${this.args.size || 'sm'}`;
+    return `close-button--${this.args.size || 'md'}`;
   }
 }

--- a/packages/core/tests/integration/components/close-button-test.ts
+++ b/packages/core/tests/integration/components/close-button-test.ts
@@ -30,16 +30,16 @@ module('Integration | Component | CloseButton', function (hooks) {
     );
     assert
       .dom('.close-button .icon')
-      .hasText('close-button__icon close-button--sm__icon');
+      .hasText('close-button__icon close-button--md__icon');
   });
 
   test('it adds size classes', async function (assert) {
     await render(hbs`<CloseButton @size={{this.size}} />`);
 
-    assert.dom('.close-button').hasClass('close-button--sm');
+    assert.dom('.close-button').hasClass('close-button--md');
     assert
       .dom('.close-button .close-button__icon')
-      .hasClass('close-button--sm__icon');
+      .hasClass('close-button--md__icon');
 
     this.set('size', 'xm');
     assert.dom('.close-button').hasClass('close-button--xm');
@@ -70,5 +70,10 @@ module('Integration | Component | CloseButton', function (hooks) {
     assert
       .dom('.close-button .close-button__icon')
       .hasClass('close-button--xl__icon');
+  });
+
+  test('it allows to pass @class for component curlying', async function (assert) {
+    await render(hbs`<CloseButton @class="some-class" />`);
+    assert.dom('.close-button').hasClass('some-class');
   });
 });

--- a/packages/overlays/addon/components/drawer/index.hbs
+++ b/packages/overlays/addon/components/drawer/index.hbs
@@ -41,19 +41,16 @@
     aria-labelledby={{this.headerId}}
     ...attributes
   >
-    {{#unless this.preventClosing}}
-      <button
-        {{on "click" this.handleClose}}
-        type="button"
-        class="modal__close-btn"
-        data-test-id="drawer-close-btn"
-      >
-        <span class="modal__close-btn--icon"></span>
-        <VisuallyHidden>Close</VisuallyHidden>
-      </button>
-    {{/unless}}
+    {{#if this.showCloseButton}}
+      <CloseButton
+        @onClick={{this.handleClose}}
+        @size={{@closeButtonSize}}
+        class="drawer__close-btn"
+      />
+    {{/if}}
 
     {{yield (hash
+      CloseButton=(component "close-button" onClick=this.handleClose class="drawer__close-btn")
       Header=(component "drawer/header" labelledById=this.headerId)
       Body=(component "drawer/body")
       Footer=(component "drawer/footer")

--- a/packages/overlays/addon/components/drawer/index.ts
+++ b/packages/overlays/addon/components/drawer/index.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { OverlayArgs } from '../overlay';
+import type { CloseButtonArgs } from '@frontile/core/components/close-button';
 
 interface DrawerArgs extends Omit<OverlayArgs, 'contentTransitionName'> {
   /*
@@ -17,6 +18,18 @@ interface DrawerArgs extends Omit<OverlayArgs, 'contentTransitionName'> {
    * @defaultValue true
    */
   allowClosing?: boolean;
+
+  /* If set to false, the close button will not be displayed.
+   *
+   *
+   * @defaultValue true
+   */
+  allowCloseButton?: boolean;
+
+  /*
+   * The Close Button size.
+   */
+  closeButtonSize?: CloseButtonArgs['size'];
 
   /*
    * The Drawer can appear from any side of the screen. The 'placement'
@@ -39,6 +52,12 @@ export default class Drawer extends Component<DrawerArgs> {
 
   get preventClosing(): boolean {
     return this.args.allowClosing === false;
+  }
+
+  get showCloseButton(): boolean {
+    return (
+      this.args.allowClosing !== false && this.args.allowCloseButton !== false
+    );
   }
 
   @action handleClose(): void {

--- a/packages/overlays/addon/components/modal/index.hbs
+++ b/packages/overlays/addon/components/modal/index.hbs
@@ -20,18 +20,16 @@
     aria-labelledby={{this.headerId}}
     ...attributes
   >
-    {{#unless this.preventClosing}}
-      <button
-        {{on "click" this.handleClose}}
-        type="button"
+    {{#if this.showCloseButton}}
+      <CloseButton
+        @onClick={{this.handleClose}}
+        @size={{@closeButtonSize}}
         class="modal__close-btn"
-      >
-        <span class="modal__close-btn--icon"></span>
-        <VisuallyHidden>Close</VisuallyHidden>
-      </button>
-    {{/unless}}
+      />
+    {{/if}}
 
     {{yield (hash
+      CloseButton=(component "close-button" onClick=this.handleClose class="modal__close-btn")
       Header=(component "modal/header" labelledById=this.headerId)
       Body=(component "modal/body")
       Footer=(component "modal/footer")

--- a/packages/overlays/addon/components/modal/index.ts
+++ b/packages/overlays/addon/components/modal/index.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { OverlayArgs } from '../overlay';
+import type { CloseButtonArgs } from '@frontile/core/components/close-button';
 
 interface ModalArgs extends Omit<OverlayArgs, 'contentTransitionName'> {
   /*
@@ -17,6 +18,18 @@ interface ModalArgs extends Omit<OverlayArgs, 'contentTransitionName'> {
    * @defaultValue true
    */
   allowClosing?: boolean;
+
+  /* If set to false, the close button will not be displayed.
+   *
+   *
+   * @defaultValue true
+   */
+  allowCloseButton?: boolean;
+
+  /*
+   * The Close Button size.
+   */
+  closeButtonSize?: CloseButtonArgs['size'];
 
   /*
    * If set to true, the modal will be vertically centered
@@ -37,6 +50,12 @@ export default class Modal extends Component<ModalArgs> {
 
   get preventClosing(): boolean {
     return this.args.allowClosing === false;
+  }
+
+  get showCloseButton(): boolean {
+    return (
+      this.args.allowClosing !== false && this.args.allowCloseButton !== false
+    );
   }
 
   @action handleClose(): void {

--- a/packages/overlays/tailwind/default-options.js
+++ b/packages/overlays/tailwind/default-options.js
@@ -132,7 +132,8 @@ function defaultOptions({ config }) {
         marginTop: defaultTheme.spacing[24],
         width: defaultTheme.width.full,
         outline: 'none',
-        overflow: 'hidden'
+        overflow: 'hidden',
+        zIndex: 0
       },
 
       centered: {
@@ -143,7 +144,8 @@ function defaultOptions({ config }) {
       closeBtn: {
         position: 'absolute',
         top: config.modal.closeBtnMargin,
-        right: config.modal.closeBtnMargin
+        right: config.modal.closeBtnMargin,
+        zIndex: 1
       },
 
       header: {
@@ -199,13 +201,15 @@ function defaultOptions({ config }) {
         backgroundColor: config.drawer.backgroundColor,
         width: '100%',
         height: '100%',
-        boxShadow: config.drawer.boxShadow.default
+        boxShadow: config.drawer.boxShadow.default,
+        zIndex: 0
       },
 
       closeBtn: {
         position: 'absolute',
         top: config.drawer.closeBtnMargin,
-        right: config.drawer.closeBtnMargin
+        right: config.drawer.closeBtnMargin,
+        zIndex: 1
       },
 
       header: {

--- a/packages/overlays/tailwind/default-options.js
+++ b/packages/overlays/tailwind/default-options.js
@@ -5,9 +5,6 @@ const defaultTheme = require('tailwindcss/resolveConfig')(
 const modalAndDrawerDefaultConfig = {
   backgroundColor: defaultTheme.colors.white,
   boxShadow: defaultTheme.boxShadow.default,
-
-  closeBtnHoverBgColor: defaultTheme.colors.gray[100],
-  iconColor: defaultTheme.colors.black,
   closeBtnMargin: defaultTheme.spacing[2],
 
   header: {
@@ -144,34 +141,11 @@ function defaultOptions({ config }) {
       },
 
       closeBtn: {
-        display: 'flex',
         position: 'absolute',
-        fontSize: defaultTheme.fontSize.xl,
-        padding: defaultTheme.spacing[2],
         top: config.modal.closeBtnMargin,
-        right: config.modal.closeBtnMargin,
-        transitionProperty: defaultTheme.transitionProperty.default,
-        transitionDuration: defaultTheme.transitionDuration[200],
-        borderRadius: defaultTheme.borderRadius.full,
-
-        '&:hover': {
-          backgroundColor: config.modal.closeBtnHoverBgColor
-        },
-
-        '&.focus-visible:focus': {
-          outline: 'none',
-          boxShadow: defaultTheme.boxShadow.outline
-        },
-
-        icon: {
-          height: '1em',
-          width: '1em',
-          backgroundRepeat: 'no-repeat',
-          iconColor: config.modal.iconColor,
-          icon: (iconColor) =>
-            `<svg fill="none" stroke="${iconColor}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6 18L18 6M6 6l12 12"></path></svg>`
-        }
+        right: config.modal.closeBtnMargin
       },
+
       header: {
         fontWeight: defaultTheme.fontWeight.bold,
         fontSize: defaultTheme.fontSize.xl,
@@ -226,6 +200,12 @@ function defaultOptions({ config }) {
         width: '100%',
         height: '100%',
         boxShadow: config.drawer.boxShadow.default
+      },
+
+      closeBtn: {
+        position: 'absolute',
+        top: config.drawer.closeBtnMargin,
+        right: config.drawer.closeBtnMargin
       },
 
       header: {

--- a/packages/overlays/tailwind/index.js
+++ b/packages/overlays/tailwind/index.js
@@ -2,8 +2,6 @@ const plugin = require('tailwindcss/plugin');
 const {
   resolve,
   isEmpty,
-  svgToDataUri,
-  replaceIconDeclarations,
   kebabCase
 } = require('@frontile/tailwindcss-plugin-helpers');
 
@@ -86,7 +84,8 @@ module.exports = plugin.withOptions(function (userConfig) {
         [`.modal--centered`]: centered,
         [`.modal__header`]: header,
         [`.modal__footer`]: footer,
-        [`.modal__body`]: body
+        [`.modal__body`]: body,
+        [`.modal__close-btn`]: closeBtn
       });
 
       Object.keys(sizes || {}).forEach((key) => {
@@ -94,35 +93,6 @@ module.exports = plugin.withOptions(function (userConfig) {
           [`.modal--${key}`]: sizes[key]
         });
       });
-
-      if (!isEmpty(closeBtn)) {
-        const { icon: btnIcon } = closeBtn;
-
-        if (btnIcon) {
-          delete closeBtn.icon;
-        }
-
-        addComponents({
-          [`.modal__close-btn`]: closeBtn
-        });
-
-        if (!isEmpty(btnIcon)) {
-          addComponents(
-            replaceIconDeclarations(
-              {
-                [`.modal__close-btn--icon`]: btnIcon
-              },
-              ({ icon = btnIcon.icon, iconColor = btnIcon.iconColor }) => {
-                return {
-                  backgroundImage: `url("${svgToDataUri(
-                    typeof icon === 'function' ? icon(iconColor) : icon
-                  )}")`
-                };
-              }
-            )
-          );
-        }
-      }
     }
 
     function addDrawer(options) {
@@ -130,13 +100,22 @@ module.exports = plugin.withOptions(function (userConfig) {
         return;
       }
 
-      const { header, body, footer, drawer, placements, sizes } = options;
+      const {
+        header,
+        body,
+        footer,
+        drawer,
+        placements,
+        sizes,
+        closeBtn
+      } = options;
 
       addComponents({
         ['.drawer']: drawer,
         ['.drawer__header']: header,
         ['.drawer__footer']: footer,
-        ['.drawer__body']: body
+        ['.drawer__body']: body,
+        [`.drawer__close-btn`]: closeBtn
       });
 
       Object.keys(placements).forEach((key) => {

--- a/packages/overlays/tests/dummy/app/components/demo-drawer.hbs
+++ b/packages/overlays/tests/dummy/app/components/demo-drawer.hbs
@@ -89,9 +89,17 @@
       @size={{this.size}}
       @placement={{this.placement}}
       @disableFocusTrap={{true}}
+      @allowCloseButton={{false}}
       as |d|
     >
-      <d.Header>Header</d.Header>
+      <d.Header>
+        Header
+
+        <d.CloseButton
+          @size="lg"
+          class="relative inset-auto ml-6 text-blue-500 bg-gray-200 rounded-md hover:bg-gray-500"
+        />
+      </d.Header>
       <d.Body>
         In Place
       </d.Body>

--- a/packages/overlays/tests/dummy/app/styles/tailwind.config.js
+++ b/packages/overlays/tests/dummy/app/styles/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   variants: {},
   plugins: [
+    require('@frontile/core/tailwind'),
     require('@frontile/overlays/tailwind'),
     require('@frontile/buttons/tailwind'),
     require('@frontile/forms/tailwind')

--- a/packages/overlays/tests/integration/components/drawer-test.ts
+++ b/packages/overlays/tests/integration/components/drawer-test.ts
@@ -19,6 +19,7 @@ module('Integration | Component | Drawer', function (hooks) {
       @disableTransitions={{true}}
       @closeOnOutsideClick={{this.closeOnOutsideClick}}
       @closeOnEscapeKey={{this.closeOnEscapeKey}}
+      @allowCloseButton={{this.allowCloseButton}}
       data-test-id="drawer"
       as |m|
     >
@@ -36,9 +37,7 @@ module('Integration | Component | Drawer', function (hooks) {
     assert.dom('[data-test-id="drawer"] .drawer__header').hasText('My Header');
     assert.dom('[data-test-id="drawer"] .drawer__body').hasText('My Content');
     assert.dom('[data-test-id="drawer"] .drawer__footer').hasText('My Footer');
-    assert
-      .dom('[data-test-id="drawer"] [data-test-id="drawer-close-btn"]')
-      .hasText('Close');
+    assert.dom('[data-test-id="drawer"] .drawer__close-btn').hasText('Close');
   });
 
   test('it renders accessibility attributes', async function (assert) {
@@ -115,8 +114,23 @@ module('Integration | Component | Drawer', function (hooks) {
 
     assert.dom('[data-test-id="drawer"]').exists();
 
-    await click('[data-test-id="drawer"] [data-test-id="drawer-close-btn"]');
+    await click('[data-test-id="drawer"] .drawer__close-btn');
     assert.dom('[data-test-id="drawer"]').doesNotExist();
+  });
+
+  test('it does not render close button when @allowCloseButton=false', async function (assert) {
+    this.set('disableTransitions', true);
+    this.set('isOpen', true);
+    this.set('allowCloseButton', false);
+
+    this.set('onClose', () => {
+      this.set('isOpen', false);
+    });
+
+    await render(template);
+
+    assert.dom('[data-test-id="drawer"]').exists();
+    assert.dom('[data-test-id="drawer"] .drawer__close-btn').doesNotExist();
   });
 
   test('it closes drawer when backdrop is clicked', async function (assert) {

--- a/packages/overlays/tests/integration/components/modal-test.ts
+++ b/packages/overlays/tests/integration/components/modal-test.ts
@@ -19,6 +19,7 @@ module('Integration | Component | modal', function (hooks) {
       @closeOnOutsideClick={{this.closeOnOutsideClick}}
       @closeOnEscapeKey={{this.closeOnEscapeKey}}
       @size={{this.size}}
+      @allowCloseButton={{this.allowCloseButton}}
       data-test-id="modal"
       as |m|
     >
@@ -103,6 +104,21 @@ module('Integration | Component | modal', function (hooks) {
     assert.dom('[data-test-id="modal"]').exists();
     await click('[data-test-id="modal"] .modal__close-btn');
     assert.dom('[data-test-id="modal"]').doesNotExist();
+  });
+
+  test('it does not render close button when @allowCloseButton=false', async function (assert) {
+    this.set('disableTransitions', true);
+    this.set('isOpen', true);
+    this.set('allowCloseButton', false);
+
+    this.set('onClose', () => {
+      this.set('isOpen', false);
+    });
+
+    await render(template);
+
+    assert.dom('[data-test-id="modal"]').exists();
+    assert.dom('[data-test-id="modal"] .modal__close-btn').doesNotExist();
   });
 
   test('it closes modal when backdrop is clicked', async function (assert) {

--- a/packages/overlays/tsconfig.json
+++ b/packages/overlays/tsconfig.json
@@ -3,28 +3,14 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "dummy/tests/*": [
-        "tests/*"
-      ],
-      "dummy/*": [
-        "tests/dummy/app/*",
-        "app/*"
-      ],
-      "@frontile/overlays": [
-        "addon"
-      ],
-      "@frontile/overlays/*": [
-        "addon/*"
-      ],
-      "@frontile/overlays/test-support": [
-        "addon-test-support"
-      ],
-      "@frontile/overlays/test-support/*": [
-        "addon-test-support/*"
-      ],
-      "*": [
-        "types/*"
-      ]
+      "dummy/tests/*": ["tests/*"],
+      "dummy/*": ["tests/dummy/app/*", "app/*"],
+      "@frontile/overlays": ["addon"],
+      "@frontile/overlays/*": ["addon/*"],
+      "@frontile/core/*": ["../core/addon/*"],
+      "@frontile/overlays/test-support": ["addon-test-support"],
+      "@frontile/overlays/test-support/*": ["addon-test-support/*"],
+      "*": ["types/*"]
     }
   },
   "include": [


### PR DESCRIPTION
For the close button to work correctly, it's necessary to set up the `@frontile/core` tailwind plugin. 

```js
// tailwind.config.js

module.exports = {
  theme: {
    // ...
  },
  plugins: [
    require('@frontile/core/tailwind'),
    require('@frontile/overlays/tailwind')
  ]
};
```