### PR TITLE
Refactor forms pkg to follow new tailwind plugin structure + new class names + `@size`

### DIFF
--- a/packages/changeset-form/addon/components/changeset-form/fields/checkbox-group.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/fields/checkbox-group.hbs
@@ -7,8 +7,7 @@
   @hasError={{@hasError}}
   @hasSubmitted={{@hasSubmitted}}
   @containerClass={{@containerClass}}
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
+  @size={{@size}}
   @isInline={{@isInline}}
 
   ...attributes
@@ -18,8 +17,7 @@
             _groupName=@groupName
             _parentOnChange=api.onChange
             changeset=@changeset
-            isSmall=@isSmall
-            isLarge=@isLarge
+            size=@size
           )
   }}
 </FormCheckboxGroup>

--- a/packages/changeset-form/addon/components/changeset-form/fields/checkbox.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/fields/checkbox.hbs
@@ -5,8 +5,7 @@
   @hint={{@hint}}
   @name={{@name}}
   @containerClass={{@containerClass}}
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
+  @size={{@size}}
 
   ...attributes
 >

--- a/packages/changeset-form/addon/components/changeset-form/fields/input.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/fields/input.hbs
@@ -11,8 +11,7 @@
   @hint={{@hint}}
   @hasError={{@hasError}}
   @containerClass={{@containerClass}}
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
+  @size={{@size}}
   @onChange={{@onChange}}
   @onFocusIn={{@onFocusIn}}
   @onFocusOut={{@onFocusOut}}

--- a/packages/changeset-form/addon/components/changeset-form/fields/radio-group.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/fields/radio-group.hbs
@@ -8,8 +8,7 @@
   @hasSubmitted={{@hasSubmitted}}
   @hasError={{@hasError}}
   @containerClass={{@containerClass}}
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
+  @size={{@size}}
   @isInline={{@isInline}}
 
   ...attributes

--- a/packages/changeset-form/addon/components/changeset-form/fields/radio.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/fields/radio.hbs
@@ -8,8 +8,7 @@
   @value={{@value}}
   @name={{@name}}
   @containerClass={{@containerClass}}
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
+  @size={{@size}}
 
   ...attributes
 >

--- a/packages/changeset-form/addon/components/changeset-form/fields/select.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/fields/select.hbs
@@ -11,8 +11,7 @@
   @hint={{@hint}}
   @hasError={{@hasError}}
   @containerClass={{@containerClass}}
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
+  @size={{@size}}
 
   @onFocusIn={{@onFocusIn}}
   @onFocus={{@onFocus}}

--- a/packages/changeset-form/addon/components/changeset-form/fields/textarea.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/fields/textarea.hbs
@@ -11,8 +11,7 @@
   @hint={{@hint}}
   @hasError={{@hasError}}
   @containerClass={{@containerClass}}
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
+  @size={{@size}}
   @onChange={{@onChange}}
   @onFocusIn={{@onFocusIn}}
   @onFocusOut={{@onFocusOut}}

--- a/packages/changeset-form/tests/dummy/app/styles/tailwind.config.js
+++ b/packages/changeset-form/tests/dummy/app/styles/tailwind.config.js
@@ -2,10 +2,9 @@ module.exports = {
   future: {
     removeDeprecatedGapUtilities: true
   },
-  theme: {
-    '@frontile/forms': {
-      default: {}
-    }
-  },
-  plugins: [require('@frontile/forms/tailwind')]
+  theme: {},
+  plugins: [
+    require('@frontile/core/tailwind'),
+    require('@frontile/forms/tailwind')
+  ]
 };

--- a/packages/core/addon/helpers/use-frontile-class.ts
+++ b/packages/core/addon/helpers/use-frontile-class.ts
@@ -24,7 +24,11 @@ export function useFrontileClass(
   }
 
   if (hash.class) {
-    classes.push(hash.class);
+    if (Array.isArray(hash.class)) {
+      classes.push(hash.class.join(' '));
+    } else {
+      classes.push(hash.class);
+    }
   }
 
   return classes.join(' ');

--- a/packages/docs/app/styles/tailwind.config.js
+++ b/packages/docs/app/styles/tailwind.config.js
@@ -2,11 +2,7 @@ module.exports = {
   future: {
     removeDeprecatedGapUtilities: true
   },
-  theme: {
-    '@frontile/forms': {
-      default: {}
-    }
-  },
+  theme: {},
   plugins: [
     require('@frontile/core/tailwind'),
     require('@frontile/forms/tailwind'),

--- a/packages/docs/app/templates/docs/changeset-form/index.md
+++ b/packages/docs/app/templates/docs/changeset-form/index.md
@@ -6,13 +6,4 @@ ember install @frontile/changeset-form
 
 ## Styles
 
-```js
-// tailwind.config.js
-
-module.exports = {
-  theme: {
-    // ...
-  },
-  plugins: [require('@frontile/forms/tailwind')]
-};
-```
+Refer to `@frontile/forms` installation.

--- a/packages/docs/app/templates/docs/forms/index.md
+++ b/packages/docs/app/templates/docs/forms/index.md
@@ -10,6 +10,27 @@ ember install @frontile/forms
 // tailwind.config.js
 
 module.exports = {
+  purge: {
+    // ...
+    options: {
+      whitelist: [
+        /^form-field-checkbox/,
+        /^form-field-feedback/,
+        /^form-field-hint/,
+        /^form-field-input/,
+        /^form-field-label/,
+        /^form-field-radio/,
+        /^form-field-textarea/,
+        /^form-input/,
+        /^form-textarea/,
+        /^form-select/,
+        /^form-checkbox/,
+        /^form-radio/,
+        /^form-checkbox-group/,
+        /^form-radio-group/,
+      ]
+    }
+  },
   theme: {
     // ...
   },

--- a/packages/forms/addon/components/form-checkbox-group.hbs
+++ b/packages/forms/addon/components/form-checkbox-group.hbs
@@ -1,30 +1,38 @@
 <FormField
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
-  class="form-checkbox-group-container
-    {{if @isInline "form-checkbox-group-container--inline"}} {{@containerClass}}
-    {{if @isSmall "form-checkbox-group-container--sm" (if @isLarge "form-checkbox-group-container--lg")}}"
-    role="group"
+  @size={{@size}}
+  class={{use-frontile-class "form-checkbox-group" @size (if @isInline "inline") class=@containerClass}}
+  role="group"
   ...attributes
   as |f|
 >
   {{#if @label}}
-    <f.Label>{{@label}}</f.Label>
+    <f.Label
+      class={{use-frontile-class "form-checkbox-group" @size (if @isInline "inline") part="label"}}
+    >
+      {{@label}}
+    </f.Label>
   {{/if}}
 
   {{#if @hint}}
-    <f.Hint>{{@hint}}</f.Hint>
+    <f.Hint
+      class={{use-frontile-class "form-checkbox-group" @size (if @isInline "inline") part="hint"}}
+    >
+      {{@hint}}
+    </f.Hint>
   {{/if}}
 
   {{yield (component "form-checkbox"
+            privateContainerClass=(use-frontile-class "form-checkbox-group" @size (if @isInline "inline") part="form-checkbox")
             _parentOnChange=this.handleChange
-            isSmall=@isSmall
-            isLarge=@isLarge
+            size=@size
           )
           (hash onChange=this.handleChange)
   }}
 
   {{#if this.showErrorFeedback}}
-    <f.Feedback @errors={{@errors}} />
+    <f.Feedback
+      class={{use-frontile-class "form-checkbox-group" @size (if @isInline "inline") part="feedback"}}
+      @errors={{@errors}}
+    />
   {{/if}}
 </FormField>

--- a/packages/forms/addon/components/form-checkbox-group.ts
+++ b/packages/forms/addon/components/form-checkbox-group.ts
@@ -9,8 +9,7 @@ interface FormCheckboxGroupArgs {
   hasError?: boolean;
   errors?: string[] | string;
   containerClass?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
   isInline?: boolean;
 
   // Callback when onchange is triggered

--- a/packages/forms/addon/components/form-checkbox.hbs
+++ b/packages/forms/addon/components/form-checkbox.hbs
@@ -1,11 +1,14 @@
 <FormField
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
-  class="form-checkbox-container {{@containerClass}} {{if @isSmall "form-checkbox-container--sm" (if @isLarge "form-checkbox-container--lg")}}"
+  @size={{@size}}
+  class={{use-frontile-class "form-checkbox" @size class=(array @containerClass @privateContainerClass)}}
   as |f|
 >
-  <div class="form-checkbox-container__label-container">
-    <div class="form-checkbox-container__input-container">
+  <div
+    class={{use-frontile-class "form-checkbox" @size part="label-container"}}
+  >
+    <div
+      class={{use-frontile-class "form-checkbox" @size part="input-container"}}
+    >
       {{!--  Zero-width space character, used to align checkbox properly --}}
       &#8203;
       <f.Checkbox
@@ -13,13 +16,14 @@
         @checked={{@checked}}
         @name={{@name}}
 
+        class={{use-frontile-class "form-checkbox" @size part="checkbox"}}
         aria-describedby={{if @hint f.hintId}}
         ...attributes
       />
     </div>
 
     <f.Label
-      class={{if this.isFocused "is-focused"}}
+      class={{use-frontile-class "form-checkbox" @size part="label"}}
     >
       {{#if hasBlock}}
         {{yield}}
@@ -30,6 +34,10 @@
   </div>
 
   {{#if @hint}}
-    <f.Hint>{{@hint}}</f.Hint>
+    <f.Hint
+      class={{use-frontile-class "form-checkbox" @size part="hint"}}
+    >
+      {{@hint}}
+    </f.Hint>
   {{/if}}
 </FormField>

--- a/packages/forms/addon/components/form-checkbox.ts
+++ b/packages/forms/addon/components/form-checkbox.ts
@@ -7,8 +7,7 @@ interface FormCheckboxArgs {
   checked?: boolean;
   name?: string;
   containerClass?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Callback when onchange is triggered
   onChange?: (value: boolean, event: Event) => void;

--- a/packages/forms/addon/components/form-field/checkbox.hbs
+++ b/packages/forms/addon/components/form-field/checkbox.hbs
@@ -4,7 +4,7 @@
   name={{@name}}
   checked={{this.isChecked}}
   type="checkbox"
-  class="form__checkbox {{if @isSmall "form__checkbox--sm" (if @isLarge "form__checkbox--lg")}}"
+  class={{use-frontile-class "form-field-checkbox" @size}}
   data-test-id="form-field-checkbox"
   ...attributes
 >

--- a/packages/forms/addon/components/form-field/checkbox.ts
+++ b/packages/forms/addon/components/form-field/checkbox.ts
@@ -4,8 +4,7 @@ import { action } from '@ember/object';
 interface FormFieldCheckboxArgs {
   checked?: boolean;
   name?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Callback when onchange is triggered
   onChange?: (value: boolean, event: Event) => void;

--- a/packages/forms/addon/components/form-field/feedback.hbs
+++ b/packages/forms/addon/components/form-field/feedback.hbs
@@ -1,6 +1,6 @@
 <div
   id={{@id}}
-  class="form__feedback {{if this.isError "form__feedback--state-error"}} {{if @isSmall "form__feedback--sm" (if @isLarge "form__feedback--lg")}}"
+  class={{use-frontile-class "form-field-feedback" @size (if this.isError "error")}}
   data-test-id="form-field-feedback"
   aria-live={{if this.isError "assertive" "polite"}}
   ...attributes

--- a/packages/forms/addon/components/form-field/feedback.ts
+++ b/packages/forms/addon/components/form-field/feedback.ts
@@ -3,8 +3,7 @@ import Component from '@glimmer/component';
 interface FormFieldFeedbackArgs {
   isError?: boolean;
   errors?: string[] | string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 }
 
 export default class FormFieldFeedback extends Component<

--- a/packages/forms/addon/components/form-field/hint.hbs
+++ b/packages/forms/addon/components/form-field/hint.hbs
@@ -1,6 +1,6 @@
 <div
   id={{@id}}
-  class="form__hint {{if @isSmall "form__hint--sm" (if @isLarge "form__hint--lg")}}"
+  class={{use-frontile-class "form-field-hint" @size}}
   data-test-id="form-field-hint"
   ...attributes
 >

--- a/packages/forms/addon/components/form-field/hint.ts
+++ b/packages/forms/addon/components/form-field/hint.ts
@@ -2,8 +2,7 @@ import Component from '@glimmer/component';
 
 interface FormFieldHintArgs {
   id?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 }
 
 export default class FormFieldHint extends Component<FormFieldHintArgs> {}

--- a/packages/forms/addon/components/form-field/index.hbs
+++ b/packages/forms/addon/components/form-field/index.hbs
@@ -7,14 +7,14 @@
       hintId=this.hintId
       feedbackId=this.feedbackId
 
-      Label=(component "form-field/label" for=this.id isSmall=@isSmall isLarge=@isLarge)
-      Hint=(component "form-field/hint" id=this.hintId isSmall=@isSmall isLarge=@isLarge)
-      Feedback=(component "form-field/feedback" id=this.feedbackId isSmall=@isSmall isLarge=@isLarge)
+      Label=(component "form-field/label" for=this.id size=@size)
+      Hint=(component "form-field/hint" id=this.hintId size=@size)
+      Feedback=(component "form-field/feedback" id=this.feedbackId size=@size)
 
-      Input=(component "form-field/input" id=this.id isSmall=@isSmall isLarge=@isLarge)
-      Textarea=(component "form-field/textarea" id=this.id isSmall=@isSmall isLarge=@isLarge)
-      Checkbox=(component "form-field/checkbox" id=this.id isSmall=@isSmall isLarge=@isLarge)
-      Radio=(component "form-field/radio" id=this.id isSmall=@isSmall isLarge=@isLarge)
+      Input=(component "form-field/input" id=this.id size=@size)
+      Textarea=(component "form-field/textarea" id=this.id size=@size)
+      Checkbox=(component "form-field/checkbox" id=this.id size=@size)
+      Radio=(component "form-field/radio" id=this.id size=@size)
     )
   }}
 </div>

--- a/packages/forms/addon/components/form-field/index.ts
+++ b/packages/forms/addon/components/form-field/index.ts
@@ -2,8 +2,7 @@ import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 
 interface FormFieldArgs {
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 }
 
 export default class FormField extends Component<FormFieldArgs> {

--- a/packages/forms/addon/components/form-field/input.hbs
+++ b/packages/forms/addon/components/form-field/input.hbs
@@ -4,7 +4,7 @@
   id={{@id}}
   value={{@value}}
   type={{this.type}}
-  class="form__input {{if @isSmall "form__input--sm" (if @isLarge "form__input--lg")}}"
+  class={{use-frontile-class "form-field-input" @size}}
   data-test-id="form-field-input"
   ...attributes
 >

--- a/packages/forms/addon/components/form-field/input.ts
+++ b/packages/forms/addon/components/form-field/input.ts
@@ -4,8 +4,7 @@ import { action } from '@ember/object';
 interface FormFieldInputArgs {
   id?: string;
   type?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Callback when oninput is triggered
   onInput?: (value: string, event: InputEvent) => void;

--- a/packages/forms/addon/components/form-field/label.hbs
+++ b/packages/forms/addon/components/form-field/label.hbs
@@ -1,6 +1,6 @@
 <label
   for={{@for}}
-  class="form__label {{if @isSmall "form__label--sm" (if @isLarge "form__label--lg")}}"
+  class={{use-frontile-class "form-field-label" @size}}
   data-test-id="form-field-label"
   ...attributes
 >

--- a/packages/forms/addon/components/form-field/label.ts
+++ b/packages/forms/addon/components/form-field/label.ts
@@ -2,8 +2,7 @@ import Component from '@glimmer/component';
 
 interface FormFieldLabelArgs {
   for?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 }
 
 export default class FormFieldLabel extends Component<FormFieldLabelArgs> {}

--- a/packages/forms/addon/components/form-field/radio.hbs
+++ b/packages/forms/addon/components/form-field/radio.hbs
@@ -5,7 +5,7 @@
   value={{@value}}
   checked={{this.isChecked}}
   type="radio"
-  class="form__radio {{if @isSmall "form__radio--sm" (if @isLarge "form__radio--lg")}}"
+  class={{use-frontile-class "form-field-radio" @size}}
   data-test-id="form-field-radio"
   ...attributes
 >

--- a/packages/forms/addon/components/form-field/radio.ts
+++ b/packages/forms/addon/components/form-field/radio.ts
@@ -5,8 +5,7 @@ interface FormFieldRadioArgs {
   value?: unknown;
   checked?: unknown;
   name?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Callback when onchange is triggered
   onChange?: (value: unknown, event: Event) => void;

--- a/packages/forms/addon/components/form-field/textarea.hbs
+++ b/packages/forms/addon/components/form-field/textarea.hbs
@@ -3,7 +3,7 @@
   {{on "change" this.handleOnChange}}
   id={{@id}}
   value={{@value}}
-  class="form__textarea {{if @isSmall "form__textarea--sm" (if @isLarge "form__textarea--lg")}}"
+  class={{use-frontile-class "form-field-textarea" @size}}
   data-test-id="form-field-textarea"
   ...attributes
 >

--- a/packages/forms/addon/components/form-field/textarea.ts
+++ b/packages/forms/addon/components/form-field/textarea.ts
@@ -3,8 +3,7 @@ import { action } from '@ember/object';
 
 interface FormFieldTextareaArgs {
   id?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Callback when oninput is triggered
   onInput?: (value: string, event: InputEvent) => void;

--- a/packages/forms/addon/components/form-input.hbs
+++ b/packages/forms/addon/components/form-input.hbs
@@ -1,15 +1,22 @@
 <FormField
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
-  class="form-input-container {{@containerClass}} {{if @isSmall "form-input-container--sm" (if @isLarge "form-input-container--lg")}}"
+  @size={{@size}}
+  class={{use-frontile-class "form-input" @size class=@containerClass}}
   as |f|
 >
   {{#if @label}}
-    <f.Label>{{@label}}</f.Label>
+    <f.Label
+      class={{use-frontile-class "form-input" @size part="label"}}
+    >
+      {{@label}}
+    </f.Label>
   {{/if}}
 
   {{#if @hint}}
-    <f.Hint>{{@hint}}</f.Hint>
+    <f.Hint
+      class={{use-frontile-class "form-input" @size part="hint"}}
+    >
+      {{@hint}}
+    </f.Hint>
   {{/if}}
 
   <f.Input
@@ -20,6 +27,8 @@
     @onChange={{@onChange}}
     @value={{@value}}
     @type={{@type}}
+
+    class={{use-frontile-class "form-input" @size part="input"}}
     aria-invalid={{if this.showErrorFeedback "true"}}
     aria-describedby="{{if @hint f.hintId}}{{if this.showErrorFeedback (concat " " f.feedbackId)}}"
     ...attributes
@@ -28,6 +37,9 @@
   {{yield}}
 
   {{#if this.showErrorFeedback}}
-    <f.Feedback @errors={{@errors}} />
+    <f.Feedback
+      class={{use-frontile-class "form-input" @size part="feedback"}}
+      @errors={{@errors}}
+    />
   {{/if}}
 </FormField>

--- a/packages/forms/addon/components/form-input.ts
+++ b/packages/forms/addon/components/form-input.ts
@@ -11,8 +11,7 @@ interface FormInputArgs {
   hasError?: boolean;
   errors?: string[] | string;
   containerClass?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Callback when oninput is triggered
   onInput?: (value: string, event: InputEvent) => void;

--- a/packages/forms/addon/components/form-radio-group.hbs
+++ b/packages/forms/addon/components/form-radio-group.hbs
@@ -1,31 +1,39 @@
 <FormField
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
-  class="form-radio-group-container
-    {{if @isInline "form-radio-group-container--inline"}} {{@containerClass}}
-    {{if @isSmall "form-radio-group-container--sm" (if @isLarge "form-radio-group-container--lg")}}"
-    role="radiogroup"
+  @size={{@size}}
+  class={{use-frontile-class "form-radio-group" @size (if @isInline "inline") class=@containerClass}}
+  role="radiogroup"
   ...attributes
   as |f|
 >
   {{#if @label}}
-    <f.Label>{{@label}}</f.Label>
+    <f.Label
+      class={{use-frontile-class "form-radio-group" @size (if @isInline "inline") part="label"}}
+    >
+      {{@label}}
+    </f.Label>
   {{/if}}
 
   {{#if @hint}}
-    <f.Hint>{{@hint}}</f.Hint>
+    <f.Hint
+      class={{use-frontile-class "form-radio-group" @size (if @isInline "inline") part="hint"}}
+    >
+      {{@hint}}
+    </f.Hint>
   {{/if}}
 
   {{yield (component "form-radio"
             checked=@value
+            privateContainerClass=(use-frontile-class "form-radio-group" @size (if @isInline "inline") part="form-radio")
             _parentOnChange=this.handleChange
-            isSmall=@isSmall
-            isLarge=@isLarge
+            size=@size
             name=(concat f.id "-radio-group")
           )
   }}
 
   {{#if this.showErrorFeedback}}
-    <f.Feedback @errors={{@errors}} />
+    <f.Feedback
+      class={{use-frontile-class "form-radio-group" @size (if @isInline "inline") part="feedback"}}
+      @errors={{@errors}}
+    />
   {{/if}}
 </FormField>

--- a/packages/forms/addon/components/form-radio-group.ts
+++ b/packages/forms/addon/components/form-radio-group.ts
@@ -10,8 +10,7 @@ interface FormRadioGroupArgs {
   hasError?: boolean;
   errors?: string[] | string;
   containerClass?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
   isInline?: boolean;
 
   // Callback when onchange is triggered

--- a/packages/forms/addon/components/form-radio.hbs
+++ b/packages/forms/addon/components/form-radio.hbs
@@ -1,11 +1,14 @@
 <FormField
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
-  class="form-radio-container {{@containerClass}} {{if @isSmall "form-radio-container--sm" (if @isLarge "form-radio-container--lg")}}"
+  @size={{@size}}
+  class={{use-frontile-class "form-radio" @size class=(array @containerClass @privateContainerClass)}}
   as |f|
 >
-  <div class="form-radio-container__label-container">
-    <div class="form-radio-container__input-container">
+  <div
+    class={{use-frontile-class "form-radio" @size part="label-container"}}
+  >
+    <div
+      class={{use-frontile-class "form-radio" @size part="input-container"}}
+    >
       {{!--  Zero-width space character, used to align checkbox properly --}}
       &#8203;
       <f.Radio
@@ -14,12 +17,15 @@
         @checked={{@checked}}
         @name={{@name}}
 
+        class={{use-frontile-class "form-radio" @size part="radio"}}
         aria-describedby={{if @hint f.hintId}}
         ...attributes
       />
     </div>
 
-    <f.Label>
+    <f.Label
+      class={{use-frontile-class "form-radio" @size part="label"}}
+    >
       {{#if hasBlock}}
         {{yield}}
       {{else}}
@@ -29,6 +35,10 @@
   </div>
 
   {{#if @hint}}
-    <f.Hint>{{@hint}}</f.Hint>
+    <f.Hint
+      class={{use-frontile-class "form-radio" @size part="hint"}}
+    >
+      {{@hint}}
+    </f.Hint>
   {{/if}}
 </FormField>

--- a/packages/forms/addon/components/form-radio.ts
+++ b/packages/forms/addon/components/form-radio.ts
@@ -8,8 +8,7 @@ interface FormRadioArgs {
   checked?: unknown;
   name?: string;
   containerClass?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Callback when onchange is triggered
   onChange?: (value: unknown, event: Event) => void;

--- a/packages/forms/addon/components/form-select.hbs
+++ b/packages/forms/addon/components/form-select.hbs
@@ -1,21 +1,24 @@
 <FormField
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
-  class="form-select-container {{@containerClass}} {{if @isSmall "form-select-container--sm" (if @isLarge "form-select-container--lg")}}"
+  @size={{@size}}
+  class={{use-frontile-class "form-select" @size class=@containerClass}}
   as |f|
 >
-
   {{#if @label}}
     <f.Label
       @for={{false}}
       id={{f.id}}
+      class={{use-frontile-class "form-select" @size part="label"}}
     >
       {{@label}}
     </f.Label>
   {{/if}}
 
   {{#if @hint}}
-    <f.Hint>{{@hint}}</f.Hint>
+    <f.Hint
+      class={{use-frontile-class "form-select" @size part="hint"}}
+    >
+      {{@hint}}
+    </f.Hint>
   {{/if}}
 
   {{#let (component (if @isMultiple "power-select-multiple" "power-select")) as |Component|}}
@@ -29,8 +32,7 @@
       @ariaDescribedBy="{{if @hint f.hintId}}{{if this.showErrorFeedback (concat " " f.feedbackId)}}{{if @ariaDescribedBy (concat " " @ariaDescribedBy)}}"
       @ariaLabelledBy="{{if @label f.id}}{{if @ariaLabelledBy (concat " "@ariaLabelledBy)}}"
       @ariaInvalid={{if this.showErrorFeedback "true"}}
-      @triggerClass="{{@triggerClass}} {{if @isSmall "ember-power-select-trigger-sm" (if @isLarge "ember-power-select-trigger-lg")}}"
-
+      @triggerClass="{{@triggerClass}} {{if @size (concat "ember-power-select-trigger-" @size)}} {{use-frontile-class "form-select" @size part="select"}}"
       @highlightOnHover={{@highlightOnHover}}
       @placeholderComponent={{@placeholderComponent}}
       @searchMessage={{@searchMessage}}

--- a/packages/forms/addon/components/form-select.hbs
+++ b/packages/forms/addon/components/form-select.hbs
@@ -87,6 +87,9 @@
   {{/let}}
 
   {{#if this.showErrorFeedback}}
-    <f.Feedback @errors={{@errors}} />
+    <f.Feedback
+      class={{use-frontile-class "form-select" @size part="feedback"}}
+      @errors={{@errors}}
+    />
   {{/if}}
 </FormField>

--- a/packages/forms/addon/components/form-select.ts
+++ b/packages/forms/addon/components/form-select.ts
@@ -13,8 +13,7 @@ interface FormSelectArgs extends PowerSelectArgs {
   hasError?: boolean;
   errors?: string[] | string;
   containerClass?: string;
-  isSmall?: boolean;
-  isLarge?: boolean;
+  size?: 'sm' | 'lg';
 
   // Same as onFocus from ember-power-select
   onFocusIn?: (select: Select, event: FocusEvent) => void;

--- a/packages/forms/addon/components/form-textarea.hbs
+++ b/packages/forms/addon/components/form-textarea.hbs
@@ -1,15 +1,22 @@
 <FormField
-  @isSmall={{@isSmall}}
-  @isLarge={{@isLarge}}
-  class="form-textarea-container {{@containerClass}} {{if @isSmall "form-textarea-container--sm" (if @isLarge "form-textarea-container--lg")}}"
+  @size={{@size}}
+  class={{use-frontile-class "form-textarea" @size class=@containerClass}}
   as |f|
 >
   {{#if @label}}
-    <f.Label>{{@label}}</f.Label>
+    <f.Label
+      class={{use-frontile-class "form-textarea" @size part="label"}}
+    >
+      {{@label}}
+    </f.Label>
   {{/if}}
 
   {{#if @hint}}
-    <f.Hint>{{@hint}}</f.Hint>
+    <f.Hint
+      class={{use-frontile-class "form-textarea" @size part="hint"}}
+    >
+      {{@hint}}
+    </f.Hint>
   {{/if}}
 
   <f.Textarea
@@ -20,6 +27,7 @@
     @onChange={{@onChange}}
     @value={{@value}}
 
+    class={{use-frontile-class "form-textarea" @size part="textarea"}}
     aria-invalid={{if this.showErrorFeedback "true"}}
     aria-describedby="{{if @hint f.hintId}}{{if this.showErrorFeedback (concat " " f.feedbackId)}}"
     ...attributes
@@ -28,6 +36,9 @@
   {{yield}}
 
   {{#if this.showErrorFeedback}}
-    <f.Feedback @errors={{@errors}} />
+    <f.Feedback
+      class={{use-frontile-class "form-textarea" @size part="feedback"}}
+      @errors={{@errors}}
+    />
   {{/if}}
 </FormField>

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -22,6 +22,7 @@
     "postpack": "ember ts:clean"
   },
   "dependencies": {
+    "@frontile/core": "^0.5.2",
     "@frontile/tailwindcss-plugin-helpers": "^0.5.2",
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^5.2.0",
@@ -32,7 +33,6 @@
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@ember/optional-features": "^2.0.0",
-    "@frontile/core": "^0.5.2",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "@types/ember": "^3.16.1",

--- a/packages/forms/tailwind/default-options.js
+++ b/packages/forms/tailwind/default-options.js
@@ -188,28 +188,19 @@ function defaultOptions({ config }) {
       }
     },
 
-    default: {
-      'formCheckboxGroup, formRadioGroup': {
-        '> *': {
-          paddingBottom: defaultTheme.spacing[1],
-          '&:last-child': {
-            paddingBottom: defaultTheme.spacing[0]
-          }
-        },
-        feedback: {
-          paddingTop: defaultTheme.spacing[0],
-          flex: '1 100%'
-        }
-      },
-
-      formSelectContainer: {
+    formSelect: {
+      baseStyle: {
         display: 'flex',
         flexDirection: 'column'
-      },
+      }
+    },
 
-      'formInputContainer, formTextareaContainer': {
+    'formInput, formTextarea': {
+      baseStyle: {
         display: 'flex',
-        flexFlow: 'row wrap',
+        flexFlow: 'row wrap'
+      },
+      parts: {
         label: {
           flex: '1 100%'
         },
@@ -219,13 +210,17 @@ function defaultOptions({ config }) {
         feedback: {
           flex: '1 100%'
         }
-      },
+      }
+    },
 
-      'formCheckboxContainer, formRadioContainer': {
+    'formCheckbox, formRadio': {
+      baseStyle: {
         display: 'flex',
         flexWrap: 'wrap',
-        alignItems: 'center',
+        alignItems: 'center'
+      },
 
+      parts: {
         labelContainer: {
           lineHeight: defaultTheme.lineHeight.tight,
           display: 'flex',
@@ -252,24 +247,46 @@ function defaultOptions({ config }) {
             flexShrink: 0
           }
         }
-      }
-    },
-
-    inline: {
-      'formCheckboxGroup, formRadioGroup': {
-        display: 'flex',
-        flexFlow: 'row wrap',
-        alignItems: 'flex-start',
-        '> *, > label': {
-          paddingRight: defaultTheme.spacing[4],
-          paddingBottom: defaultTheme.spacing[0]
+      },
+      variants: {
+        sm: {
+          parts: {
+            label: {
+              fontSize: defaultTheme.fontSize.sm
+            }
+          }
         }
       }
     },
-    sm: {
-      'formCheckboxContainer, formRadioContainer': {
-        label: {
-          fontSize: defaultTheme.fontSize.sm
+
+    'formCheckboxGroup, formRadioGroup': {
+      baseStyle: {},
+      parts: {
+        feedback: {
+          paddingTop: defaultTheme.spacing[0],
+          flex: '1 100%'
+        },
+
+        'label, hint, formCheckbox, formRadio, feedback': {
+          paddingBottom: defaultTheme.spacing[1],
+          '&:last-child': {
+            paddingBottom: defaultTheme.spacing[0]
+          }
+        }
+      },
+      variants: {
+        inline: {
+          baseStyle: {
+            display: 'flex',
+            flexFlow: 'row wrap',
+            alignItems: 'flex-start'
+          },
+          parts: {
+            'label, hint, formCheckbox, formRadio, feedback': {
+              paddingRight: defaultTheme.spacing[4],
+              paddingBottom: defaultTheme.spacing[0]
+            }
+          }
         }
       }
     }

--- a/packages/forms/tailwind/default-options.js
+++ b/packages/forms/tailwind/default-options.js
@@ -22,27 +22,38 @@ const defaultConfig = {
 
 function defaultOptions({ config }) {
   return {
-    default: {
-      label: {
+    label: {
+      baseStyle: {
         display: 'inline-block',
         color: config.labelColor,
         fontWeight: defaultTheme.fontWeight.semibold,
         lineHeight: defaultTheme.lineHeight.tight,
         paddingBottom: defaultTheme.spacing[1]
-      },
-      hint: {
+      }
+    },
+    hint: {
+      baseStyle: {
         color: config.hintColor,
         fontSize: defaultTheme.fontSize.xs,
         paddingBottom: defaultTheme.spacing[1],
         '&:last-child': {
           paddingBottom: defaultTheme.spacing[0]
         }
-      },
-      feedback: {
+      }
+    },
+    feedback: {
+      baseStyle: {
         fontSize: defaultTheme.fontSize.xs,
         paddingTop: defaultTheme.spacing[1]
       },
-      'input, textarea': {
+      variants: {
+        error: {
+          color: config.invalidColor
+        }
+      }
+    },
+    'input, textarea': {
+      baseStyle: {
         appearance: 'none',
         flex: defaultTheme.flex[1],
         width: defaultTheme.width.full,
@@ -77,11 +88,38 @@ function defaultOptions({ config }) {
           }
         }
       },
-      textarea: {
+      variants: {
+        sm: {
+          fontSize: defaultTheme.fontSize.sm,
+          paddingTop: defaultTheme.spacing[2],
+          paddingRight: defaultTheme.spacing[2],
+          paddingBottom: defaultTheme.spacing[2],
+          paddingLeft: defaultTheme.spacing[2]
+        },
+        lg: {
+          paddingTop: defaultTheme.spacing[4],
+          paddingRight: defaultTheme.spacing[4],
+          paddingBottom: defaultTheme.spacing[4],
+          paddingLeft: defaultTheme.spacing[4]
+        }
+      }
+    },
+    textarea: {
+      baseStyle: {
         minHeight: defaultTheme.height[24]
       },
+      variants: {
+        sm: {
+          minHeight: defaultTheme.height[16]
+        },
+        lg: {
+          minHeight: defaultTheme.height[32]
+        }
+      }
+    },
 
-      'checkbox, radio': {
+    'checkbox, radio': {
+      baseStyle: {
         appearance: 'none',
         colorAdjust: 'exact',
         '&::-ms-check': {
@@ -126,17 +164,31 @@ function defaultOptions({ config }) {
           borderColor: config.disabledBorderColor
         }
       },
-      checkbox: {
+      variants: {
+        sm: {
+          fontSize: defaultTheme.fontSize.sm
+        },
+        lg: {
+          fontSize: defaultTheme.fontSize.lg
+        }
+      }
+    },
+    checkbox: {
+      baseStyle: {
         borderRadius: defaultTheme.borderRadius.sm,
         icon: (iconColor) =>
           `<svg viewBox="0 0 16 16" fill="${iconColor}" xmlns="http://www.w3.org/2000/svg"><path d="M5.125 7.666a1.304 1.304 0 00-.882-.328 1.3 1.3 0 00-.876.343c-.232.216-.364.51-.367.816-.003.307.124.602.352.822l2.508 2.339c.235.219.554.342.886.342.333 0 .651-.123.887-.342l5.015-4.677c.228-.22.355-.516.352-.822a1.132 1.132 0 00-.367-.817A1.301 1.301 0 0011.757 5a1.304 1.304 0 00-.882.328l-4.129 3.85-1.621-1.512z"/></svg>`
-      },
-      radio: {
+      }
+    },
+    radio: {
+      baseStyle: {
         borderRadius: defaultTheme.borderRadius.full,
         icon: (iconColor) =>
           `<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="6" stroke="${iconColor}" stroke-width="3" fill="none" /></svg>`
-      },
+      }
+    },
 
+    default: {
       'formCheckboxGroup, formRadioGroup': {
         '> *': {
           paddingBottom: defaultTheme.spacing[1],
@@ -202,11 +254,7 @@ function defaultOptions({ config }) {
         }
       }
     },
-    stateError: {
-      feedback: {
-        color: config.invalidColor
-      }
-    },
+
     inline: {
       'formCheckboxGroup, formRadioGroup': {
         display: 'flex',
@@ -219,38 +267,10 @@ function defaultOptions({ config }) {
       }
     },
     sm: {
-      'input, textarea': {
-        fontSize: defaultTheme.fontSize.sm,
-        paddingTop: defaultTheme.spacing[2],
-        paddingRight: defaultTheme.spacing[2],
-        paddingBottom: defaultTheme.spacing[2],
-        paddingLeft: defaultTheme.spacing[2]
-      },
-      textarea: {
-        minHeight: defaultTheme.height[16]
-      },
-      'checkbox, radio': {
-        fontSize: defaultTheme.fontSize.sm
-      },
-
       'formCheckboxContainer, formRadioContainer': {
         label: {
           fontSize: defaultTheme.fontSize.sm
         }
-      }
-    },
-    lg: {
-      'input, textarea': {
-        paddingTop: defaultTheme.spacing[4],
-        paddingRight: defaultTheme.spacing[4],
-        paddingBottom: defaultTheme.spacing[4],
-        paddingLeft: defaultTheme.spacing[4]
-      },
-      textarea: {
-        minHeight: defaultTheme.height[32]
-      },
-      'checkbox, radio': {
-        fontSize: defaultTheme.fontSize.lg
       }
     }
   };

--- a/packages/forms/tailwind/index.js
+++ b/packages/forms/tailwind/index.js
@@ -8,7 +8,8 @@ const {
   svgToDataUri,
   isEmpty,
   kebabCase,
-  flattenOptions
+  flattenOptions,
+  addSinglePartComponent
 } = require('@frontile/tailwindcss-plugin-helpers');
 
 module.exports = plugin.withOptions(function (userConfig) {
@@ -19,6 +20,64 @@ module.exports = plugin.withOptions(function (userConfig) {
       userConfig,
       theme
     );
+
+    function replaceIconFn({
+      icon = options.icon,
+      iconColor = options.iconColor
+    }) {
+      return {
+        '&:checked': {
+          backgroundImage: `url("${svgToDataUri(
+            typeof icon === 'function' ? icon(iconColor) : icon
+          )}")`
+        }
+      };
+    }
+
+    addSinglePartComponent(
+      addComponents,
+      '.form-field-checkbox',
+      options.checkbox,
+      replaceIconFn
+    );
+    addSinglePartComponent(
+      addComponents,
+      '.form-field-feedback',
+      options.feedback,
+      replaceIconFn
+    );
+    addSinglePartComponent(
+      addComponents,
+      '.form-field-hint',
+      options.hint,
+      replaceIconFn
+    );
+    addSinglePartComponent(
+      addComponents,
+      '.form-field-input',
+      options.input,
+      replaceIconFn
+    );
+    addSinglePartComponent(
+      addComponents,
+      '.form-field-label',
+      options.label,
+      replaceIconFn
+    );
+    addSinglePartComponent(
+      addComponents,
+      '.form-field-radio',
+      options.radio,
+      replaceIconFn
+    );
+    addSinglePartComponent(
+      addComponents,
+      '.form-field-textarea',
+      options.textarea,
+      replaceIconFn
+    );
+
+    // OLD ---
 
     function addFormElementComponent(
       namespace,

--- a/packages/forms/tailwind/index.js
+++ b/packages/forms/tailwind/index.js
@@ -1,30 +1,22 @@
 const plugin = require('tailwindcss/plugin');
 const {
   merge,
-  map,
-  fromPairs,
-  replaceIconDeclarations,
-  resolve,
+  resolveComponents,
   svgToDataUri,
-  isEmpty,
-  kebabCase,
-  flattenOptions,
   addSinglePartComponent,
   addMultipartComponent
 } = require('@frontile/tailwindcss-plugin-helpers');
 
-module.exports = plugin.withOptions(function (userConfig) {
+module.exports = plugin.withOptions(function () {
   return function ({ addComponents, theme }) {
-    const { config, options } = resolve(
-      '@frontile/forms',
-      require('./default-options'),
-      userConfig,
-      theme
+    const { config, components } = resolveComponents(
+      theme('frontile.forms'),
+      require('./default-options')
     );
 
     function replaceIconFn({
-      icon = options.icon,
-      iconColor = options.iconColor
+      icon = components.icon,
+      iconColor = components.iconColor
     }) {
       return {
         '&:checked': {
@@ -47,7 +39,7 @@ module.exports = plugin.withOptions(function (userConfig) {
       addSinglePartComponent(
         addComponents,
         selector,
-        options[key],
+        components[key],
         replaceIconFn
       );
     });
@@ -61,10 +53,10 @@ module.exports = plugin.withOptions(function (userConfig) {
       ['.form-checkbox-group', 'formRadioGroup'],
       ['.form-radio-group', 'formRadioGroup']
     ].forEach(([selector, key]) => {
-      addMultipartComponent(addComponents, selector, options[key]);
+      addMultipartComponent(addComponents, selector, components[key]);
     });
 
-    const { powerSelect: powerSelectOptions } = options.default || {};
+    const { powerSelect: powerSelectOptions } = components || {};
 
     require('tailwindcss-ember-power-select').registerComponents(
       { addComponents },

--- a/packages/forms/tailwind/index.js
+++ b/packages/forms/tailwind/index.js
@@ -64,35 +64,6 @@ module.exports = plugin.withOptions(function (userConfig) {
       addMultipartComponent(addComponents, selector, options[key]);
     });
 
-    // const { namespaced } = options;
-    // options.namespaced = undefined;
-    // addNamespaced('', options);
-
-    // if (namespaced && Object.keys(namespaced).length > 0) {
-    // Object.keys(namespaced).forEach((namespace) => {
-    // const namespacedOptions = fromPairs(
-    // map(namespaced[namespace], (value, key) => [
-    // key,
-    // flattenOptions(value)
-    // ])
-    // );
-
-    // // Work around to allow change color of icons in namespace
-    // Object.keys(namespacedOptions).forEach((key) => {
-    // Object.keys(namespacedOptions[key]).forEach((k) => {
-    // if (
-    // k === 'checkbox' ||
-    // (k === 'radio' && namespacedOptions[key][k].iconColor)
-    // ) {
-    // namespacedOptions[key][k].icon = options[key][k].icon;
-    // }
-    // });
-    // });
-
-    // addNamespaced(`${namespace} `, namespacedOptions);
-    // });
-    // }
-
     const { powerSelect: powerSelectOptions } = options.default || {};
 
     require('tailwindcss-ember-power-select').registerComponents(

--- a/packages/forms/tailwind/index.js
+++ b/packages/forms/tailwind/index.js
@@ -9,7 +9,8 @@ const {
   isEmpty,
   kebabCase,
   flattenOptions,
-  addSinglePartComponent
+  addSinglePartComponent,
+  addMultipartComponent
 } = require('@frontile/tailwindcss-plugin-helpers');
 
 module.exports = plugin.withOptions(function (userConfig) {
@@ -34,308 +35,63 @@ module.exports = plugin.withOptions(function (userConfig) {
       };
     }
 
-    addSinglePartComponent(
-      addComponents,
-      '.form-field-checkbox',
-      options.checkbox,
-      replaceIconFn
-    );
-    addSinglePartComponent(
-      addComponents,
-      '.form-field-feedback',
-      options.feedback,
-      replaceIconFn
-    );
-    addSinglePartComponent(
-      addComponents,
-      '.form-field-hint',
-      options.hint,
-      replaceIconFn
-    );
-    addSinglePartComponent(
-      addComponents,
-      '.form-field-input',
-      options.input,
-      replaceIconFn
-    );
-    addSinglePartComponent(
-      addComponents,
-      '.form-field-label',
-      options.label,
-      replaceIconFn
-    );
-    addSinglePartComponent(
-      addComponents,
-      '.form-field-radio',
-      options.radio,
-      replaceIconFn
-    );
-    addSinglePartComponent(
-      addComponents,
-      '.form-field-textarea',
-      options.textarea,
-      replaceIconFn
-    );
-
-    // OLD ---
-
-    function addFormElementComponent(
-      namespace,
-      key,
-      options,
-      modifier = '',
-      prefix = ''
-    ) {
-      if (isEmpty(options)) {
-        return;
-      }
-
-      addComponents({
-        [`${namespace}${prefix}.form__${key}${modifier}`]: options
-      });
-    }
-
-    // To be used with Radio and Checkbox elements
-    function addFromElementWithIcon(
-      namespace,
-      key,
-      options,
-      modifier = '',
-      prefix = ''
-    ) {
-      if (isEmpty(options)) {
-        return;
-      }
-
-      addComponents(
-        replaceIconDeclarations(
-          {
-            [`${namespace}${prefix}.form__${key}${modifier}`]: merge(
-              options.borderWidth === undefined
-                ? {}
-                : {
-                    '&::-ms-check': {
-                      '@media not print': {
-                        borderWidth: options.borderWidth
-                      }
-                    }
-                  },
-              options
-            )
-          },
-          ({ icon = options.icon, iconColor = options.iconColor }) => {
-            return {
-              '&:checked': {
-                backgroundImage: `url("${svgToDataUri(
-                  typeof icon === 'function' ? icon(iconColor) : icon
-                )}")`
-              }
-            };
-          }
-        )
+    [
+      ['.form-field-checkbox', 'checkbox'],
+      ['.form-field-feedback', 'feedback'],
+      ['.form-field-hint', 'hint'],
+      ['.form-field-input', 'input'],
+      ['.form-field-label', 'label'],
+      ['.form-field-radio', 'radio'],
+      ['.form-field-textarea', 'textarea']
+    ].forEach(([selector, key]) => {
+      addSinglePartComponent(
+        addComponents,
+        selector,
+        options[key],
+        replaceIconFn
       );
-    }
+    });
 
-    function addFormContainerComponents(namespace, key, options, modifier) {
-      const {
-        label,
-        input,
-        textarea,
-        checkbox,
-        radio,
-        hint,
-        feedback,
-        labelContainer,
-        inputContainer,
-        ...rest
-      } = options || {};
+    [
+      ['.form-input', 'formInput'],
+      ['.form-textarea', 'formTextarea'],
+      ['.form-select', 'formSelect'],
+      ['.form-checkbox', 'formCheckbox'],
+      ['.form-radio', 'formRadio'],
+      ['.form-checkbox-group', 'formRadioGroup'],
+      ['.form-radio-group', 'formRadioGroup']
+    ].forEach(([selector, key]) => {
+      addMultipartComponent(addComponents, selector, options[key]);
+    });
 
-      const className = `${namespace}.form-${key}-container${modifier}`;
+    // const { namespaced } = options;
+    // options.namespaced = undefined;
+    // addNamespaced('', options);
 
-      if (!isEmpty(rest)) {
-        addComponents({ [className]: rest });
-      }
+    // if (namespaced && Object.keys(namespaced).length > 0) {
+    // Object.keys(namespaced).forEach((namespace) => {
+    // const namespacedOptions = fromPairs(
+    // map(namespaced[namespace], (value, key) => [
+    // key,
+    // flattenOptions(value)
+    // ])
+    // );
 
-      addFormElementComponent(
-        namespace,
-        'label',
-        label,
-        modifier,
-        `${className} `
-      );
-      addFormElementComponent(
-        namespace,
-        'input',
-        input,
-        modifier,
-        `${className} > `
-      );
-      addFormElementComponent(
-        namespace,
-        'textarea',
-        textarea,
-        modifier,
-        `${className} > `
-      );
-      addFormElementComponent(
-        namespace,
-        'feedback',
-        feedback,
-        modifier,
-        `${className} > `
-      );
-      addFromElementWithIcon(
-        namespace,
-        'checkbox',
-        checkbox,
-        modifier,
-        `${className} > `
-      );
-      addFromElementWithIcon(
-        namespace,
-        'radio',
-        radio,
-        modifier,
-        `${className} > `
-      );
+    // // Work around to allow change color of icons in namespace
+    // Object.keys(namespacedOptions).forEach((key) => {
+    // Object.keys(namespacedOptions[key]).forEach((k) => {
+    // if (
+    // k === 'checkbox' ||
+    // (k === 'radio' && namespacedOptions[key][k].iconColor)
+    // ) {
+    // namespacedOptions[key][k].icon = options[key][k].icon;
+    // }
+    // });
+    // });
 
-      if (!isEmpty(hint)) {
-        let hintOptions = hint;
-
-        // Make sure to set up the fontSize for hint before
-        if (hintOptions['&::before'] !== undefined && modifier === '') {
-          hintOptions = merge(hintOptions, {
-            '&::before': {
-              fontSize: rest.fontSize || '1rem'
-            }
-          });
-        }
-
-        addFormElementComponent(
-          namespace,
-          'hint',
-          hintOptions,
-          modifier,
-          `${className} > `
-        );
-      }
-
-      // Used in FormCheckbox and FormRadio components
-      if (!isEmpty(labelContainer)) {
-        addComponents({
-          [`${namespace}.form-${key}-container__label-container`]: labelContainer
-        });
-      }
-      if (!isEmpty(inputContainer)) {
-        addComponents({
-          [`${namespace}.form-${key}-container__input-container`]: inputContainer
-        });
-      }
-    }
-
-    function addNamespaced(namespace, options) {
-      Object.keys(options).forEach((key) => {
-        const {
-          label,
-          input,
-          textarea,
-          checkbox,
-          radio,
-          hint,
-          feedback,
-
-          formInputContainer,
-          formTextareaContainer,
-          formCheckboxGroup,
-          formRadioGroup,
-          formCheckboxContainer,
-          formRadioContainer,
-          formSelectContainer
-        } = options[key] || {};
-
-        const modifier = key === 'default' ? '' : `--${kebabCase(key)}`;
-
-        addFormElementComponent(namespace, 'label', label, modifier);
-        addFormElementComponent(namespace, 'input', input, modifier);
-        addFormElementComponent(namespace, 'textarea', textarea, modifier);
-        addFormElementComponent(namespace, 'hint', hint, modifier);
-        addFormElementComponent(namespace, 'feedback', feedback, modifier);
-        addFromElementWithIcon(namespace, 'checkbox', checkbox, modifier);
-        addFromElementWithIcon(namespace, 'radio', radio, modifier);
-
-        addFormContainerComponents(
-          namespace,
-          'input',
-          formInputContainer,
-          modifier
-        );
-        addFormContainerComponents(
-          namespace,
-          'textarea',
-          formTextareaContainer,
-          modifier
-        );
-        addFormContainerComponents(
-          namespace,
-          'checkbox',
-          formCheckboxContainer,
-          modifier
-        );
-        addFormContainerComponents(
-          namespace,
-          'radio',
-          formRadioContainer,
-          modifier
-        );
-        addFormContainerComponents(
-          namespace,
-          'select',
-          formSelectContainer,
-          modifier
-        );
-        addFormContainerComponents(
-          namespace,
-          'checkbox-group',
-          formCheckboxGroup,
-          modifier
-        );
-        addFormContainerComponents(
-          namespace,
-          'radio-group',
-          formRadioGroup,
-          modifier
-        );
-      });
-    }
-
-    const { namespaced } = options;
-    options.namespaced = undefined;
-    addNamespaced('', options);
-
-    if (namespaced && Object.keys(namespaced).length > 0) {
-      Object.keys(namespaced).forEach((namespace) => {
-        const namespacedOptions = fromPairs(
-          map(namespaced[namespace], (value, key) => [
-            key,
-            flattenOptions(value)
-          ])
-        );
-
-        // Work around to allow change color of icons in namespace
-        Object.keys(namespacedOptions).forEach((key) => {
-          Object.keys(namespacedOptions[key]).forEach((k) => {
-            if (
-              k === 'checkbox' ||
-              (k === 'radio' && namespacedOptions[key][k].iconColor)
-            ) {
-              namespacedOptions[key][k].icon = options[key][k].icon;
-            }
-          });
-        });
-
-        addNamespaced(`${namespace} `, namespacedOptions);
-      });
-    }
+    // addNamespaced(`${namespace} `, namespacedOptions);
+    // });
+    // }
 
     const { powerSelect: powerSelectOptions } = options.default || {};
 

--- a/packages/forms/tests/dummy/app/components/form-example.hbs
+++ b/packages/forms/tests/dummy/app/components/form-example.hbs
@@ -1,21 +1,30 @@
 <div class="p-4 bg-gray-100 border rounded">
+  <FormRadioGroup
+    @label="Size"
+    @value={{this.size}}
+    @onChange={{fn this.setField "size"}}
+    @isInline={{true}}
+    as |Radio|
+  >
+    <Radio
+      @value="sm"
+      @label="sm"
+    />
+    <Radio
+      @value="lg"
+      @label="lg"
+    />
+    <Radio
+      @value=""
+      @label="default"
+    />
+  </FormRadioGroup>
+
   <FormCheckboxGroup
     @isInline={{true}}
     @label="Settings"
     as |Checkbox|
   >
-    <Checkbox
-      disabled={{this.isLarge}}
-      @label="@isSmall"
-      @checked={{this.isSmall}}
-      @onChange={{fn this.setField "isSmall"}}
-    />
-    <Checkbox
-      disabled={{this.isSmall}}
-      @label="@isLarge"
-      @checked={{this.isLarge}}
-      @onChange={{fn this.setField "isLarge"}}
-    />
     <Checkbox
       @label="@isInline"
       @checked={{this.isInline}}
@@ -32,8 +41,7 @@
   @errors={{this.firstNameErrors}}
   placeholder="Joe"
   @containerClass="mt-4"
-  @isSmall={{this.isSmall}}
-  @isLarge={{this.isLarge}}
+  @size={{this.size}}
 />
 
 <FormInput
@@ -42,14 +50,12 @@
   @onChange={{fn this.setField "email"}}
   @errors={{this.emailErrors}}
   @containerClass="mt-4"
-  @isSmall={{this.isSmall}}
-  @isLarge={{this.isLarge}}
+  @size={{this.size}}
 />
 
 <FormSelect
   @isMultiple={{false}}
-  @isSmall={{this.isSmall}}
-  @isLarge={{this.isLarge}}
+  @size={{this.size}}
   @containerClass="mt-4"
   @hint="Select your country of residence"
   @errors={{this.countryErrors}}
@@ -71,8 +77,7 @@
   @onChange={{fn this.setField "accountType"}}
   @errors={{this.accountTypeErrors}}
   @containerClass="mt-4"
-  @isSmall={{this.isSmall}}
-  @isLarge={{this.isLarge}}
+  @size={{this.size}}
   @isInline={{this.isInline}}
   as |Radio|
 >
@@ -95,8 +100,7 @@
   @label="Interests"
   @errors={{this.interestsErrors}}
   @containerClass="mt-4"
-  @isSmall={{this.isSmall}}
-  @isLarge={{this.isLarge}}
+  @size={{this.size}}
   @isInline={{this.isInline}}
   as |Checkbox|
 >
@@ -124,14 +128,12 @@
   @value={{this.bio}}
   @onChange={{fn this.setField "bio"}}
   @containerClass="mt-4"
-  @isSmall={{this.isSmall}}
-  @isLarge={{this.isLarge}}
+  @size={{this.size}}
 />
 
 <FormCheckbox
   @containerClass="mt-4"
-  @isSmall={{this.isSmall}}
-  @isLarge={{this.isLarge}}
+  @size={{this.size}}
 >
   I agree to the <a href="#" class="underline">privacy policy</a>
 </FormCheckbox>

--- a/packages/forms/tests/dummy/app/components/form-example.ts
+++ b/packages/forms/tests/dummy/app/components/form-example.ts
@@ -5,8 +5,7 @@ import { action } from '@ember/object';
 interface FormExampleArgs {}
 
 export default class FormExample extends Component<FormExampleArgs> {
-  @tracked isSmall = false;
-  @tracked isLarge = false;
+  @tracked size = '';
   @tracked isInline = false;
 
   @tracked firstName!: string;
@@ -78,24 +77,18 @@ export default class FormExample extends Component<FormExampleArgs> {
     return this.interests.includes('Entertainment');
   }
 
-  @action setCountry(value: unknown) {
+  @action setCountry(value: unknown): void {
     this.country = value;
   }
 
   @action setField(
-    fieldName:
-      | 'firstName'
-      | 'email'
-      | 'accountType'
-      | 'isLarge'
-      | 'isSmall'
-      | 'isInline',
+    fieldName: 'firstName' | 'email' | 'accountType' | 'isInline' | 'size',
     value: string | boolean
-  ) {
+  ): void {
     this[fieldName] = value as never;
   }
 
-  @action setInterest(interest: string, isChecked: boolean) {
+  @action setInterest(interest: string, isChecked: boolean): void {
     if (isChecked) {
       this.interests = [...this.interests, interest];
     } else {

--- a/packages/forms/tests/dummy/app/styles/tailwind.config.js
+++ b/packages/forms/tests/dummy/app/styles/tailwind.config.js
@@ -5,8 +5,11 @@ module.exports = {
     removeDeprecatedGapUtilities: true
   },
   theme: {
-    '@frontile/forms': {
-      default: {}
+    frontile: {
+      forms: {
+        config: {},
+        extend: {}
+      }
     }
   },
   plugins: [require('@frontile/forms/tailwind')]

--- a/packages/forms/tests/integration/components/form-checkbox-group-test.ts
+++ b/packages/forms/tests/integration/components/form-checkbox-group-test.ts
@@ -15,8 +15,7 @@ module('Integration | Component | FormCheckboxGroup', function (hooks) {
         @containerClass={{this.containerClass}}
         @hasSubmitted={{this.hasSubmitted}}
         @isInline={{this.isInline}}
-        @isSmall={{this.isSmall}}
-        @isLarge={{this.isLarge}}
+        @size={{this.size}}
         @label="My Group"
         @hint="Hint"
         as |Checkbox|
@@ -64,7 +63,7 @@ module('Integration | Component | FormCheckboxGroup', function (hooks) {
 
     assert
       .dom('[data-test-input-group]')
-      .hasClass('form-checkbox-group-container--inline');
+      .hasClass('form-checkbox-group--inline');
   });
 
   test('show error messages when errors array has items', async function (assert) {
@@ -130,59 +129,35 @@ module('Integration | Component | FormCheckboxGroup', function (hooks) {
     assert.dom('.my-container-class').exists();
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
     this.set('errors', ['Error']);
     this.set('hasSubmitted', true);
     await render(template);
 
-    assert
-      .dom('[data-test-input-group]')
-      .hasClass('form-checkbox-group-container--sm');
-    assert.dom('[data-test-checkbox-1]').hasClass('form__checkbox--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
-
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert
-      .dom('[data-test-input-group]')
-      .hasClass('form-checkbox-group-container--lg');
-    assert.dom('[data-test-checkbox-1]').hasClass('form__checkbox--lg');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--lg');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--lg');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert
-      .dom('[data-test-input-group]')
-      .hasClass('form-checkbox-group-container--sm');
-    assert.dom('[data-test-checkbox-1]').hasClass('form__checkbox--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
-    assert
-      .dom('[data-test-input-group]')
-      .doesNotHaveClass('form-checkbox-group-container--lg');
-    assert.dom('[data-test-checkbox-1]').doesNotHaveClass('form__checkbox--lg');
+    assert.dom('[data-test-input-group]').hasClass('form-checkbox-group--sm');
+    assert.dom('[data-test-checkbox-1]').hasClass('form-field-checkbox--sm');
     assert
       .dom('[data-test-id="form-field-label"]')
-      .doesNotHaveClass('form__label--lg');
+      .hasClass('form-field-label--sm');
     assert
       .dom('[data-test-id="form-field-hint"]')
-      .doesNotHaveClass('form__hint--lg');
+      .hasClass('form-field-hint--sm');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .doesNotHaveClass('form__feedback--lg');
+      .hasClass('form-field-feedback--sm');
+
+    this.set('size', 'lg');
+    assert.dom('[data-test-input-group]').hasClass('form-checkbox-group--lg');
+    assert.dom('[data-test-checkbox-1]').hasClass('form-field-checkbox--lg');
+    assert
+      .dom('[data-test-id="form-field-label"]')
+      .hasClass('form-field-label--lg');
+    assert
+      .dom('[data-test-id="form-field-hint"]')
+      .hasClass('form-field-hint--lg');
+    assert
+      .dom('[data-test-id="form-field-feedback"]')
+      .hasClass('form-field-feedback--lg');
   });
 });

--- a/packages/forms/tests/integration/components/form-checkbox-test.ts
+++ b/packages/forms/tests/integration/components/form-checkbox-test.ts
@@ -143,9 +143,8 @@ module('Integration | Component | FormCheckbox', function (hooks) {
     assert.dom('.my-container-class').exists();
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
     await render(
       hbs`<FormCheckbox
@@ -153,37 +152,27 @@ module('Integration | Component | FormCheckbox', function (hooks) {
             @containerClass="my-container"
             @label="Label"
             @hint="Hint"
-            @isSmall={{this.isSmall}}
-            @isLarge={{this.isLarge}}
+            @size={{this.size}}
           />`
     );
 
-    assert.dom('.my-container').hasClass('form-checkbox-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__checkbox--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-checkbox-container--lg');
-    assert.dom('[data-test-input]').hasClass('form__checkbox--lg');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--lg');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-checkbox-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__checkbox--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert.dom('.my-container').doesNotHaveClass('form-checkbox-container--lg');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__checkbox--lg');
+    assert.dom('.my-container').hasClass('form-checkbox--sm');
+    assert.dom('[data-test-input]').hasClass('form-checkbox--sm__checkbox');
     assert
       .dom('[data-test-id="form-field-label"]')
-      .doesNotHaveClass('form__label--lg');
+      .hasClass('form-checkbox--sm__label');
     assert
       .dom('[data-test-id="form-field-hint"]')
-      .doesNotHaveClass('form__hint--lg');
+      .hasClass('form-checkbox--sm__hint');
+
+    this.set('size', 'lg');
+    assert.dom('.my-container').hasClass('form-checkbox--lg');
+    assert.dom('[data-test-input]').hasClass('form-checkbox--lg__checkbox');
+    assert
+      .dom('[data-test-id="form-field-label"]')
+      .hasClass('form-checkbox--lg__label');
+    assert
+      .dom('[data-test-id="form-field-hint"]')
+      .hasClass('form-checkbox--lg__hint');
   });
 });

--- a/packages/forms/tests/integration/components/form-field/checkbox-test.ts
+++ b/packages/forms/tests/integration/components/form-field/checkbox-test.ts
@@ -21,24 +21,17 @@ module('Integration | Component | FormField::Checkbox', function (hooks) {
     assert.dom('[data-test-checkbox]').hasAttribute('id', 'my-id');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
     await render(
-      hbs`<FormField::Checkbox data-test-input @isSmall={{this.isSmall}} @isLarge={{this.isLarge}} />`
+      hbs`<FormField::Checkbox data-test-input @size={{this.size}} />`
     );
 
-    assert.dom('[data-test-input]').hasClass('form__checkbox--sm');
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__checkbox--lg');
+    assert.dom('[data-test-input]').hasClass('form-field-checkbox--sm');
 
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__checkbox--sm');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__checkbox--lg');
+    this.set('size', 'lg');
+    assert.dom('[data-test-input]').hasClass('form-field-checkbox--lg');
   });
 
   test('it renders id html attribute', async function (assert) {

--- a/packages/forms/tests/integration/components/form-field/feedback-test.ts
+++ b/packages/forms/tests/integration/components/form-field/feedback-test.ts
@@ -21,7 +21,7 @@ module('Integration | Component | FormField::Feedback', function (hooks) {
       .containsText('Some error');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--state-error');
+      .hasClass('form-field-feedback--error');
   });
 
   test('it renders an array of errors by joing elements', async function (assert) {
@@ -32,7 +32,7 @@ module('Integration | Component | FormField::Feedback', function (hooks) {
       .containsText('Some error; Another error');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--state-error');
+      .hasClass('form-field-feedback--error');
   });
 
   test('it renders when passing an string', async function (assert) {
@@ -43,7 +43,7 @@ module('Integration | Component | FormField::Feedback', function (hooks) {
       .containsText('Another error');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--state-error');
+      .hasClass('form-field-feedback--error');
   });
 
   test('it adds aria-live as assertive', async function (assert) {
@@ -54,24 +54,16 @@ module('Integration | Component | FormField::Feedback', function (hooks) {
       .hasAttribute('aria-live', 'assertive');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
     await render(
-      hbs`<FormField::Feedback data-test-input @isSmall={{this.isSmall}} @isLarge={{this.isLarge}} />`
+      hbs`<FormField::Feedback data-test-input @size={{this.size}} />`
     );
 
-    assert.dom('[data-test-input]').hasClass('form__feedback--sm');
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__feedback--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__feedback--sm');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__feedback--lg');
+    assert.dom('[data-test-input]').hasClass('form-field-feedback--sm');
+    this.set('size', 'lg');
+    assert.dom('[data-test-input]').hasClass('form-field-feedback--lg');
   });
 
   test('it does not break if passed an undefined arg', async function (assert) {
@@ -80,7 +72,7 @@ module('Integration | Component | FormField::Feedback', function (hooks) {
     assert.dom('[data-test-id="form-field-feedback"]').exists();
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .doesNotHaveClass('form__feedback--state-error');
+      .doesNotHaveClass('form-field-feedback--error');
     assert
       .dom('[data-test-id="form-field-feedback"]')
       .hasAttribute('aria-live', 'polite');
@@ -90,7 +82,7 @@ module('Integration | Component | FormField::Feedback', function (hooks) {
     await render(hbs`<FormField::Feedback>Block content</FormField::Feedback>`);
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .doesNotHaveClass('form__feedback--state-error');
+      .doesNotHaveClass('form-field-feedback--error');
     assert
       .dom('[data-test-id="form-field-feedback"]')
       .containsText('Block content');
@@ -102,7 +94,7 @@ module('Integration | Component | FormField::Feedback', function (hooks) {
     );
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--state-error');
+      .hasClass('form-field-feedback--error');
     assert
       .dom('[data-test-id="form-field-feedback"]')
       .containsText('Block content');

--- a/packages/forms/tests/integration/components/form-field/hint-test.ts
+++ b/packages/forms/tests/integration/components/form-field/hint-test.ts
@@ -14,28 +14,18 @@ module('Integration | Component | FormField::Hint', function (hooks) {
       .dom('[data-test-id="form-field-hint"]')
       .hasAttribute('id', 'some-hint-id');
 
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint');
+    assert.dom('[data-test-id="form-field-hint"]').hasClass('form-field-hint');
     assert.dom('[data-test-id="form-field-hint"]').hasClass('something-else');
     assert.dom('[data-test-id="form-field-hint"]').hasTextContaining('Content');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
-    await render(
-      hbs`<FormField::Hint data-test-input @isSmall={{this.isSmall}} @isLarge={{this.isLarge}} />`
-    );
+    await render(hbs`<FormField::Hint data-test-input @size={{this.size}} />`);
 
-    assert.dom('[data-test-input]').hasClass('form__hint--sm');
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__hint--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__hint--sm');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__hint--lg');
+    assert.dom('[data-test-input]').hasClass('form-field-hint--sm');
+    this.set('size', 'lg');
+    assert.dom('[data-test-input]').hasClass('form-field-hint--lg');
   });
 });

--- a/packages/forms/tests/integration/components/form-field/input-test.ts
+++ b/packages/forms/tests/integration/components/form-field/input-test.ts
@@ -39,24 +39,14 @@ module('Integration | Component | FormField::Input', function (hooks) {
     assert.dom('[data-test-my-input]').hasAttribute('id', 'my-id');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
-    await render(
-      hbs`<FormField::Input data-test-input @isSmall={{this.isSmall}} @isLarge={{this.isLarge}} />`
-    );
+    await render(hbs`<FormField::Input data-test-input @size={{this.size}} />`);
 
-    assert.dom('[data-test-input]').hasClass('form__input--sm');
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__input--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__input--sm');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__input--lg');
+    assert.dom('[data-test-input]').hasClass('form-field-input--sm');
+    this.set('size', 'lg');
+    assert.dom('[data-test-input]').hasClass('form-field-input--lg');
   });
 
   test('renders @value arg, does not mutate it by default', async function (assert) {

--- a/packages/forms/tests/integration/components/form-field/label-test.ts
+++ b/packages/forms/tests/integration/components/form-field/label-test.ts
@@ -14,30 +14,22 @@ module('Integration | Component | FormField::Label', function (hooks) {
       .dom('[data-test-id="form-field-label"]')
       .hasAttribute('for', 'some-input-id');
 
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label');
+    assert
+      .dom('[data-test-id="form-field-label"]')
+      .hasClass('form-field-label');
     assert.dom('[data-test-id="form-field-label"]').hasClass('something-else');
     assert
       .dom('[data-test-id="form-field-label"]')
       .hasTextContaining('My Label');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
-    await render(
-      hbs`<FormField::Label data-test-input @isSmall={{this.isSmall}} @isLarge={{this.isLarge}} />`
-    );
+    await render(hbs`<FormField::Label data-test-input @size={{this.size}} />`);
 
-    assert.dom('[data-test-input]').hasClass('form__label--sm');
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__label--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__label--sm');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__label--lg');
+    assert.dom('[data-test-input]').hasClass('form-field-label--sm');
+    this.set('size', 'lg');
+    assert.dom('[data-test-input]').hasClass('form-field-label--lg');
   });
 });

--- a/packages/forms/tests/integration/components/form-field/radio-test.ts
+++ b/packages/forms/tests/integration/components/form-field/radio-test.ts
@@ -27,24 +27,14 @@ module('Integration | Component | FormField::Radio', function (hooks) {
     assert.dom('[data-test-radio]').hasAttribute('id', 'my-id');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
-    await render(
-      hbs`<FormField::Radio data-test-input @isSmall={{this.isSmall}} @isLarge={{this.isLarge}} />`
-    );
+    await render(hbs`<FormField::Radio data-test-input @size={{this.size}} />`);
 
-    assert.dom('[data-test-input]').hasClass('form__radio--sm');
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__radio--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__radio--sm');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__radio--lg');
+    assert.dom('[data-test-input]').hasClass('form-field-radio--sm');
+    this.set('size', 'lg');
+    assert.dom('[data-test-input]').hasClass('form-field-radio--lg');
   });
 
   test('it renders @name arg', async function (assert) {

--- a/packages/forms/tests/integration/components/form-field/textarea-test.ts
+++ b/packages/forms/tests/integration/components/form-field/textarea-test.ts
@@ -28,24 +28,16 @@ module('Integration | Component | FormField::Textarea', function (hooks) {
     assert.dom('[data-test-textarea]').hasAttribute('id', 'my-id');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
     await render(
-      hbs`<FormField::Textarea data-test-input @isSmall={{this.isSmall}} @isLarge={{this.isLarge}} />`
+      hbs`<FormField::Textarea data-test-input @size={{this.size}} />`
     );
 
-    assert.dom('[data-test-input]').hasClass('form__textarea--sm');
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__textarea--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('[data-test-input]').hasClass('form__textarea--sm');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__textarea--lg');
+    assert.dom('[data-test-input]').hasClass('form-field-textarea--sm');
+    this.set('size', 'lg');
+    assert.dom('[data-test-input]').hasClass('form-field-textarea--lg');
   });
 
   test('renders @value arg, does not mutate it by default', async function (assert) {

--- a/packages/forms/tests/integration/components/form-input-test.ts
+++ b/packages/forms/tests/integration/components/form-input-test.ts
@@ -254,9 +254,8 @@ module('Integration | Component | FormInput', function (hooks) {
     assert.dom('.my-container-class').exists();
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
     await render(
       hbs`<FormInput
@@ -266,49 +265,33 @@ module('Integration | Component | FormInput', function (hooks) {
             @hint="Hint"
             @errors="Error"
             @hasSubmitted={{true}}
-            @isSmall={{this.isSmall}}
-            @isLarge={{this.isLarge}}
+            @size={{this.size}}
           />`
     );
 
-    assert.dom('.my-container').hasClass('form-input-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__input--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
-
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-input-container--lg');
-    assert.dom('[data-test-input]').hasClass('form__input--lg');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--lg');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--lg');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-input-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__input--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
-    assert.dom('.my-container').doesNotHaveClass('form-input-container--lg');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__input--lg');
+    assert.dom('.my-container').hasClass('form-input--sm');
+    assert.dom('[data-test-input]').hasClass('form-input--sm__input');
     assert
       .dom('[data-test-id="form-field-label"]')
-      .doesNotHaveClass('form__label--lg');
+      .hasClass('form-input--sm__label');
     assert
       .dom('[data-test-id="form-field-hint"]')
-      .doesNotHaveClass('form__hint--lg');
+      .hasClass('form-input--sm__hint');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .doesNotHaveClass('form__feedback--lg');
+      .hasClass('form-input--sm__feedback');
+
+    this.set('size', 'lg');
+    assert.dom('.my-container').hasClass('form-input--lg');
+    assert.dom('[data-test-input]').hasClass('form-input--lg__input');
+    assert
+      .dom('[data-test-id="form-field-label"]')
+      .hasClass('form-input--lg__label');
+    assert
+      .dom('[data-test-id="form-field-hint"]')
+      .hasClass('form-input--lg__hint');
+    assert
+      .dom('[data-test-id="form-field-feedback"]')
+      .hasClass('form-input--lg__feedback');
   });
 });

--- a/packages/forms/tests/integration/components/form-radio-group-test.ts
+++ b/packages/forms/tests/integration/components/form-radio-group-test.ts
@@ -15,8 +15,7 @@ module('Integration | Component | FormRadioGroup', function (hooks) {
         @errors={{this.errors}}
         @hasSubmitted={{this.hasSubmitted}}
         @isInline={{this.isInline}}
-        @isSmall={{this.isSmall}}
-        @isLarge={{this.isLarge}}
+        @size={{this.size}}
         @containerClass={{this.containerClass}}
         @label="My Group"
         @value={{this.myValue}}
@@ -75,9 +74,7 @@ module('Integration | Component | FormRadioGroup', function (hooks) {
     this.set('isInline', true);
     await render(template);
 
-    assert
-      .dom('[data-test-input-group]')
-      .hasClass('form-radio-group-container--inline');
+    assert.dom('[data-test-input-group]').hasClass('form-radio-group--inline');
   });
 
   test('show error messages when errors array has items', async function (assert) {

--- a/packages/forms/tests/integration/components/form-radio-test.ts
+++ b/packages/forms/tests/integration/components/form-radio-test.ts
@@ -146,9 +146,8 @@ module('Integration | Component | FormRadio', function (hooks) {
     assert.dom('.my-container-class').exists();
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
     await render(
       hbs`<FormRadio
@@ -156,37 +155,27 @@ module('Integration | Component | FormRadio', function (hooks) {
             @containerClass="my-container"
             @label="Label"
             @hint="Hint"
-            @isSmall={{this.isSmall}}
-            @isLarge={{this.isLarge}}
+            @size={{this.size}}
           />`
     );
 
-    assert.dom('.my-container').hasClass('form-radio-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__radio--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-radio-container--lg');
-    assert.dom('[data-test-input]').hasClass('form__radio--lg');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--lg');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-radio-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__radio--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert.dom('.my-container').doesNotHaveClass('form-radio-container--lg');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__radio--lg');
+    assert.dom('.my-container').hasClass('form-radio--sm');
+    assert.dom('[data-test-input]').hasClass('form-radio--sm__radio');
     assert
       .dom('[data-test-id="form-field-label"]')
-      .doesNotHaveClass('form__label--lg');
+      .hasClass('form-radio--sm__label');
     assert
       .dom('[data-test-id="form-field-hint"]')
-      .doesNotHaveClass('form__hint--lg');
+      .hasClass('form-radio--sm__hint');
+
+    this.set('size', 'lg');
+    assert.dom('.my-container').hasClass('form-radio--lg');
+    assert.dom('[data-test-input]').hasClass('form-radio--lg__radio');
+    assert
+      .dom('[data-test-id="form-field-label"]')
+      .hasClass('form-radio--lg__label');
+    assert
+      .dom('[data-test-id="form-field-hint"]')
+      .hasClass('form-radio--lg__hint');
   });
 });

--- a/packages/forms/tests/integration/components/form-select-test.ts
+++ b/packages/forms/tests/integration/components/form-select-test.ts
@@ -16,8 +16,7 @@ module('Integration | Component | FormSelect', function (hooks) {
                           @label="Select Countries"
                           @hint="The countries where you have lived"
                           @onChange={{action (mut this.value)}}
-                          @isSmall={{this.isSmall}}
-                          @isLarge={{this.isLarge}}
+                          @size={{this.size}}
                           @hasError={{this.hasError}}
                           @errors={{this.errors}}
                           @hasSubmitted={{this.hasSubmitted}}
@@ -177,60 +176,40 @@ module('Integration | Component | FormSelect', function (hooks) {
       .hasText('This field is required');
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
     this.set('errors', ['something']);
     this.set('hasSubmitted', true);
 
     await render(template);
 
-    assert.dom('.my-container').hasClass('form-select-container--sm');
+    assert.dom('.my-container').hasClass('form-select--sm');
     assert
       .dom('.ember-power-select-trigger')
       .hasClass('ember-power-select-trigger-sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
+    assert
+      .dom('[data-test-id="form-field-label"]')
+      .hasClass('form-select--sm__label');
+    assert
+      .dom('[data-test-id="form-field-hint"]')
+      .hasClass('form-select--sm__hint');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
+      .hasClass('form-select--sm__feedback');
 
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-select-container--lg');
+    this.set('size', 'lg');
+    assert.dom('.my-container').hasClass('form-select--lg');
     assert
       .dom('.ember-power-select-trigger')
       .hasClass('ember-power-select-trigger-lg');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--lg');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--lg');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-select-container--sm');
-    assert
-      .dom('.ember-power-select-trigger')
-      .hasClass('ember-power-select-trigger-sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
-    assert.dom('.my-container').doesNotHaveClass('form-select-container--lg');
-    assert
-      .dom('.ember-power-select-trigger')
-      .doesNotHaveClass('ember-power-select-trigger-lg');
     assert
       .dom('[data-test-id="form-field-label"]')
-      .doesNotHaveClass('form__label--lg');
+      .hasClass('form-select--lg__label');
     assert
       .dom('[data-test-id="form-field-hint"]')
-      .doesNotHaveClass('form__hint--lg');
+      .hasClass('form-select--lg__hint');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .doesNotHaveClass('form__feedback--lg');
+      .hasClass('form-select--lg__feedback');
   });
 });

--- a/packages/forms/tests/integration/components/form-textarea-test.ts
+++ b/packages/forms/tests/integration/components/form-textarea-test.ts
@@ -250,9 +250,8 @@ module('Integration | Component | FormTextarea', function (hooks) {
     assert.dom('.my-container-class').exists();
   });
 
-  test('it adds size classes for @isSmall and @isLarge', async function (assert) {
-    this.set('isSmall', true);
-    this.set('isLarge', false);
+  test('it adds size classes for @size', async function (assert) {
+    this.set('size', 'sm');
 
     await render(
       hbs`<FormTextarea
@@ -262,49 +261,33 @@ module('Integration | Component | FormTextarea', function (hooks) {
             @hint="Hint"
             @errors="Error"
             @hasSubmitted={{true}}
-            @isSmall={{this.isSmall}}
-            @isLarge={{this.isLarge}}
+            @size={{this.size}}
           />`
     );
 
-    assert.dom('.my-container').hasClass('form-textarea-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__textarea--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
-
-    this.set('isSmall', false);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-textarea-container--lg');
-    assert.dom('[data-test-input]').hasClass('form__textarea--lg');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--lg');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--lg');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--lg');
-
-    // should only add one size class
-    this.set('isSmall', true);
-    this.set('isLarge', true);
-    assert.dom('.my-container').hasClass('form-textarea-container--sm');
-    assert.dom('[data-test-input]').hasClass('form__textarea--sm');
-    assert.dom('[data-test-id="form-field-label"]').hasClass('form__label--sm');
-    assert.dom('[data-test-id="form-field-hint"]').hasClass('form__hint--sm');
-    assert
-      .dom('[data-test-id="form-field-feedback"]')
-      .hasClass('form__feedback--sm');
-    assert.dom('.my-container').doesNotHaveClass('form-textarea-container--lg');
-    assert.dom('[data-test-input]').doesNotHaveClass('form__textarea--lg');
+    assert.dom('.my-container').hasClass('form-textarea--sm');
+    assert.dom('[data-test-input]').hasClass('form-textarea--sm__textarea');
     assert
       .dom('[data-test-id="form-field-label"]')
-      .doesNotHaveClass('form__label--lg');
+      .hasClass('form-textarea--sm__label');
     assert
       .dom('[data-test-id="form-field-hint"]')
-      .doesNotHaveClass('form__hint--lg');
+      .hasClass('form-textarea--sm__hint');
     assert
       .dom('[data-test-id="form-field-feedback"]')
-      .doesNotHaveClass('form__feedback--lg');
+      .hasClass('form-textarea--sm__feedback');
+
+    this.set('size', 'lg');
+    assert.dom('.my-container').hasClass('form-textarea--lg');
+    assert.dom('[data-test-input]').hasClass('form-textarea--lg__textarea');
+    assert
+      .dom('[data-test-id="form-field-label"]')
+      .hasClass('form-textarea--lg__label');
+    assert
+      .dom('[data-test-id="form-field-hint"]')
+      .hasClass('form-textarea--lg__hint');
+    assert
+      .dom('[data-test-id="form-field-feedback"]')
+      .hasClass('form-textarea--lg__feedback');
   });
 });

--- a/packages/tailwindcss-plugin-helpers/src/index.js
+++ b/packages/tailwindcss-plugin-helpers/src/index.js
@@ -1,36 +1,21 @@
 const isEmpty = require('lodash/isEmpty');
 const toPairs = require('lodash/toPairs');
 const fromPairs = require('lodash/fromPairs');
-const mergeWith = require('lodash/mergeWith');
+const merge = require('lodash/merge');
 const kebabCase = require('lodash/kebabCase');
 const map = require('lodash/map');
-const flatMap = require('lodash/flatMap');
 const isPlainObject = require('lodash/isPlainObject');
 const traverse = require('traverse');
 const svgToDataUri = require('mini-svg-data-uri');
 
-function merge(...options) {
-  function mergeCustomizer(objValue, srcValue, key, obj, src) {
-    if (isPlainObject(srcValue)) {
-      return mergeWith(objValue, srcValue, mergeCustomizer);
-    }
-    return Object.keys(src).includes(key)
-      ? // Convert undefined to null otherwise lodash won't replace the key
-        // PostCSS still omits properties with a null value so it behaves
-        // the same as undefined.
-        srcValue === undefined
-        ? null
-        : srcValue
-      : objValue;
-  }
-
-  return mergeWith({}, ...options, mergeCustomizer);
-}
-
 function flattenOptions(options) {
   return merge(
-    ...flatMap(toPairs(options), ([keys, value]) => {
-      return fromPairs(keys.split(', ').map((key) => [key, value]));
+    {},
+    ...toPairs(options).map(([keys, value]) => {
+      const flattendValue = isPlainObject(value)
+        ? flattenOptions(value)
+        : value;
+      return fromPairs(keys.split(', ').map((key) => [key, flattendValue]));
     })
   );
 }

--- a/packages/tailwindcss-plugin-helpers/src/index.js
+++ b/packages/tailwindcss-plugin-helpers/src/index.js
@@ -87,7 +87,7 @@ function resolve(optionsName, params, userConfig, theme) {
   };
 }
 
-function resolveComponents({ config: userConfig, extend }, params) {
+function resolveComponents({ config: userConfig, extend } = {}, params) {
   const { defaultConfig, defaultOptions } = params;
   const config = merge(
     flattenOptions(defaultConfig),

--- a/packages/tailwindcss-plugin-helpers/src/index.js
+++ b/packages/tailwindcss-plugin-helpers/src/index.js
@@ -118,16 +118,18 @@ function addMultipartComponent(
     baseSelector += `--${modifier}`;
   }
 
-  const { baseStyle, variants, parts } = options;
+  let { baseStyle, variants, parts } = options;
+  variants = flattenOptions(variants || {});
+  parts = flattenOptions(parts || {});
 
-  let defaultVariant = {};
   if (variants && !isEmpty(variants.default)) {
-    defaultVariant = variants.default;
+    const defaultVariant = variants.default;
     delete variants.default;
+    baseStyle = merge(baseStyle, defaultVariant);
   }
 
   addComponents({
-    [baseSelector]: merge(baseStyle, defaultVariant)
+    [baseSelector]: baseStyle
   });
 
   if (!isEmpty(parts)) {
@@ -187,6 +189,7 @@ function addSinglePartComponent(
   }
 
   let { baseStyle, variants } = options;
+  variants = flattenOptions(variants || {});
 
   if (variants && !isEmpty(variants.default)) {
     const defaultVariant = variants.default;

--- a/packages/tailwindcss-plugin-helpers/src/index.js
+++ b/packages/tailwindcss-plugin-helpers/src/index.js
@@ -150,28 +150,65 @@ function addMultipartComponent(
   }
 }
 
-function addSinglePartComponent(addComponents, baseSelector, options) {
+function addComponentsMaybeWithIcon(
+  addComponents,
+  selector,
+  styles,
+  replaceIconFn
+) {
+  if (
+    (Object.keys(styles).includes('iconColor') ||
+      Object.keys(styles).includes('icon')) &&
+    typeof replaceIconFn === 'function'
+  ) {
+    addComponents(
+      replaceIconDeclarations(
+        {
+          [selector]: styles
+        },
+        replaceIconFn
+      )
+    );
+  } else {
+    addComponents({
+      [selector]: styles
+    });
+  }
+}
+
+function addSinglePartComponent(
+  addComponents,
+  baseSelector,
+  options,
+  replaceIconFn
+) {
   if (isEmpty(options)) {
     return;
   }
 
-  const { baseStyle, variants } = options;
+  let { baseStyle, variants } = options;
 
-  let defaultVariant = {};
   if (variants && !isEmpty(variants.default)) {
-    defaultVariant = variants.default;
+    const defaultVariant = variants.default;
     delete variants.default;
+    baseStyle = merge(baseStyle, defaultVariant);
   }
 
-  addComponents({
-    [baseSelector]: merge(baseStyle, defaultVariant)
-  });
+  addComponentsMaybeWithIcon(
+    addComponents,
+    baseSelector,
+    baseStyle,
+    replaceIconFn
+  );
 
   if (!isEmpty(variants)) {
     Object.keys(variants).forEach((key) => {
-      addComponents({
-        [`${baseSelector}--${kebabCase(key)}`]: variants[key]
-      });
+      addComponentsMaybeWithIcon(
+        addComponents,
+        `${baseSelector}--${kebabCase(key)}`,
+        variants[key],
+        replaceIconFn
+      );
     });
   }
 }

--- a/packages/tailwindcss-plugin-helpers/src/index.js
+++ b/packages/tailwindcss-plugin-helpers/src/index.js
@@ -118,7 +118,7 @@ function addMultipartComponent(
     baseSelector += `--${modifier}`;
   }
 
-  let { baseStyle, variants, parts } = options;
+  let { baseStyle, variants, parts, namespaces } = options;
   variants = flattenOptions(variants || {});
   parts = flattenOptions(parts || {});
 
@@ -147,6 +147,16 @@ function addMultipartComponent(
         baseSelector,
         variants[key],
         kebabCase(key)
+      );
+    });
+  }
+
+  if (!isEmpty(namespaces)) {
+    Object.keys(namespaces).forEach((namespace) => {
+      addMultipartComponent(
+        addComponents,
+        `${namespace} ${baseSelector}`,
+        namespaces[namespace]
       );
     });
   }
@@ -188,7 +198,7 @@ function addSinglePartComponent(
     return;
   }
 
-  let { baseStyle, variants } = options;
+  let { baseStyle, variants, namespaces } = options;
   variants = flattenOptions(variants || {});
 
   if (variants && !isEmpty(variants.default)) {
@@ -206,10 +216,39 @@ function addSinglePartComponent(
 
   if (!isEmpty(variants)) {
     Object.keys(variants).forEach((key) => {
+      if (
+        Object.keys(baseStyle).includes('icon') &&
+        Object.keys(variants[key]).includes('iconColor') &&
+        !Object.keys(variants[key]).includes('icon')
+      ) {
+        variants[key].icon = baseStyle.icon;
+      }
+
       addComponentsMaybeWithIcon(
         addComponents,
         `${baseSelector}--${kebabCase(key)}`,
         variants[key],
+        replaceIconFn
+      );
+    });
+  }
+
+  if (!isEmpty(namespaces)) {
+    Object.keys(namespaces).forEach((namespace) => {
+      if (
+        Object.keys(baseStyle).includes('icon') &&
+        Object.keys(namespaces[namespace].baseStyle || {}).includes(
+          'iconColor'
+        ) &&
+        !Object.keys(namespaces[namespace].baseStyle || {}).includes('icon')
+      ) {
+        namespaces[namespace].baseStyle.icon = baseStyle.icon;
+      }
+
+      addSinglePartComponent(
+        addComponents,
+        `${namespace} ${baseSelector}`,
+        namespaces[namespace],
         replaceIconFn
       );
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8442,7 +8442,7 @@ esdoc-ecmascript-proposal-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/esdoc-ecmascript-proposal-plugin/-/esdoc-ecmascript-proposal-plugin-1.0.0.tgz#390dc5656ba8a2830e39dba3570d79138df2ffd9"
   integrity sha1-OQ3FZWuoooMOOdujVw15E43y/9k=
 
-"esdoc@github:pzuraq/esdoc#015a342":
+esdoc@pzuraq/esdoc#015a342:
   version "1.0.4"
   resolved "https://codeload.github.com/pzuraq/esdoc/tar.gz/015a3426b2e53b2b0270a9c00133780db3f1d144"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,10 +1142,10 @@
     resolve "^1.8.1"
     semver "^5.6.0"
 
-"@eslint/eslintrc@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
-  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
+"@eslint/eslintrc@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.1.tgz#f72069c330461a06684d119384435e12a5d76e3c"
+  integrity sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -1270,10 +1270,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@glimmer/interfaces@0.62.3":
-  version "0.62.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.62.3.tgz#8ad314d66d1a43197663509806e1cc2088db6741"
-  integrity sha512-bhbKs5vfys4mo+LRxcA4bfMl2zGn+43et4uAzsYppuNPSkP7rwdPD+mLXTYQRkTm0G5K4SnyxDPxMsWCWUNuTw==
+"@glimmer/interfaces@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.62.4.tgz#e9027d637a0ea80522f29a241aa819e686c623ae"
+  integrity sha512-x3L9YUL17fRgxFrnUvUYTxgnLoh8BipdqkweUEVA5qdIa1dcidUzHUFtWgRiWZ+dKCJBtxh2ubEwjOfgobpMuQ==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
@@ -1295,12 +1295,12 @@
     simple-html-tokenizer "^0.5.9"
 
 "@glimmer/syntax@^0.62.3":
-  version "0.62.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.62.3.tgz#8c4abd245a54e8cc084a47ab4a65c33194256fda"
-  integrity sha512-PU4PpMg9UOeYFTODkHN9K6As74lm16XGEQAQbd59oAbvGRu5OAIWFtSU4sMexpKOXu6iJacFO5udX7gVTACRQQ==
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.62.4.tgz#9d5ec15584fed85d807762992a1879fe7fe15ae8"
+  integrity sha512-c/c+tqv1Ob+IaiVYe3DfHsLQwk/DZ3RA14gVcrE8Bbqrr7RtmjdKPfgNswiQhx7b+1ygcUhvYUfxfI8nCVswIw==
   dependencies:
-    "@glimmer/interfaces" "0.62.3"
-    "@glimmer/util" "0.62.3"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/util" "0.62.4"
     "@handlebars/parser" "^1.1.0"
     simple-html-tokenizer "^0.5.10"
 
@@ -1312,13 +1312,13 @@
     "@glimmer/env" "^0.1.7"
     "@glimmer/validator" "^0.44.0"
 
-"@glimmer/util@0.62.3":
-  version "0.62.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.62.3.tgz#d6fc5d64e5e97cbec02b5fcf8a8c78c7f67dc6f5"
-  integrity sha512-HImkS2UJuZYPxyjXPFL9PS659kwjNcRIr5hnUo1PzrPfyZxXwWys2+vTxIv34tI1xkgkQmB1pB0S8pCdNrJY5w==
+"@glimmer/util@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.62.4.tgz#2e33dd2a8e3e81f5ffc8325fdc9bebb0e274c421"
+  integrity sha512-7x04I4mQpxveAoEbpFfXFFkYpuJoATHuGdwPjgcQc0nSjAkGDkzIMlRN3stgZAz32eSVj9n7SOXHVtHEhw3cCg==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.62.3"
+    "@glimmer/interfaces" "0.62.4"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/util@^0.44.0":
@@ -2093,9 +2093,9 @@
     "@octokit/types" "^2.0.1"
 
 "@octokit/plugin-request-log@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz#eef87a431300f6148c39a7f75f8cfeb218b2547e"
-  integrity sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz#394d59ec734cd2f122431fbaf05099861ece3c44"
+  integrity sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==
 
 "@octokit/plugin-rest-endpoint-methods@2.4.0":
   version "2.4.0"
@@ -2547,9 +2547,9 @@
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/node@*", "@types/node@>= 8":
-  version "14.14.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.0.tgz#f1091b6ad5de18e8e91bdbd43ec63f13de372538"
-  integrity sha512-BfbIHP9IapdupGhq/hc+jT5dyiBVZ2DdeC5WwJWQWDb0GijQlzUFAeIQn/2GtvZcd2HVUU7An8felIICFTC2qg==
+  version "14.14.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.5.tgz#e92d3b8f76583efa26c1a63a21c9d3c1143daa29"
+  integrity sha512-H5Wn24s/ZOukBmDn03nnGTp18A60ny9AmCwnEcgJiTgSGsCO7k+NWP7zjCCbhlcnVCoI+co52dUAt9GMhOSULw==
 
 "@types/node@^9.6.0":
   version "9.6.60"
@@ -4338,13 +4338,13 @@ broccoli-asset-rewrite@^2.0.0:
   dependencies:
     broccoli-filter "^1.2.3"
 
-broccoli-autoprefixer@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-autoprefixer/-/broccoli-autoprefixer-7.2.0.tgz#a6a84345475fa13c05f937067e4f69d970222d34"
-  integrity sha512-KR6Cr6h/tLy/c3fRHDawvglZrytmR9sSIxlzTlHxxwoCP1mAP4m20bdApTOrd3TIUDo1hbszt9mAfzYcq+OpcQ==
+broccoli-autoprefixer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-autoprefixer/-/broccoli-autoprefixer-8.0.0.tgz#9c21422e2597433146a43df4b02b6699b0885489"
+  integrity sha512-9HRCaMLihugxO/f55ESmgpjGiKRN5dWlI7ub5dAOl2zLgVCcV5F4BxNrkLn8nhuQABd1WuYFGmv2GwdQsiuXSg==
   dependencies:
     autoprefixer "^9.8.4"
-    broccoli-persistent-filter "^1.1.6"
+    broccoli-persistent-filter "^3.0.0"
     postcss "^7.0.2"
 
 broccoli-babel-transpiler@^6.5.0:
@@ -4753,10 +4753,10 @@ broccoli-persistent-filter@^2.1.0, broccoli-persistent-filter@^2.1.1, broccoli-p
     sync-disk-cache "^1.3.3"
     walk-sync "^1.0.0"
 
-broccoli-persistent-filter@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.1.tgz#318c68a82d5759582bb60e7e2c0f3ca008176224"
-  integrity sha512-gP797MF87JjkcwhGBkE0fhF3aIbGnOF3K3A0iZpQSxtpmSNt+rbNzuqDOmgiKwWpx6v0+APkM5HUA0NiIZpgsQ==
+broccoli-persistent-filter@^3.0.0, broccoli-persistent-filter@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz#41da6b9577be09a170ecde185f2c5a6099f99c4e"
+  integrity sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==
   dependencies:
     async-disk-cache "^2.0.0"
     async-promise-queue "^1.0.3"
@@ -5368,9 +5368,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001148"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz#dc97c7ed918ab33bf8706ddd5e387287e015d637"
-  integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
+  version "1.0.30001151"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz#1ddfde5e6fff02aad7940b4edb7d3ac76b0cb00b"
+  integrity sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5804,9 +5804,9 @@ commander@^5.0.0:
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 commander@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
-  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
+  integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
 common-tags@^1.4.0, common-tags@^1.8.0:
   version "1.8.0"
@@ -6825,9 +6825,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.571:
-  version "1.3.582"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.582.tgz#1adfac5affce84d85b3d7b3dfbc4ade293a6ffc4"
-  integrity sha512-0nCJ7cSqnkMC+kUuPs0YgklFHraWGl/xHqtZWWtOeVtyi+YqkoAOMGuZQad43DscXCQI/yizcTa3u6B5r+BLww==
+  version "1.3.584"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.584.tgz#506cf7ba5895aafa8241876ab028654b61fd9ceb"
+  integrity sha512-NB3DzrTzJFhWkUp+nl2KtUtoFzrfGXTir2S+BU4tXGyXH9vlluPuFpE3pTKeH7+PY460tHLjKzh6K2+TWwW+Ww==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -6915,9 +6915,9 @@ ember-auto-import@^1.2.19, ember-auto-import@^1.5.2, ember-auto-import@^1.5.3, e
     webpack "~4.28"
 
 ember-basic-dropdown@^3.0.10:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.10.tgz#47ed9fe9ff9e69d1a021771a91823c730985ffe0"
-  integrity sha512-TabEKUIlLPQLZqyXx1N8M/tDhrf/2meXjK2mNw6RfiOvwMHYJ41MwIhJusnlQd/Rn7cL0MbA+EGCnjdI0HhB/w==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.11.tgz#d74e931381595678bede7adea91631db3a269aaa"
+  integrity sha512-J6PFb+BGD7Md43ZJo8N2c/y0sgcoG3O1/m488XxVbb20UpIRlGXjw9Zwm8cd2f7xhSefNXsbVWyQHEkl4iXzDg==
   dependencies:
     "@ember/render-modifiers" "^1.0.2"
     "@glimmer/component" "^1.0.1"
@@ -6927,7 +6927,7 @@ ember-basic-dropdown@^3.0.10:
     ember-cli-typescript "^3.1.2"
     ember-element-helper "^0.2.0"
     ember-maybe-in-element "^2.0.1"
-    ember-truth-helpers "2.1.0"
+    ember-truth-helpers "^2.1.0 || ^3.0.0"
 
 ember-changeset-validations@^3.9.1:
   version "3.9.1"
@@ -7046,12 +7046,12 @@ ember-cli-app-version@^4.0.0:
     git-repo-info "^2.1.1"
 
 ember-cli-autoprefixer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-autoprefixer/-/ember-cli-autoprefixer-1.0.2.tgz#89cfd73a397752690077366ed6b53def215d9570"
-  integrity sha512-353yLfZbFDzMWglUA2G8aSU8NnBqNuovSCNLK0LjakeaOmkylecpl35iMVBUk75Wmxf+OcitSiFT6eKdbzl3rQ==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-autoprefixer/-/ember-cli-autoprefixer-1.0.3.tgz#d4603c2e649c0b3a094c52b87664e172b550924e"
+  integrity sha512-bh0BrUKQ4G4aj85mG7k3SkhQB5QpB1NipmYPhXQvMjOw5RihqF3k5aB98RFx/0AWAVnY8pF17iIrsHMvvwD1WQ==
   dependencies:
-    broccoli-autoprefixer "^7.0.0"
-    ember-cli-htmlbars "^4.2.2"
+    broccoli-autoprefixer "^8.0.0"
+    ember-cli-htmlbars "^5.0.0"
 
 ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, ember-cli-babel-plugin-helpers@^1.1.1:
   version "1.1.1"
@@ -7247,7 +7247,7 @@ ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
     json-stable-stringify "^1.0.1"
     strip-bom "^3.0.0"
 
-ember-cli-htmlbars@^4.0.5, ember-cli-htmlbars@^4.2.2, ember-cli-htmlbars@^4.2.3, ember-cli-htmlbars@^4.3.1:
+ember-cli-htmlbars@^4.0.5, ember-cli-htmlbars@^4.2.3, ember-cli-htmlbars@^4.3.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.4.0.tgz#7ca17d5ca8f7550984346d9e6e93da0c3323f8d9"
   integrity sha512-ohgctqk7dXIZR4TgN0xRoUYltWhghFJgqmtuswQTpZ7p74RxI9PKx+E8WV/95mGcPzraesvMNBg5utQNvcqgNg==
@@ -7267,7 +7267,7 @@ ember-cli-htmlbars@^4.0.5, ember-cli-htmlbars@^4.2.2, ember-cli-htmlbars@^4.2.3,
     strip-bom "^4.0.0"
     walk-sync "^2.0.2"
 
-ember-cli-htmlbars@^5.2.0:
+ember-cli-htmlbars@^5.0.0, ember-cli-htmlbars@^5.2.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.3.1.tgz#61793964fc2599ce750db9e972ab55c6dd177c48"
   integrity sha512-ZjQTt44euDoqLvUkWbt1svgNCXgLzOztEbc2qqYMQvhQig416LMrWK7l3SSbNU+BtLD5UIxmwvLfF1tsO2CVyA==
@@ -8129,12 +8129,19 @@ ember-text-measurer@^0.6.0:
     ember-cli-babel "^7.19.0"
     ember-cli-htmlbars "^4.3.1"
 
-ember-truth-helpers@2.1.0, ember-truth-helpers@^2.1.0:
+ember-truth-helpers@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz#d4dab4eee7945aa2388126485977baeb33ca0798"
   integrity sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==
   dependencies:
     ember-cli-babel "^6.6.0"
+
+"ember-truth-helpers@^2.1.0 || ^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-3.0.0.tgz#86766bdca4ac9b86bce3d262dff2aabc4a0ea384"
+  integrity sha512-hPKG9QqruAELh0li5xaiLZtr88ioWYxWCXisAWHWE0qCP4a2hgtuMzKUPpiTCkltvKjuqpzTZCU4VhQ+IlRmew==
+  dependencies:
+    ember-cli-babel "^7.22.1"
 
 ember-try-config@^3.0.0:
   version "3.0.0"
@@ -8442,7 +8449,7 @@ esdoc-ecmascript-proposal-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/esdoc-ecmascript-proposal-plugin/-/esdoc-ecmascript-proposal-plugin-1.0.0.tgz#390dc5656ba8a2830e39dba3570d79138df2ffd9"
   integrity sha1-OQ3FZWuoooMOOdujVw15E43y/9k=
 
-esdoc@pzuraq/esdoc#015a342:
+"esdoc@github:pzuraq/esdoc#015a342":
   version "1.0.4"
   resolved "https://codeload.github.com/pzuraq/esdoc/tar.gz/015a3426b2e53b2b0270a9c00133780db3f1d144"
   dependencies:
@@ -8459,9 +8466,9 @@ esdoc@pzuraq/esdoc#015a342:
     taffydb "2.7.2"
 
 eslint-config-prettier@^6.11.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.13.0.tgz#207d88796b5624e5bb815bbbdfc5891ceb9ebffa"
-  integrity sha512-LcT0i0LSmnzqK2t764pyIt7kKH2AuuqKRTtJTdddWxOiUja9HdG5GXBVF2gmCTvVYWVsTu8J2MhJLVGRh+pj8w==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
+  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -8543,12 +8550,12 @@ eslint-visitor-keys@^2.0.0:
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.11.0:
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.11.0.tgz#aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b"
-  integrity sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.12.1.tgz#bd9a81fa67a6cfd51656cdb88812ce49ccec5801"
+  integrity sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.1.3"
+    "@eslint/eslintrc" "^0.2.1"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -9670,9 +9677,9 @@ git-up@^4.0.0:
     parse-url "^5.0.0"
 
 git-url-parse@^11.1.2:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.3.0.tgz#1515b4574c4eb2efda7d25cc50b29ce8beaefaae"
-  integrity sha512-i3XNa8IKmqnUqWBcdWBjOcnyZYfN3C1WRvnKI6ouFWwsXCZEnlgbwbm55ZpJ3OJMhfEP/ryFhqW8bBhej3C5Ug==
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.4.0.tgz#f2bb1f2b00f05552540e95a62e31399a639a6aa6"
+  integrity sha512-KlIa5jvMYLjXMQXkqpFzobsyD/V2K5DRHl5OAf+6oDFPlPLxrGDVQlIdI63c4/Kt6kai4kALENSALlzTGST3GQ==
   dependencies:
     git-up "^4.0.0"
 
@@ -14472,9 +14479,9 @@ run-async@^2.2.0, run-async@^2.4.0:
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 run-parallel@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
-  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
+  integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -14930,9 +14937,9 @@ sort-object-keys@^1.1.3:
   integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
 
 sort-package-json@^1.46.0:
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.46.0.tgz#ea30a03d17c23762bfbf115fa54500459508c9ca"
-  integrity sha512-Fn5iiGKkATkEOQ0rol45dClfvNNW3r6PZ87mU4rbpz/M0Dxz+0D6oEU8nfpwUB5rd8u+WzsH2BQ/kRDwz+yVDQ==
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.46.1.tgz#b7812bb53ec34ca69ac0ad920e31193fd983015c"
+  integrity sha512-jUkuCxcXCZD31eIJ/Zza62LRP0lzd4LNkY0z0q1kDSvfBfCmPotrHPXVrz6WTppbGeM2JzNyyARQLUEnK4dUyg==
   dependencies:
     detect-indent "^6.0.0"
     detect-newline "3.1.0"
@@ -15481,9 +15488,9 @@ tailwindcss-ember-power-select@^0.3.0:
     traverse "^0.6.6"
 
 tailwindcss@^1.2.0, tailwindcss@^1.9.5:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.5.tgz#3339b790a68bc1f09a8efd8eb94cb05aed5235c2"
-  integrity sha512-Je5t1fAfyW333YTpSxF+8uJwbnrkpyBskDtZYgSMMKQbNp6QUhEKJ4g/JIevZjD2Zidz9VxLraEUq/yWOx6nQg==
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.6.tgz#0c5089911d24e1e98e592a31bfdb3d8f34ecf1a0"
+  integrity sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==
   dependencies:
     "@fullhuman/postcss-purgecss" "^2.1.2"
     autoprefixer "^9.4.5"
@@ -15697,9 +15704,9 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timers-browserify@^2.0.4:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
-  integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee"
+  integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
 
@@ -16033,9 +16040,9 @@ typescript-memoize@^1.0.0-alpha.3:
     core-js "2.4.1"
 
 typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -16043,9 +16050,9 @@ uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.3.tgz#b2f8c87826344f091ba48c417c499d6cba5d5786"
-  integrity sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA==
+  version "3.11.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.4.tgz#b47b7ae99d4bd1dca65b53aaa69caa0909e6fadf"
+  integrity sha512-FyYnoxVL1D6+jDGQpbK5jW6y/2JlVfRfEeQ67BPCUg5wfCjaKOpr2XeceE4QL+MkhxliLtf5EbrMDZgzpt2CNw==
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -16770,9 +16777,9 @@ y18n@^4.0.0:
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
 y18n@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.4.tgz#0ab2db89dd5873b5ec4682d8e703e833373ea897"
-  integrity sha512-deLOfD+RvFgrpAmSZgfGdWYE+OKyHcVHaRQ7NphG/63scpRvTHHeQMAxGGvaLVGJ+HYVcCXlzcTK0ZehFf+eHQ==
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
This is implementing the same concepts introduced in #109 & #110, but for the forms pkg.

- This also drops the `@isSmall` & `@isLarge` args in favor of `@size` with possible values of `sm` and `lg`.

- This also drops all usages of css specificity...