### PR TITLE
Cursor pointer (hand) on radios/checkbox + label

### DIFF
--- a/packages/forms/addon/components/form-checkbox.hbs
+++ b/packages/forms/addon/components/form-checkbox.hbs
@@ -1,30 +1,25 @@
 <FormField
   @size={{@size}}
-  class={{
-    use-frontile-class
+  class={{use-frontile-class
     "form-checkbox"
     @size
     class=(array @containerClass @privateContainerClass)
-  }} as |f|
+  }}
+  as |f|
 >
   <div
-    class={{use-frontile-class "form-checkbox" @size part="label-container"}}
+    class={{use-frontile-class "form-checkbox" @size part="input-container"}}
   >
-    <div
-      class={{use-frontile-class "form-checkbox" @size part="input-container"}}
-    >
-      {{!  Zero-width space character, used to align checkbox properly }}
-      ​
-      <f.Checkbox
-        @onChange={{this.handleChange}}
-        @checked={{@checked}}
-        @name={{@name}}
-        class={{use-frontile-class "form-checkbox" @size part="checkbox"}}
-        aria-describedby={{if @hint f.hintId}}
-        ...attributes
-      />
-    </div>
-
+    <f.Checkbox
+      @onChange={{this.handleChange}}
+      @checked={{@checked}}
+      @name={{@name}}
+      class={{use-frontile-class "form-checkbox" @size part="checkbox"}}
+      aria-describedby={{if @hint f.hintId}}
+      ...attributes
+    />
+    {{!  Zero-width space character, used to align checkbox properly }}
+    ​
     <f.Label class={{use-frontile-class "form-checkbox" @size part="label"}}>
       {{#if (has-block)}}
         {{yield}}

--- a/packages/forms/addon/components/form-radio.hbs
+++ b/packages/forms/addon/components/form-radio.hbs
@@ -1,27 +1,24 @@
 <FormField
   @size={{@size}}
-  class={{
-    use-frontile-class
+  class={{use-frontile-class
     "form-radio"
     @size
     class=(array @containerClass @privateContainerClass)
-  }} as |f|
+  }}
+  as |f|
 >
-  <div class={{use-frontile-class "form-radio" @size part="label-container"}}>
-    <div class={{use-frontile-class "form-radio" @size part="input-container"}}>
-      {{!  Zero-width space character, used to align checkbox properly }}
-      ​
-      <f.Radio
-        @onChange={{this.handleChange}}
-        @value={{@value}}
-        @checked={{@checked}}
-        @name={{@name}}
-        class={{use-frontile-class "form-radio" @size part="radio"}}
-        aria-describedby={{if @hint f.hintId}}
-        ...attributes
-      />
-    </div>
-
+  <div class={{use-frontile-class "form-radio" @size part="input-container"}}>
+    {{!  Zero-width space character, used to align checkbox properly }}
+    ​
+    <f.Radio
+      @onChange={{this.handleChange}}
+      @value={{@value}}
+      @checked={{@checked}}
+      @name={{@name}}
+      class={{use-frontile-class "form-radio" @size part="radio"}}
+      aria-describedby={{if @hint f.hintId}}
+      ...attributes
+    />
     <f.Label class={{use-frontile-class "form-radio" @size part="label"}}>
       {{#if (has-block)}}
         {{yield}}
@@ -30,7 +27,6 @@
       {{/if}}
     </f.Label>
   </div>
-
   {{#if @hint}}
     <f.Hint class={{use-frontile-class "form-radio" @size part="hint"}}>
       {{@hint}}

--- a/packages/forms/tailwind/default-options.js
+++ b/packages/forms/tailwind/default-options.js
@@ -221,14 +221,22 @@ function defaultOptions({ config }) {
       },
 
       parts: {
-        labelContainer: {
+        inputContainer: {
           lineHeight: defaultTheme.lineHeight.tight,
           display: 'flex',
-          alignItems: 'flex-start'
-        },
-        inputContainer: {
-          display: 'flex',
-          alignItems: 'center'
+          alignItems: 'center',
+          '& > input:not([disabled])': {
+            cursor: defaultTheme.cursor['pointer'],
+            '& + label': {
+              cursor: defaultTheme.cursor['pointer']
+            }
+          },
+          '& > input[disabled]': {
+            cursor: defaultTheme.cursor['not-allowed'],
+            '& + label': {
+              cursor: defaultTheme.cursor['not-allowed']
+            }
+          }
         },
         label: {
           fontWeight: defaultTheme.fontWeight.normal,


### PR DESCRIPTION
- Added enabled checkbox/radio inputs cursor  `pointer` (hand).
- Added disabled checkbox/radio input cursor `not-allowed`
- Added enabled checkbox/radio label cursor `pointer`
- Added disabled checkbox/radio label cursor `not-allowed`


Note: 
Before this pr the structure was:
```
<label-container>
    <input-container>
       <input />
   </input-container>
   <label/>
<label-container>
```
Because the child `:has()` pseudo selector is not yet available, and the html `...attributes`  go for the `input` element, the only way to make cursor apply to the label only when input is not disabled  is to have the `label` be a sibling of `input` and use the  adjacent sibling combinator selector `+`. Something like `input:not([disabled]) + label`

 For that, `label-container` container needed to be removed.

So the new structure is 
```
<input-container>
   <input />
   <label/>
</input-container>
```

At simple glance, the extra `label-container` wrapper doesn't seems to be exactly necessary, but of course, I might be missing something. Is it safe to remove? 
<img width="238" alt="image" src="https://user-images.githubusercontent.com/17834212/170183593-60ff8e5f-90fd-460c-a58f-9cb026557438.png">

