### PR TITLE
[Rebased] Notifications: Binding for template usage 

### DIFF
--- a/packages/notifications/addon/services/notifications.ts
+++ b/packages/notifications/addon/services/notifications.ts
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import Notification from '../-private/notification';
 import NotificationsManager from '../-private/manager';
 import { NotificationOptions } from '../-private/types';
+import { action } from '@ember/object';
 
 export default class NotificationsService extends Service {
   manager = new NotificationsManager();
@@ -10,14 +11,17 @@ export default class NotificationsService extends Service {
     return this.manager.notifications;
   }
 
+  @action
   add(message: string, options?: NotificationOptions): Notification {
     return this.manager.add(message, options);
   }
 
+  @action
   remove(notification?: Notification): void {
     this.manager.remove(notification);
   }
 
+  @action
   removeAll(): void {
     this.manager.removeAll();
   }

--- a/packages/notifications/addon/services/notifications.ts
+++ b/packages/notifications/addon/services/notifications.ts
@@ -2,7 +2,6 @@ import Service from '@ember/service';
 import Notification from '../-private/notification';
 import NotificationsManager from '../-private/manager';
 import { NotificationOptions } from '../-private/types';
-import { action } from '@ember/object';
 
 export default class NotificationsService extends Service {
   manager = new NotificationsManager();
@@ -11,20 +10,17 @@ export default class NotificationsService extends Service {
     return this.manager.notifications;
   }
 
-  @action
-  add(message: string, options?: NotificationOptions): Notification {
+  add = (message: string, options?: NotificationOptions): Notification => {
     return this.manager.add(message, options);
-  }
+  };
 
-  @action
-  remove(notification?: Notification): void {
+  remove = (notification?: Notification): void => {
     this.manager.remove(notification);
-  }
+  };
 
-  @action
-  removeAll(): void {
+  removeAll = (): void => {
     this.manager.removeAll();
-  }
+  };
 
   willDestroy(): void {
     this.removeAll();

--- a/packages/notifications/tests/integration/components/notification-card-test.ts
+++ b/packages/notifications/tests/integration/components/notification-card-test.ts
@@ -91,9 +91,9 @@ module('Integration | Component | NotificationCard', function (hooks) {
       new Notification('My message', { transitionDuration: 1 })
     );
 
-    const service: NotificationsService = this.owner.lookup(
+    const service = this.owner.lookup(
       'service:notifications'
-    );
+    ) as NotificationsService;
 
     sinon.stub(service, 'remove').callsFake((n: Notification): void => {
       assert.equal(n, this.notification);
@@ -130,9 +130,9 @@ module('Integration | Component | NotificationCard', function (hooks) {
       })
     );
 
-    const service: NotificationsService = this.owner.lookup(
+    const service = this.owner.lookup(
       'service:notifications'
-    );
+    ) as NotificationsService;
 
     sinon.stub(service, 'remove').callsFake((n: Notification): void => {
       assert.equal(n, this.notification);

--- a/packages/notifications/tests/integration/components/notifications-container-test.ts
+++ b/packages/notifications/tests/integration/components/notifications-container-test.ts
@@ -28,9 +28,9 @@ module('Integration | Component | NotificationsContainer', function (hooks) {
   });
 
   test('it render all notifications from service', async function (assert) {
-    const service: NotificationsService = this.owner.lookup(
+    const service = this.owner.lookup(
       'service:notifications'
-    );
+    ) as NotificationsService;
 
     service.add('Message 1', options);
     service.add('Message 2', options);


### PR DESCRIPTION
This takes the changes from @betocantu93 in PR #123. 

It also changes from the action decorator to arrow functions, which works with sinon. 

Closes #123. 