### PR TITLE
Prevent overlay closing when clicking content and dragging to backdrop

### DIFF
--- a/packages/overlays/addon/components/overlay.hbs
+++ b/packages/overlays/addon/components/overlay.hbs
@@ -46,6 +46,7 @@
           }}
           {{on "click" this.handleContentClick}}
           {{on "keydown" this.handleKeyDown}}
+          {{on "mousedown" this.handleContentMouseDown}}
           {{did-insert this.setup}}
           {{will-destroy this.teardown}}
           {{css-transition

--- a/packages/overlays/addon/components/overlay.ts
+++ b/packages/overlays/addon/components/overlay.ts
@@ -108,6 +108,7 @@ export interface OverlayArgs {
 export default class Overlay extends Component<OverlayArgs> {
   @tracked keepOpen = false;
   contentElement: HTMLElement | undefined;
+  mouseDownContentElement: EventTarget | null = null;
 
   get destinationElement(): HTMLElement | null {
     const doc = getDOM(this);
@@ -148,16 +149,23 @@ export default class Overlay extends Component<OverlayArgs> {
   @action handleContentClick(event: MouseEvent): void {
     if (
       this.args.closeOnOutsideClick !== false &&
-      event.target === this.contentElement
+      event.target === this.contentElement &&
+      this.mouseDownContentElement == this.contentElement
     ) {
       this.handleClose();
     }
+    this.mouseDownContentElement = null;
   }
 
   @action handleClose(): void {
     if (typeof this.args.onClose === 'function') {
       this.args.onClose();
     }
+  }
+
+  @action
+  handleContentMouseDown(event: MouseEvent): void {
+    this.mouseDownContentElement = event.target;
   }
 
   @action


### PR DESCRIPTION
Fixes #153. 