### PR TITLE
ChangesetForm: Only allow changeset as argument, removing auto mode

### DIFF
--- a/packages/changeset-form/addon/components/changeset-form/context/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/context/index.hbs
@@ -1,15 +1,15 @@
 {{yield
   (hash
-    Input=(component 'changeset-form/fields/input' changeset=@changeset)
-    Textarea=(component 'changeset-form/fields/textarea' changeset=@changeset)
-    Select=(component 'changeset-form/fields/select' changeset=@changeset)
-    Checkbox=(component 'changeset-form/fields/checkbox' changeset=@changeset)
+    Input=(component "changeset-form/fields/input" changeset=@changeset)
+    Textarea=(component "changeset-form/fields/textarea" changeset=@changeset)
+    Select=(component "changeset-form/fields/select" changeset=@changeset)
+    Checkbox=(component "changeset-form/fields/checkbox" changeset=@changeset)
     CheckboxGroup=(component
-      'changeset-form/fields/checkbox-group' changeset=@changeset
+      "changeset-form/fields/checkbox-group" changeset=@changeset
     )
-    Radio=(component 'changeset-form/fields/radio' changeset=@changeset)
+    Radio=(component "changeset-form/fields/radio" changeset=@changeset)
     RadioGroup=(component
-      'changeset-form/fields/radio-group' changeset=@changeset
+      "changeset-form/fields/radio-group" changeset=@changeset
     )
   )
 }}

--- a/packages/changeset-form/addon/components/changeset-form/context/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/context/index.hbs
@@ -1,0 +1,15 @@
+{{yield
+  (hash
+    Input=(component 'changeset-form/fields/input' changeset=@changeset)
+    Textarea=(component 'changeset-form/fields/textarea' changeset=@changeset)
+    Select=(component 'changeset-form/fields/select' changeset=@changeset)
+    Checkbox=(component 'changeset-form/fields/checkbox' changeset=@changeset)
+    CheckboxGroup=(component
+      'changeset-form/fields/checkbox-group' changeset=@changeset
+    )
+    Radio=(component 'changeset-form/fields/radio' changeset=@changeset)
+    RadioGroup=(component
+      'changeset-form/fields/radio-group' changeset=@changeset
+    )
+  )
+}}

--- a/packages/changeset-form/addon/components/changeset-form/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/index.hbs
@@ -1,6 +1,9 @@
 <form
   {{on "submit" this.handleSubmit}}
   {{on "reset" this.handleReset}}
+  {{did-insert this.setup}}
+  {{did-update this.setup @changeset}}
+  {{did-update this.setup @model}}
   ...attributes
 >
   {{yield

--- a/packages/changeset-form/addon/components/changeset-form/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/index.hbs
@@ -1,7 +1,7 @@
 <form
   ...attributes
-  {{on 'submit' (fn this.handleSubmit @changeset)}}
-  {{on 'reset' (fn this.handleReset @changeset)}}
+  {{on "submit" (fn this.handleSubmit @changeset)}}
+  {{on "reset" (fn this.handleReset @changeset)}}
 >
   <ChangesetForm::Context @changeset={{@changeset}} as |Form|>
     {{yield

--- a/packages/changeset-form/addon/components/changeset-form/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/index.hbs
@@ -1,41 +1,22 @@
 <form
-  {{on "submit" this.handleSubmit}}
-  {{on "reset" this.handleReset}}
   ...attributes
+  {{on 'submit' this.handleSubmit}}
+  {{on 'reset' this.handleReset}}
 >
-  {{yield
-    (hash
-      Input=(component "changeset-form/fields/input"
-        changeset=@changeset
-        hasSubmitted=this.hasSubmitted
+  <ChangesetForm::Context @changeset={{@changeset}} as |Form|>
+    {{yield
+      (hash
+        Input=(component Form.input hasSubmitted=this.hasSubmitted)
+        Textarea=(component Form.Textarea hasSubmitted=this.hasSubmitted)
+        Select=(component Form.Select hasSubmitted=this.hasSubmitted)
+        Checkbox=(component Form.Checkbox hasSubmitted=this.hasSubmitted)
+        CheckboxGroup=(component
+          Form.CheckboxGroup hasSubmitted=this.hasSubmitted
+        )
+        Radio=(component Form.Radio hasSubmitted=this.hasSubmitted)
+        RadioGroup=(component Form.RadioGroup hasSubmitted=this.hasSubmitted)
       )
-      Textarea=(component "changeset-form/fields/textarea"
-        changeset=@changeset
-        hasSubmitted=this.hasSubmitted
-      )
-      Select=(component "changeset-form/fields/select"
-        changeset=@changeset
-        hasSubmitted=this.hasSubmitted
-      )
-      Checkbox=(component "changeset-form/fields/checkbox"
-        changeset=@changeset
-        hasSubmitted=this.hasSubmitted
-      )
-      CheckboxGroup=(component "changeset-form/fields/checkbox-group"
-        changeset=@changeset
-        hasSubmitted=this.hasSubmitted
-      )
-      Radio=(component "changeset-form/fields/radio"
-        changeset=@changeset
-        hasSubmitted=this.hasSubmitted
-      )
-      RadioGroup=(component "changeset-form/fields/radio-group"
-        changeset=@changeset
-        hasSubmitted=this.hasSubmitted
-      )
-    )
-    (hash
-      hasSubmitted=this.hasSubmitted
-    )
-  }}
+      (hash hasSubmitted=this.hasSubmitted)
+    }}
+  </ChangesetForm::Context>
 </form>

--- a/packages/changeset-form/addon/components/changeset-form/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/index.hbs
@@ -1,7 +1,7 @@
 <form
   ...attributes
-  {{on 'submit' this.handleSubmit}}
-  {{on 'reset' this.handleReset}}
+  {{on 'submit' (fn this.handleSubmit @changeset)}}
+  {{on 'reset' (fn this.handleReset @changeset)}}
 >
   <ChangesetForm::Context @changeset={{@changeset}} as |Form|>
     {{yield

--- a/packages/changeset-form/addon/components/changeset-form/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/index.hbs
@@ -1,43 +1,39 @@
 <form
   {{on "submit" this.handleSubmit}}
   {{on "reset" this.handleReset}}
-  {{did-insert this.setup}}
-  {{did-update this.setup @changeset}}
-  {{did-update this.setup @model}}
   ...attributes
 >
   {{yield
     (hash
       Input=(component "changeset-form/fields/input"
-        changeset=this.changeset
+        changeset=@changeset
         hasSubmitted=this.hasSubmitted
       )
       Textarea=(component "changeset-form/fields/textarea"
-        changeset=this.changeset
+        changeset=@changeset
         hasSubmitted=this.hasSubmitted
       )
       Select=(component "changeset-form/fields/select"
-        changeset=this.changeset
+        changeset=@changeset
         hasSubmitted=this.hasSubmitted
       )
       Checkbox=(component "changeset-form/fields/checkbox"
-        changeset=this.changeset
+        changeset=@changeset
         hasSubmitted=this.hasSubmitted
       )
       CheckboxGroup=(component "changeset-form/fields/checkbox-group"
-        changeset=this.changeset
+        changeset=@changeset
         hasSubmitted=this.hasSubmitted
       )
       Radio=(component "changeset-form/fields/radio"
-        changeset=this.changeset
+        changeset=@changeset
         hasSubmitted=this.hasSubmitted
       )
       RadioGroup=(component "changeset-form/fields/radio-group"
-        changeset=this.changeset
+        changeset=@changeset
         hasSubmitted=this.hasSubmitted
       )
     )
-    this.changeset
     (hash
       hasSubmitted=this.hasSubmitted
     )

--- a/packages/changeset-form/addon/components/changeset-form/index.hbs
+++ b/packages/changeset-form/addon/components/changeset-form/index.hbs
@@ -6,7 +6,7 @@
   <ChangesetForm::Context @changeset={{@changeset}} as |Form|>
     {{yield
       (hash
-        Input=(component Form.input hasSubmitted=this.hasSubmitted)
+        Input=(component Form.Input hasSubmitted=this.hasSubmitted)
         Textarea=(component Form.Textarea hasSubmitted=this.hasSubmitted)
         Select=(component Form.Select hasSubmitted=this.hasSubmitted)
         Checkbox=(component Form.Checkbox hasSubmitted=this.hasSubmitted)
@@ -16,6 +16,7 @@
         Radio=(component Form.Radio hasSubmitted=this.hasSubmitted)
         RadioGroup=(component Form.RadioGroup hasSubmitted=this.hasSubmitted)
       )
+      @changeset
       (hash hasSubmitted=this.hasSubmitted)
     }}
   </ChangesetForm::Context>

--- a/packages/changeset-form/addon/components/changeset-form/index.ts
+++ b/packages/changeset-form/addon/components/changeset-form/index.ts
@@ -18,13 +18,12 @@ interface ChangesetFormArgs {
 }
 
 export default class ChangesetForm extends Component<ChangesetFormArgs> {
-  changeset!: BufferedChangeset;
+  @tracked changeset!: BufferedChangeset;
 
   @tracked hasSubmitted = false;
 
-  constructor(owner: unknown, args: ChangesetFormArgs) {
-    super(owner, args);
-
+  @action
+  setup() {
     if (typeof this.args.changeset === 'undefined') {
       assert(
         '@model must be defined on <ChangesetForm> component if you do not provide a @changeset argument',

--- a/packages/changeset-form/addon/components/changeset-form/index.ts
+++ b/packages/changeset-form/addon/components/changeset-form/index.ts
@@ -22,21 +22,21 @@ export default class ChangesetForm extends Component<ChangesetFormArgs> {
   }
 
   @action
-  async handleSubmit(event: Event): Promise<void> {
+  async handleSubmit(changeset: BufferedChangeset, event: Event): Promise<void> {
     event.preventDefault();
-    await this.args.changeset.validate();
+    await changeset.validate();
 
     this.hasSubmitted = true;
 
-    if (this.args.changeset.isInvalid) {
+    if (changeset.isInvalid) {
       return;
     }
 
     let result;
     if (this.args.runExecuteInsteadOfSave) {
-      result = this.args.changeset.execute();
+      result = changeset.execute();
     } else {
-      result = await this.args.changeset.save({});
+      result = await changeset.save({});
     }
 
     if (typeof this.args.onSubmit === 'function') {
@@ -45,11 +45,11 @@ export default class ChangesetForm extends Component<ChangesetFormArgs> {
   }
 
   @action
-  handleReset(event: Event): void {
+  handleReset(changeset: BufferedChangeset, event: Event): void {
     event.preventDefault();
     this.hasSubmitted = false;
 
-    const { data } = this.args.changeset.rollback();
+    const { data } = changeset.rollback();
     if (typeof this.args.onReset === 'function') {
       this.args.onReset(data, event);
     }

--- a/packages/changeset-form/addon/components/changeset-form/index.ts
+++ b/packages/changeset-form/addon/components/changeset-form/index.ts
@@ -22,7 +22,10 @@ export default class ChangesetForm extends Component<ChangesetFormArgs> {
   }
 
   @action
-  async handleSubmit(changeset: BufferedChangeset, event: Event): Promise<void> {
+  async handleSubmit(
+    changeset: BufferedChangeset,
+    event: Event
+  ): Promise<void> {
     event.preventDefault();
     await changeset.validate();
 

--- a/packages/changeset-form/addon/components/changeset-form/index.ts
+++ b/packages/changeset-form/addon/components/changeset-form/index.ts
@@ -2,9 +2,10 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { BufferedChangeset } from 'ember-changeset/types';
 import { action } from '@ember/object';
+import { assert } from '@ember/debug';
 
 interface ChangesetFormArgs {
-  changeset?: BufferedChangeset;
+  changeset: BufferedChangeset;
 
   runExecuteInsteadOfSave?: boolean;
 
@@ -14,6 +15,11 @@ interface ChangesetFormArgs {
 
 export default class ChangesetForm extends Component<ChangesetFormArgs> {
   @tracked hasSubmitted = false;
+
+  constructor(owner: unknown, args: ChangesetFormArgs) {
+    super(owner, args);
+    assert('Must passs down a changeset', this.args.changeset);
+  }
 
   @action
   async handleSubmit(event: Event): Promise<void> {

--- a/packages/changeset-form/addon/components/changeset-form/index.ts
+++ b/packages/changeset-form/addon/components/changeset-form/index.ts
@@ -1,15 +1,10 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { Changeset } from 'ember-changeset';
-import { BufferedChangeset, ValidatorMap } from 'ember-changeset/types';
+import { BufferedChangeset } from 'ember-changeset/types';
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
-import lookupValidator from 'ember-changeset-validations';
 
 interface ChangesetFormArgs {
-  model?: { [key: string]: unknown };
   changeset?: BufferedChangeset;
-  validations?: ValidatorMap;
 
   runExecuteInsteadOfSave?: boolean;
 
@@ -18,48 +13,24 @@ interface ChangesetFormArgs {
 }
 
 export default class ChangesetForm extends Component<ChangesetFormArgs> {
-  @tracked changeset!: BufferedChangeset;
-
   @tracked hasSubmitted = false;
-
-  @action
-  setup() {
-    if (typeof this.args.changeset === 'undefined') {
-      assert(
-        '@model must be defined on <ChangesetForm> component if you do not provide a @changeset argument',
-        typeof this.args.model !== 'undefined'
-      );
-
-      if (typeof this.args.validations !== 'undefined') {
-        this.changeset = Changeset(
-          this.args.model || {},
-          lookupValidator(this.args.validations || {}),
-          this.args.validations
-        );
-      } else {
-        this.changeset = Changeset(this.args.model || {});
-      }
-    } else {
-      this.changeset = this.args.changeset;
-    }
-  }
 
   @action
   async handleSubmit(event: Event): Promise<void> {
     event.preventDefault();
-    await this.changeset.validate();
+    await this.args.changeset.validate();
 
     this.hasSubmitted = true;
 
-    if (this.changeset.isInvalid) {
+    if (this.args.changeset.isInvalid) {
       return;
     }
 
     let result;
     if (this.args.runExecuteInsteadOfSave) {
-      result = this.changeset.execute();
+      result = this.args.changeset.execute();
     } else {
-      result = await this.changeset.save({});
+      result = await this.args.changeset.save({});
     }
 
     if (typeof this.args.onSubmit === 'function') {
@@ -72,7 +43,7 @@ export default class ChangesetForm extends Component<ChangesetFormArgs> {
     event.preventDefault();
     this.hasSubmitted = false;
 
-    const { data } = this.changeset.rollback();
+    const { data } = this.args.changeset.rollback();
     if (typeof this.args.onReset === 'function') {
       this.args.onReset(data, event);
     }

--- a/packages/changeset-form/addon/components/changeset-form/index.ts
+++ b/packages/changeset-form/addon/components/changeset-form/index.ts
@@ -18,7 +18,7 @@ export default class ChangesetForm extends Component<ChangesetFormArgs> {
 
   constructor(owner: unknown, args: ChangesetFormArgs) {
     super(owner, args);
-    assert('Must passs down a changeset', this.args.changeset);
+    assert('@changeset must be defined on <ChangesetForm> component', this.args.changeset);
   }
 
   @action

--- a/packages/changeset-form/addon/components/changeset-form/index.ts
+++ b/packages/changeset-form/addon/components/changeset-form/index.ts
@@ -18,7 +18,10 @@ export default class ChangesetForm extends Component<ChangesetFormArgs> {
 
   constructor(owner: unknown, args: ChangesetFormArgs) {
     super(owner, args);
-    assert('@changeset must be defined on <ChangesetForm> component', this.args.changeset);
+    assert(
+      '@changeset must be defined on <ChangesetForm> component',
+      this.args.changeset
+    );
   }
 
   @action

--- a/packages/changeset-form/app/components/changeset-form/context/index.js
+++ b/packages/changeset-form/app/components/changeset-form/context/index.js
@@ -1,0 +1,1 @@
+export { default } from '@frontile/changeset-form/components/changeset-form/context';

--- a/packages/changeset-form/tests/dummy/app/components/changeset-form-example.hbs
+++ b/packages/changeset-form/tests/dummy/app/components/changeset-form-example.hbs
@@ -1,5 +1,5 @@
 <ChangesetForm
-  @changeset={{changeset this.model this.validations}} as |Form changeset state|
+  @changeset={{changeset this.model this.validations}} as |Form changeset|
 >
   <Form.Input
     @label="First Name"
@@ -56,8 +56,8 @@
     class="p-2 my-4 rounded
       {{if
         changeset.isInvalid
-        'bg-gray-100 text-gray-500'
-        'bg-gray-900 text-white'
+        "bg-gray-100 text-gray-500"
+        "bg-gray-900 text-white"
       }}"
     disabled={{changeset.isInvalid}}
   >

--- a/packages/changeset-form/tests/dummy/app/components/changeset-form-example.hbs
+++ b/packages/changeset-form/tests/dummy/app/components/changeset-form-example.hbs
@@ -1,7 +1,5 @@
 <ChangesetForm
-  @model={{this.model}}
-  @validations={{this.validations}}
-  as |Form changeset|
+  @changeset={{changeset this.model this.validations}} as |Form changeset state|
 >
   <Form.Input
     @label="First Name"
@@ -20,76 +18,63 @@
     type="email"
     @containerClass="mt-4"
   />
-
   <Form.Textarea
     @label="Comments"
     @fieldName="comments"
     @containerClass="mt-4"
   />
-
   <Form.Select
     @label="Countries"
     @fieldName="countries"
     @isMultiple={{true}}
     @options={{this.countries}}
     @allowClear={{true}}
-    @containerClass="mt-4"
-    as |option|
+    @containerClass="mt-4" as |option|
   >
     {{option}}
   </Form.Select>
-
   <Form.CheckboxGroup
     @label="Core Values"
     @isInline={{true}}
-    @containerClass="mt-4"
-    as |Checkbox|
+    @containerClass="mt-4" as |Checkbox|
   >
-    <Checkbox
-      @label="Hungry"
-      @fieldName="hungry"
-    />
-    <Checkbox
-      @label="Humble"
-      @fieldName="humble"
-    />
-    <Checkbox
-      @label="Curious"
-      @fieldName="curious"
-    />
+    <Checkbox @label="Hungry" @fieldName="hungry" />
+    <Checkbox @label="Humble" @fieldName="humble" />
+    <Checkbox @label="Curious" @fieldName="curious" />
   </Form.CheckboxGroup>
-
   <Form.RadioGroup
     @label="Favorite Meal"
     @containerClass="mt-4"
-    @fieldName="favoriteMeal"
-    as |Radio|
+    @fieldName="favoriteMeal" as |Radio|
   >
-    <Radio
-      @label="Breakfast"
-      @value="breakfast"
-    />
-    <Radio
-      @label="Lunch"
-      @value="lunch"
-    />
-    <Radio
-      @label="Dinner"
-      @value="dinner"
-    />
+    <Radio @label="Breakfast" @value="breakfast" />
+    <Radio @label="Lunch" @value="lunch" />
+    <Radio @label="Dinner" @value="dinner" />
   </Form.RadioGroup>
-
   <button
     type="submit"
-    class="p-2 my-4 rounded {{if changeset.isInvalid "bg-gray-100 text-gray-500" "bg-gray-900 text-white"}}"
+    class="p-2 my-4 rounded
+      {{if
+        changeset.isInvalid
+        'bg-gray-100 text-gray-500'
+        'bg-gray-900 text-white'
+      }}"
     disabled={{changeset.isInvalid}}
   >
     Submit
   </button>
-
   <div class="mb-4">
-    <p>isPristine: {{changeset.isPristine}}</p>
-    <p>isValid: {{changeset.isValid}}</p>
-    <p>isInvalid: {{changeset.isInvalid}}</p>
+    <p>
+      isPristine:
+      {{changeset.isPristine}}
+    </p>
+    <p>
+      isValid:
+      {{changeset.isValid}}
+    </p>
+    <p>
+      isInvalid:
+      {{changeset.isInvalid}}
+    </p>
   </div>
 </ChangesetForm>

--- a/packages/changeset-form/tests/integration/components/changeset-form-test.ts
+++ b/packages/changeset-form/tests/integration/components/changeset-form-test.ts
@@ -173,7 +173,6 @@ module('Integration | Component | ChangesetForm', function (hooks) {
     // assert.dom('[data-test-name-last]').hasTextContaining('Silva');
   });
 
-
   test('it shows error message when the changeset is invalid', async function (assert) {
     assert.expect(1);
     await fillIn('[data-test-email-input]', '');

--- a/packages/changeset-form/tests/integration/components/changeset-form-test.ts
+++ b/packages/changeset-form/tests/integration/components/changeset-form-test.ts
@@ -42,38 +42,44 @@ module('Integration | Component | ChangesetForm', function (hooks) {
     this.set('validations', validations);
 
     await render(hbs`
-      <ChangesetForm
-        @model={{this.model}}
-        @validations={{this.validations}}
-        @onSubmit={{this.onSubmit}}
-        @onReset={{this.onReset}}
-        data-test-changeset-form
-        as |Form changeset state|
-      >
-        <div data-test-id="has-submitted">{{state.hasSubmitted}}</div>
-        <Form.Input
-          @fieldName="name.first"
-          @label="First Name"
-          data-test-name-first-input
-        />
-        <div data-test-name-first>{{changeset.name.first}}</div>
-        <Form.Input
-          @fieldName="name.last"
-          @label="Last Name"
-          data-test-name-last-input
-        />
-        <div data-test-name-last>{{changeset.name.last}}</div>
-        <Form.Input
-          @containerClass="email-field"
-          @fieldName="email"
-          @label="Email Address"
-          data-test-email-input
-        />
-        <div data-test-email>{{changeset.email}}</div>
+      {{#let (changeset this.model this.validations) as |changesetObj|}}
+        <ChangesetForm
+          @changeset={{changesetObj}}
+          @onSubmit={{this.onSubmit}}
+          @onReset={{this.onReset}}
+          data-test-changeset-form
+          as |Form changeset state|
+        >
+        {{log changesetObj changeset}}
+          <div data-test-id="has-submitted">{{state.hasSubmitted}}</div>
+          {{#if changeset.isInvalid}}
+            <p data-test-id="form-error">There were one or more errors in your form.</p>
+          {{/if}}
+          <Form.Input
+            @fieldName="name.first"
+            @label="First Name"
+            data-test-name-first-input
+          />
+          <div data-test-name-first>{{changeset.name.first}}</div>
+          
+          <Form.Input
+            @fieldName="name.last"
+            @label="Last Name"
+            data-test-name-last-input
+          />
+          <div data-test-name-last>{{changeset.name.last}}</div>
+          <Form.Input
+            @containerClass="email-field"
+            @fieldName="email"
+            @label="Email Address"
+            data-test-email-input
+          />
+          <div data-test-email>{{changeset.email}}</div>
 
-        <button type="submit" data-test-submit>Submit</button>
-        <button type="reset" data-test-reset>Reset</button>
-      </ChangesetForm>
+          <button type="submit" data-test-submit>Submit</button>
+          <button type="reset" data-test-reset>Reset</button>
+        </ChangesetForm>
+      {{/let}}
     `);
   });
 
@@ -165,5 +171,13 @@ module('Integration | Component | ChangesetForm', function (hooks) {
 
     // assert.dom('[data-test-name-first]').hasTextContaining('James2');
     // assert.dom('[data-test-name-last]').hasTextContaining('Silva');
+  });
+
+
+  test('it shows error message when the changeset is invalid', async function (assert) {
+    assert.expect(1);
+    await fillIn('[data-test-email-input]', '');
+    await click('[data-test-submit]');
+    assert.dom('[data-test-id="form-error"]').exists();
   });
 });

--- a/packages/docs/app/components/demo/changeset-form/complete-form/index.hbs
+++ b/packages/docs/app/components/demo/changeset-form/complete-form/index.hbs
@@ -1,109 +1,93 @@
 <DocsDemo as |demo|>
   {{#demo.example name="demo-changeset-form-complete-form-index.hbs"}}
-    <ChangesetForm
-      @model={{this.model}}
-      @validations={{this.validations}}
-      as |Form changeset|
-    >
-      <Form.Input
-        @label="First Name"
-        @fieldName="firstName"
-        placeholder="What is your first name?"
-      />
-      <Form.Input
-        @label="Last Name"
-        @fieldName="lastName"
-        @containerClass="mt-4"
-        placeholder="What is your family name?"
-      />
-      <Form.Input
-        @label="Email Address"
-        @fieldName="email"
-        type="email"
-        @containerClass="mt-4"
-      />
-
-      <Form.Textarea
-        @label="Comments"
-        @fieldName="comments"
-        @containerClass="mt-4"
-      />
-
-      <Form.Select
-        @label="Countries"
-        @fieldName="countries"
-        @isMultiple={{true}}
-        @options={{this.countries}}
-        @allowClear={{true}}
-        @containerClass="mt-4"
-        as |option|
-      >
-        {{option}}
-      </Form.Select>
-
-      <Form.CheckboxGroup
-        @groupName="coreValues"
-        @label="Core Values"
-        @isInline={{true}}
-        @containerClass="mt-4"
-        as |Checkbox|
-      >
-        <Checkbox
-          @label="Hungry"
-          @fieldName="hungry"
+    {{#let (changeset this.model this.validations) as |changesetObject|}}
+      <ChangesetForm @changeset={{changesetObject}} as |Form changeset|>
+        <Form.Input
+          @label="First Name"
+          @fieldName="firstName"
+          placeholder="What is your first name?"
         />
-        <Checkbox
-          @label="Humble"
-          @fieldName="humble"
+        <Form.Input
+          @label="Last Name"
+          @fieldName="lastName"
+          @containerClass="mt-4"
+          placeholder="What is your family name?"
         />
-        <Checkbox
-          @label="Curious"
-          @fieldName="curious"
+        <Form.Input
+          @label="Email Address"
+          @fieldName="email"
+          type="email"
+          @containerClass="mt-4"
         />
-      </Form.CheckboxGroup>
-
-      <Form.RadioGroup
-        @label="Favorite Meal"
-        @containerClass="mt-4"
-        @fieldName="favoriteMeal"
-        as |Radio|
-      >
-        <Radio
-          @label="Breakfast"
-          @value="breakfast"
+        <Form.Textarea
+          @label="Comments"
+          @fieldName="comments"
+          @containerClass="mt-4"
         />
-        <Radio
-          @label="Lunch"
-          @value="lunch"
-        />
-        <Radio
-          @label="Dinner"
-          @value="dinner"
-        />
-      </Form.RadioGroup>
-
-      <button
-        type="submit"
-        class="py-2 px-4 my-4 rounded {{if changeset.isInvalid "bg-gray-100 text-gray-500" "bg-gray-900 text-white"}}"
-        disabled={{changeset.isInvalid}}
-      >
-        Save
-      </button>
-      <button
-        type="reset"
-        class="px-4 py-2 my-4 ml-2 text-gray-900 bg-gray-200 rounded"
-      >
-        Reset
-      </button>
-
-      <div class="mb-4">
-        <p>isPristine: {{changeset.isPristine}}</p>
-        <p>isValid: {{changeset.isValid}}</p>
-        <p>isInvalid: {{changeset.isInvalid}}</p>
-      </div>
-    </ChangesetForm>
+        <Form.Select
+          @label="Countries"
+          @fieldName="countries"
+          @isMultiple={{true}}
+          @options={{this.countries}}
+          @allowClear={{true}}
+          @containerClass="mt-4" as |option|
+        >
+          {{option}}
+        </Form.Select>
+        <Form.CheckboxGroup
+          @groupName="coreValues"
+          @label="Core Values"
+          @isInline={{true}}
+          @containerClass="mt-4" as |Checkbox|
+        >
+          <Checkbox @label="Hungry" @fieldName="hungry" />
+          <Checkbox @label="Humble" @fieldName="humble" />
+          <Checkbox @label="Curious" @fieldName="curious" />
+        </Form.CheckboxGroup>
+        <Form.RadioGroup
+          @label="Favorite Meal"
+          @containerClass="mt-4"
+          @fieldName="favoriteMeal" as |Radio|
+        >
+          <Radio @label="Breakfast" @value="breakfast" />
+          <Radio @label="Lunch" @value="lunch" />
+          <Radio @label="Dinner" @value="dinner" />
+        </Form.RadioGroup>
+        <button
+          type="submit"
+          class="py-2 px-4 my-4 rounded
+            {{if
+              changeset.isInvalid
+              "bg-gray-100 text-gray-500"
+              "bg-gray-900 text-white"
+            }}"
+          disabled={{changeset.isInvalid}}
+        >
+          Save
+        </button>
+        <button
+          type="reset"
+          class="px-4 py-2 my-4 ml-2 text-gray-900 bg-gray-200 rounded"
+        >
+          Reset
+        </button>
+        <div class="mb-4">
+          <p>
+            isPristine:
+            {{changeset.isPristine}}
+          </p>
+          <p>
+            isValid:
+            {{changeset.isValid}}
+          </p>
+          <p>
+            isInvalid:
+            {{changeset.isInvalid}}
+          </p>
+        </div>
+      </ChangesetForm>
+    {{/let}}
   {{/demo.example}}
-
   <demo.snippet
     @name="demo-changeset-form-complete-form-index.hbs"
     @label="components/demo.hbs"

--- a/packages/docs/app/templates/docs/changeset-form/usage.md
+++ b/packages/docs/app/templates/docs/changeset-form/usage.md
@@ -17,21 +17,20 @@ you need to access any information directly.
 
 Here's the list of yielded form components:
 
-| Key               | Component                                                   |
-| ------------------| ----------------------------------------------------------- |
-| Text              | [`<FormText>`](/docs/forms/form-input)                      |
-| Textarea          | [`<FormTextArea>`](/docs/forms/form-textarea)               |
-| Select            | [`<FormSelect>`](/docs/forms/form-select)                   |
-| Checkbox          | [`<FormCheckbox>`](/docs/forms/form-checkbox)               |
-| CheckboxGroup     | [`<FormCheckboxGroup>`](/docs/forms/form-checkbox-group)    |
-| Radio             | [`<FormRadio>`](/docs/forms/form-radio)                     |
-| RadioGroup        | [`<FormRadioGroup>`](/docs/forms/form-radio-group)          |
+| Key           | Component                                                |
+| ------------- | -------------------------------------------------------- |
+| Text          | [`<FormText>`](/docs/forms/form-input)                   |
+| Textarea      | [`<FormTextArea>`](/docs/forms/form-textarea)            |
+| Select        | [`<FormSelect>`](/docs/forms/form-select)                |
+| Checkbox      | [`<FormCheckbox>`](/docs/forms/form-checkbox)            |
+| CheckboxGroup | [`<FormCheckboxGroup>`](/docs/forms/form-checkbox-group) |
+| Radio         | [`<FormRadio>`](/docs/forms/form-radio)                  |
+| RadioGroup    | [`<FormRadioGroup>`](/docs/forms/form-radio-group)       |
 
 ### Form Data Model
 
-The data model used to back the `<ChangesetForm>` is just a simple JS object,
-and nested property paths are supported. Ember Data Models are also supported
-by `ember-changeset`.
+The data model used to back the `<ChangesetForm>` is an instance of a changeset object by `ember-changeset`,
+and so, nested property paths are supported. Ember Data Models are also supported.
 
 ```js
 import Component from '@glimmer/component';
@@ -52,7 +51,7 @@ export default class Demo extends Component {
 ### Validation
 
 Changeset validation is provided by [`ember-changeset-validations`](https://github.com/poteto/ember-changeset-validations/),
-and is optional for `<ChangesetForm>` components. This takes the form of another
+and is optional for any `Changeset` object used by <ChangesetForm>` components. This takes the form of another
 JS object literal mapping properties to validation functions:
 
 ```js
@@ -72,42 +71,42 @@ export default class Demo extends Component {
 }
 ```
 
-### Creating an Instance
+### Creating an Instance of a changeset via the template
 
 ```hbs
-<ChangesetForm
-  @model={{this.myFormModel}}
-  @validations={{this.myValidations}}
-  as |Form changeset|
->
-  <Form.Input
-    @fieldName="name.first"
-    @label="First Name"
-  />
-  <Form.Input
-    @fieldName="name.last"
-    @label="Last Name"
-  />
-  <Form.Input
-    @fieldName="email"
-    @label="Email"
-  />
-  <Form.Input
-    @fieldName="hometown"
-    @label="Home Town"
-  />
-  <Form.Select
-    @fieldName="preferences"
-    @label="Preferences"
-  />
+{{#let (changeset this.myFormModel this.myValidations) as |changesetObject|}}
+  <ChangesetForm
+    @changeset={{changesetObject}}
+    as |Form changeset|
+  >
+    <Form.Input
+      @fieldName="name.first"
+      @label="First Name"
+    />
+    <Form.Input
+      @fieldName="name.last"
+      @label="Last Name"
+    />
+    <Form.Input
+      @fieldName="email"
+      @label="Email"
+    />
+    <Form.Input
+      @fieldName="hometown"
+      @label="Home Town"
+    />
+    <Form.Select
+      @fieldName="preferences"
+      @label="Preferences"
+    />
 
-  <button type="submit">Submit</button>
-</ChangesetForm>
+    <button type="submit">Submit</button>
+  </ChangesetForm>
+{{/let}}
 ```
 
-### Providing Your Own Changeset
+### Creating Your Own Changeset via JS
 
-For added flexibility, you may provide your own `Changeset` object for the form.
 In this case you are responsible for also providing any validation you wish to apply
 to your `Changeset`. The following is a brief example of that method:
 
@@ -126,12 +125,14 @@ export default class Demo extends Component {
     myValue: ''
   };
 
-  myChangeset = new Changeset(this.myModel, lookupValidator(this.validations), this.validations);
+  myChangeset = new Changeset(
+    this.myModel,
+    lookupValidator(this.validations),
+    this.validations
+  );
 }
 ```
 
-In the template, instead of providing your `@model` and `@validations` objects,
-you only need to provide the `@changeset` object.
 
 ```hbs
 <ChangesetForm @changeset={{this.myChangeset}} as |Form changeset|>

--- a/packages/docs/app/templates/docs/changeset-form/usage.md
+++ b/packages/docs/app/templates/docs/changeset-form/usage.md
@@ -51,7 +51,7 @@ export default class Demo extends Component {
 ### Validation
 
 Changeset validation is provided by [`ember-changeset-validations`](https://github.com/poteto/ember-changeset-validations/),
-and is optional for any `Changeset` object used by <ChangesetForm>` components. This takes the form of another
+and is optional for any `Changeset` object used by `<ChangesetForm>` components. This takes the form of another
 JS object literal mapping properties to validation functions:
 
 ```js


### PR DESCRIPTION
## ChangesetForm Refactor
 
This PR aims to provide more simple yet flexible api for ChangesetForm component.

The component serves as a lightweight mechanism for common tasks, like preventing browser native event reload on submit, persisting or rolling back changes to the _changeset_ and providing contextual components with some predefined args like `@changeset` to all types of inputs, and so, preventing typos and boilerplate needed in order to support ChangesetForm Fields

It builds on top of a new utility/ergonomic component called `<ChangesetForm::Context />` which serves as a way to pass down common args _like the changeset_ to all of the types of inputs. This allows the client to optionally use it to build custom forms without much hassle.

This PR also introduces a new feature and a breaking change. 

### Feature:
1. You can now pass new changesets for completely reset the form.

### Breaking change:

Previously we had two "modes": 

1. Manual mode: passing down a changeset to the component via `@changeset`
2. Auto mode: passing down an object or so via `@model` and optionally `@validations`

Auto mode is deprecated, now you must provide a changeset to the component, you can easily do it by using the `changeset` helper

Before:
```handlebars
<ChangesetForm @model={{this.model}} @validations={{this.validations}} />
```

After:
```handlebars
<ChangesetForm @changeset={{changeset this.model this.validations}} />
```