### PR TITLE
Use rehype-highlight instead of remark-highlight.js & Update highlight theme to GitHub

### DIFF
--- a/site/.docfy-config.js
+++ b/site/.docfy-config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const autolinkHeadings = require('remark-autolink-headings');
-const highlight = require('remark-highlight.js');
+const highlight = require('rehype-highlight');
 const codeImport = require('remark-code-import');
 const withProse = require('@docfy/plugin-with-prose');
 
@@ -14,7 +14,17 @@ module.exports = {
   },
   tocMaxDepth: 3,
   plugins: [withProse({ className: 'prose dark:prose-light' })],
-  remarkPlugins: [autolinkHeadings, codeImport, highlight],
+  remarkPlugins: [autolinkHeadings, codeImport],
+  rehypePlugins: [
+    [
+      highlight
+      // {
+      // languages: {
+      // glimmer: require('highlightjs-glimmer').glimmer
+      // }
+      // }
+    ]
+  ],
   sources: [
     {
       root: path.resolve(__dirname, '../docs'),

--- a/site/app/styles/docfy-demo.css
+++ b/site/app/styles/docfy-demo.css
@@ -45,10 +45,11 @@
 
   pre {
     @apply p-4;
-    @apply flex text-gray-200 bg-gray-900;
+    @apply flex text-gray-200 bg-gray-800;
     @apply text-sm leading-normal;
     @apply font-mono;
     @apply rounded-b;
+    @apply overflow-auto;
     scrollbar-width: none;
   }
 }
@@ -67,7 +68,7 @@
   }
 
   .docfy-demo__snippet pre {
-    @apply bg-gray-1000;
+    @apply bg-gray-900;
     @apply border-gray-700;
   }
 

--- a/site/app/styles/highlight.css
+++ b/site/app/styles/highlight.css
@@ -1,83 +1,125 @@
-/*
-Original: Atom One Dark by Daniel Gamage
-Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
+/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
 */
 
 .hljs {
-  display: block;
-  overflow-x: auto;
-  padding: 0.5em;
-  color: #abb2bf;
-  /* background: #282c34; */
-}
-
-.hljs-comment,
-.hljs-quote {
-  color: #5c6370;
-  font-style: italic;
+  color: #c9d1d9;
 }
 
 .hljs-doctag,
 .hljs-keyword,
-.hljs-formula {
-  color: #c678dd;
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #ff7b72;
 }
 
-.hljs-section,
-.hljs-name,
-.hljs-selector-tag,
-.hljs-deletion,
-.hljs-subst {
-  color: #e06c75;
-}
-
-.hljs-literal {
-  color: #56b6c2;
-}
-
-.hljs-string,
-.hljs-regexp,
-.hljs-addition,
-.hljs-attribute,
-.hljs-meta-string {
-  color: #98c379;
-}
-
-.hljs-built_in,
-.hljs-class .hljs-title {
-  color: #e6c07b;
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #d2a8ff;
 }
 
 .hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
 .hljs-variable,
-.hljs-template-variable,
-.hljs-type,
-.hljs-selector-class,
 .hljs-selector-attr,
-.hljs-selector-pseudo,
-.hljs-number {
-  color: #e06c75;
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #79c0ff;
 }
 
-.hljs-symbol,
-.hljs-bullet,
-.hljs-link,
-.hljs-meta,
-.hljs-selector-id,
-.hljs-title {
-  color: #61aeee;
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #a5d6ff;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #ffa657;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #8b949e;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #7ee787;
+}
+
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #c9d1d9;
+}
+
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #1f6feb;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #f2cc60;
 }
 
 .hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #c9d1d9;
   font-style: italic;
 }
 
 .hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #c9d1d9;
   font-weight: bold;
 }
 
-.hljs-link {
-  text-decoration: underline;
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #aff5b4;
+  background-color: #033a16;
+}
+
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
 }
 
 .prose code.code-transparent {
@@ -87,63 +129,116 @@ Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
 
 .hljs-light-theme {
   .hljs {
-    color: #383a42;
-  }
-
-  .hljs-comment,
-  .hljs-quote {
-    color: #a0a1a7;
-    font-style: italic;
+    color: #24292e;
   }
 
   .hljs-doctag,
   .hljs-keyword,
-  .hljs-formula {
-    color: #a626a4;
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    /* prettylights-syntax-keyword */
+    color: #d73a49;
   }
 
-  .hljs-section,
-  .hljs-name,
-  .hljs-selector-tag,
-  .hljs-deletion,
-  .hljs-subst {
-    color: #e45649;
-  }
-
-  .hljs-literal {
-    color: #0184bb;
-  }
-
-  .hljs-string,
-  .hljs-regexp,
-  .hljs-addition,
-  .hljs-attribute,
-  .hljs-meta-string {
-    color: #50a14f;
-  }
-
-  .hljs-built_in,
-  .hljs-class .hljs-title {
-    color: #c18401;
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    /* prettylights-syntax-entity */
+    color: #6f42c1;
   }
 
   .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
   .hljs-variable,
-  .hljs-template-variable,
-  .hljs-type,
-  .hljs-selector-class,
   .hljs-selector-attr,
-  .hljs-selector-pseudo,
-  .hljs-number {
-    color: #986801;
+  .hljs-selector-class,
+  .hljs-selector-id {
+    /* prettylights-syntax-constant */
+    color: #005cc5;
   }
 
-  .hljs-symbol,
-  .hljs-bullet,
+  .hljs-regexp,
+  .hljs-string,
+  .hljs-meta .hljs-string {
+    /* prettylights-syntax-string */
+    color: #032f62;
+  }
+
+  .hljs-built_in,
+  .hljs-symbol {
+    /* prettylights-syntax-variable */
+    color: #e36209;
+  }
+
+  .hljs-comment,
+  .hljs-code,
+  .hljs-formula {
+    /* prettylights-syntax-comment */
+    color: #6a737d;
+  }
+
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-tag,
+  .hljs-selector-pseudo {
+    /* prettylights-syntax-entity-tag */
+    color: #22863a;
+  }
+
+  .hljs-subst {
+    /* prettylights-syntax-storage-modifier-import */
+    color: #24292e;
+  }
+
+  .hljs-section {
+    /* prettylights-syntax-markup-heading */
+    color: #005cc5;
+    font-weight: bold;
+  }
+
+  .hljs-bullet {
+    /* prettylights-syntax-markup-list */
+    color: #735c0f;
+  }
+
+  .hljs-emphasis {
+    /* prettylights-syntax-markup-italic */
+    color: #24292e;
+    font-style: italic;
+  }
+
+  .hljs-strong {
+    /* prettylights-syntax-markup-bold */
+    color: #24292e;
+    font-weight: bold;
+  }
+
+  .hljs-addition {
+    /* prettylights-syntax-markup-inserted */
+    color: #22863a;
+    background-color: #f0fff4;
+  }
+
+  .hljs-deletion {
+    /* prettylights-syntax-markup-deleted */
+    color: #b31d28;
+    background-color: #ffeef0;
+  }
+
+  .hljs-char.escape_,
   .hljs-link,
-  .hljs-meta,
-  .hljs-selector-id,
-  .hljs-title {
-    color: #4078f2;
+  .hljs-params,
+  .hljs-property,
+  .hljs-punctuation,
+  .hljs-tag {
+    /* purposely ignored */
   }
 }

--- a/site/ember-cli-build.js
+++ b/site/ember-cli-build.js
@@ -74,6 +74,9 @@ module.exports = function (defaults) {
     prember: {
       urls: ['/']
     },
+    fastboot: {
+      hostWhitelist: [/^localhost:\d+$/]
+    },
     postcssOptions: {
       compile: {
         enabled: true,

--- a/site/package.json
+++ b/site/package.json
@@ -68,9 +68,9 @@
     "prember": "^1.0.5",
     "qunit": "^2.15.0",
     "qunit-dom": "^1.6.0",
+    "rehype-highlight": "^4.1.0",
     "remark-autolink-headings": "^6.0.1",
     "remark-code-import": "^0.3.0",
-    "remark-highlight.js": "^6.0.0",
     "tailwindcss": "^2.1.2",
     "typescript": "^4.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9435,6 +9435,15 @@ hast-util-to-html@^7.1.1:
     unist-util-is "^4.0.0"
     xtend "^4.0.0"
 
+hast-util-to-text@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-2.0.1.tgz#04f2e065642a0edb08341976084aa217624a0f8b"
+  integrity sha512-8nsgCARfs6VkwH2jJU9b8LNTuR4700na+0h3PqCaEk4MAnMDeu5P0tP8mjk9LLNGxIeQRLbiDbZVw6rku+pYsQ==
+  dependencies:
+    hast-util-is-element "^1.0.0"
+    repeat-string "^1.0.0"
+    unist-util-find-after "^3.0.0"
+
 hast-util-whitespace@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz#e4fe77c4a9ae1cb2e6c25e02df0043d0164f6e41"
@@ -11039,7 +11048,7 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lowlight@^1.2.0, lowlight@^1.20.0:
+lowlight@^1.10.0, lowlight@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
   integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
@@ -13734,6 +13743,15 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+rehype-highlight@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rehype-highlight/-/rehype-highlight-4.1.0.tgz#817da5ad61072e6c098703a177db158408625255"
+  integrity sha512-JPcnZFJdk2Fnna+ymrEZI8LV7aJohDOicTQv+YEkxB00A3AS8bfrkVpJ0LrmSfzqvBH+fYe/l9/dxav33mP11w==
+  dependencies:
+    hast-util-to-text "^2.0.0"
+    lowlight "^1.10.0"
+    unist-util-visit "^2.0.0"
+
 rehype-stringify@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-8.0.0.tgz#9b6afb599bcf3165f10f93fc8548f9a03d2ec2ba"
@@ -13785,14 +13803,6 @@ remark-hbs@^0.4.0:
   dependencies:
     unist-builder "^2.0.3"
     unist-util-visit "^2.0.3"
-
-remark-highlight.js@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/remark-highlight.js/-/remark-highlight.js-6.0.0.tgz#cb05387ddddeb078f0b61ce6299f6323f05098fc"
-  integrity sha512-eNHP/ezuDKoeh3KV+rWLeBVzU3SYVt0uu1tHdsCB6TUJYHwTNMJWZ5+nU+2fJHQXb+7PtpfGXVtFS9zk/W6qdw==
-  dependencies:
-    lowlight "^1.2.0"
-    unist-util-visit "^2.0.0"
 
 remark-normalize-headings@^2.0.0:
   version "2.0.0"
@@ -15768,6 +15778,13 @@ unist-builder@^2.0.0, unist-builder@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
+
+unist-util-find-after@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-3.0.0.tgz#5c65fcebf64d4f8f496db46fa8fd0fbf354b43e6"
+  integrity sha512-ojlBqfsBftYXExNu3+hHLfJQ/X1jYY/9vdm4yZWjIbf0VuWF6CRufci1ZyoD/wV2TYMKxXUoNuoqwy+CkgzAiQ==
+  dependencies:
+    unist-util-is "^4.0.0"
 
 unist-util-find@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This will allow us to get the glimmer grammar for better highlight.

cc/ @nullVoxPopuli

Currently including `highlightjs-glimmer` breaks with the following error:

```

  - broccoliBuilderErrorStack: TypeError: Cannot read property 'length' of undefined
    at /Users/josemarluedke/code/oss/frontile/node_modules/highlight.js/lib/core.js:420:15
    at Array.map (<anonymous>)
    at join (/Users/josemarluedke/code/oss/frontile/node_modules/highlight.js/lib/core.js:414:18)
    at MultiRegex.compile (/Users/josemarluedke/code/oss/frontile/node_modules/highlight.js/lib/core.js:880:31)
    at ResumableMultiRegex.getMatcher (/Users/josemarluedke/code/oss/frontile/node_modules/highlight.js/lib/core.js:951:15)
    at ResumableMultiRegex.exec (/Users/josemarluedke/code/oss/frontile/node_modules/highlight.js/lib/core.js:972:22)
    at _highlight (/Users/josemarluedke/code/oss/frontile/node_modules/highlight.js/lib/core.js:2003:35)
    at Object.highlight (/Users/josemarluedke/code/oss/frontile/node_modules/highlight.js/lib/core.js:1626:9)
    at highlight (/Users/josemarluedke/code/oss/frontile/node_modules/lowlight/lib/core.js:48:17)
    at Object.highlightAuto (/Users/josemarluedke/code/oss/frontile/node_modules/lowlight/lib/core.js:94:15)
  - code: [undefined]
  - codeFrame: Cannot read property 'length' of undefined
  - errorMessage: Cannot read property 'length' of undefined
        at DocfyBroccoli
```