### PR TITLE
Notifications: Binding for template usage

### DIFF
--- a/packages/notifications/addon/services/notifications.ts
+++ b/packages/notifications/addon/services/notifications.ts
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import Notification from '../-private/notification';
 import NotificationsManager from '../-private/manager';
 import { NotificationOptions } from '../-private/types';
+import { action } from '@ember/object';
 
 export default class NotificationsService extends Service {
   manager = new NotificationsManager();
@@ -10,14 +11,17 @@ export default class NotificationsService extends Service {
     return this.manager.notifications;
   }
 
+  @action
   add(message: string, options?: NotificationOptions): Notification {
     return this.manager.add(message, options);
   }
 
+  @action
   remove(notification?: Notification): void {
     this.manager.remove(notification);
   }
 
+  @action
   removeAll(): void {
     this.manager.removeAll();
   }


### PR DESCRIPTION
Hello @josemarluedke awesome addon, I was eager to try it out and I'm loving it, its great!

This PR justs adds binding to the notifications service.

I have a preference to use lots queue's and pipe's inside the templates, so for me a normal use case would be to trigger a notification like this

```hbs
<Button {{on "click" (pipe this.oneFn this.secondFn (fn this.notifications.add "all good!")) }}>
  Pipe actions
</Button>
```

Let me know what you think , thanks.