### PR TITLE
doc: Overlays + Power Select

### DIFF
--- a/packages/overlays/addon/components/overlay.md
+++ b/packages/overlays/addon/components/overlay.md
@@ -17,7 +17,7 @@ It contains all the core features necessary for a great experience.
 `FormSelect` uses Power Select under the hood and has `@renderInPlace={{false}}` set by default, which will insert the content of the drop-down outside of the `Overlay` (or `Drawer` or `Modal`) and because of that focus-trap will prevent accessing focusable elements ([search input](https://ember-power-select.com/docs/the-search)) in said Power Select. To solve this you have following options:
 
 - `<Overlay @disableFocusTrap={{true}} />` (not recommended)
-- `<FormSelect @renderInPlace={{false}} />` (recommended)
+- `<FormSelect @renderInPlace={{true}} />` (recommended)
 
 ## API
 

--- a/packages/overlays/addon/components/overlay.md
+++ b/packages/overlays/addon/components/overlay.md
@@ -12,6 +12,13 @@ It contains all the core features necessary for a great experience.
 
 > Important: You must have a focusable element inside of the Overlay.
 
+## Note on Overlays and other portal elements
+
+`FormSelect` uses Power Select under the hood and has `@renderInPlace={{false}}` set by default, which will insert the content of the drop-down outside of the `Overlay` (or `Drawer` or `Modal`) and because of that focus-trap will prevent accessing focusable elements ([search input](https://ember-power-select.com/docs/the-search)) in said Power Select. To solve this you have following options:
+
+- `<Overlay @disableFocusTrap={{true}} />` (not recommended)
+- `<FormSelect @renderInPlace={{false}} />` (recommended)
+
 ## API
 
 <ArgsTable @of="Overlay" />


### PR DESCRIPTION
Because power select inserts popover content outside of the drawer
content then any focusable elements will be inaccessible thanks to
focus-trap. This documentation tries to shed some light on how this
can be solved.

Fixes #148