### PR TITLE
fix(overlays): set modal/drawer body to overflow auto

### DIFF
--- a/packages/overlays/tailwind/default-options.js
+++ b/packages/overlays/tailwind/default-options.js
@@ -152,7 +152,7 @@ function defaultOptions({ config }) {
         body: {
           flexGrow: 1,
           padding: config.modal.body.padding,
-          overflowY: 'scroll',
+          overflowY: 'auto',
           '-webkit-overflow-scrolling': 'touch'
         },
         footer: {

--- a/packages/overlays/tailwind/default-options.js
+++ b/packages/overlays/tailwind/default-options.js
@@ -232,7 +232,7 @@ function defaultOptions({ config }) {
           flexGrow: 1,
           flexBasis: 0,
           padding: config.drawer.body.padding,
-          overflowY: 'scroll',
+          overflowY: 'auto',
           '-webkit-overflow-scrolling': 'touch'
         },
 


### PR DESCRIPTION
Prevents an ugly scroll bar that's always there.

<img width="527" alt="Screen Shot 2021-04-14 at 3 24 17 PM" src="https://user-images.githubusercontent.com/34726/114767412-97c48b80-9d35-11eb-8cf1-13fd6237fcf8.png">
