### PR TITLE
Mark radio and checkbox container elements as checked to allow label styling

### DIFF
--- a/packages/forms/addon/components/form-checkbox.hbs
+++ b/packages/forms/addon/components/form-checkbox.hbs
@@ -11,7 +11,12 @@
     class={{use-frontile-class "form-checkbox" @size part="label-container"}}
   >
     <div
-      class={{use-frontile-class "form-checkbox" @size part="input-container"}}
+      class={{use-frontile-class
+        "form-checkbox"
+        @size
+        (if @checked "checked")
+        part="input-container"
+      }}
     >
       {{!  Zero-width space character, used to align checkbox properly }}
       ​

--- a/packages/forms/addon/components/form-checkbox.hbs
+++ b/packages/forms/addon/components/form-checkbox.hbs
@@ -1,22 +1,18 @@
 <FormField
   @size={{@size}}
-  class={{
-    use-frontile-class
+  class={{use-frontile-class
     "form-checkbox"
     @size
+    (if @checked "checked")
     class=(array @containerClass @privateContainerClass)
-  }} as |f|
+  }}
+  as |f|
 >
   <div
     class={{use-frontile-class "form-checkbox" @size part="label-container"}}
   >
     <div
-      class={{use-frontile-class
-        "form-checkbox"
-        @size
-        (if @checked "checked")
-        part="input-container"
-      }}
+      class={{use-frontile-class "form-checkbox" @size part="input-container"}}
     >
       {{!  Zero-width space character, used to align checkbox properly }}
       ​

--- a/packages/forms/addon/components/form-radio.hbs
+++ b/packages/forms/addon/components/form-radio.hbs
@@ -1,21 +1,15 @@
 <FormField
   @size={{@size}}
-  class={{
-    use-frontile-class
+  class={{use-frontile-class
     "form-radio"
     @size
+    (if (eq @checked @value) "checked")
     class=(array @containerClass @privateContainerClass)
-  }} as |f|
+  }}
+  as |f|
 >
   <div class={{use-frontile-class "form-radio" @size part="label-container"}}>
-    <div
-      class={{use-frontile-class
-        "form-radio"
-        @size
-        (if (eq @checked @value) "checked")
-        part="input-container"
-      }}
-    >
+    <div class={{use-frontile-class "form-radio" @size part="input-container"}}>
       {{!  Zero-width space character, used to align checkbox properly }}
       ​
       <f.Radio

--- a/packages/forms/addon/components/form-radio.hbs
+++ b/packages/forms/addon/components/form-radio.hbs
@@ -8,7 +8,14 @@
   }} as |f|
 >
   <div class={{use-frontile-class "form-radio" @size part="label-container"}}>
-    <div class={{use-frontile-class "form-radio" @size part="input-container"}}>
+    <div
+      class={{use-frontile-class
+        "form-radio"
+        @size
+        (if (eq @checked @value) "checked")
+        part="input-container"
+      }}
+    >
       {{!  Zero-width space character, used to align checkbox properly }}
       ​
       <f.Radio

--- a/test-app/tests/integration/components/forms/form-checkbox-test.ts
+++ b/test-app/tests/integration/components/forms/form-checkbox-test.ts
@@ -157,14 +157,12 @@ module(
       );
 
       assert.dom('[data-test-input]').isNotChecked();
-      assert.dom('.form-checkbox--checked__input-container').doesNotExist();
+      assert.dom('.form-checkbox--checked').doesNotExist();
 
       this.set('myValue', true);
 
       assert.dom('[data-test-input]').isChecked();
-      assert.dom('.form-checkbox--checked__input-container').exists();
-
-      assert.dom('.form-checkbox--checked__input-container + label').exists();
+      assert.dom('.form-checkbox--checked').exists();
     });
 
     test('it adds size classes for @size', async function (assert) {

--- a/test-app/tests/integration/components/forms/form-checkbox-test.ts
+++ b/test-app/tests/integration/components/forms/form-checkbox-test.ts
@@ -145,6 +145,28 @@ module(
       assert.dom('.my-container-class').exists();
     });
 
+    test('it adds class to input wrapper when checked to allow selected label css styling', async function (assert) {
+      this.set('myValue', false);
+
+      await render(
+        hbs`<FormCheckbox
+            data-test-input
+            @label="My Checkbox Input"
+            @checked={{this.myValue}}
+          />`
+      );
+
+      assert.dom('[data-test-input]').isNotChecked();
+      assert.dom('.form-checkbox--checked__input-container').doesNotExist();
+
+      this.set('myValue', true);
+
+      assert.dom('[data-test-input]').isChecked();
+      assert.dom('.form-checkbox--checked__input-container').exists();
+
+      assert.dom('.form-checkbox--checked__input-container + label').exists();
+    });
+
     test('it adds size classes for @size', async function (assert) {
       this.set('size', 'sm');
 

--- a/test-app/tests/integration/components/forms/form-radio-group-test.ts
+++ b/test-app/tests/integration/components/forms/form-radio-group-test.ts
@@ -155,15 +155,9 @@ module(
       await render(template);
 
       assert.dom('[data-test-option-no]').isNotChecked();
-      assert
-        .dom('.form-radio--checked__input-container [data-test-option-no]')
-        .doesNotExist();
+      assert.dom('.form-radio--checked [data-test-option-no]').doesNotExist();
       assert.dom('[data-test-option-yes]').isChecked();
-      assert
-        .dom('.form-radio--checked__input-container [data-test-option-yes]')
-        .exists();
-
-      assert.dom('.form-radio--checked__input-container + label').exists();
+      assert.dom('.form-radio--checked [data-test-option-yes]').exists();
     });
 
     test('it adds container class from @containerClass arg', async function (assert) {

--- a/test-app/tests/integration/components/forms/form-radio-group-test.ts
+++ b/test-app/tests/integration/components/forms/form-radio-group-test.ts
@@ -150,6 +150,22 @@ module(
         .hasText('This field is required');
     });
 
+    test('it adds class to input wrapper when checked to allow selected label css styling', async function (assert) {
+      this.set('myValue', true);
+      await render(template);
+
+      assert.dom('[data-test-option-no]').isNotChecked();
+      assert
+        .dom('.form-radio--checked__input-container [data-test-option-no]')
+        .doesNotExist();
+      assert.dom('[data-test-option-yes]').isChecked();
+      assert
+        .dom('.form-radio--checked__input-container [data-test-option-yes]')
+        .exists();
+
+      assert.dom('.form-radio--checked__input-container + label').exists();
+    });
+
     test('it adds container class from @containerClass arg', async function (assert) {
       this.set('containerClass', 'my-container-class');
 


### PR DESCRIPTION
Currently with the `<input>` element inside a wrapper element, you can't style the form labels differently based on the checked state of the input (which I'd normally do with a `input:checked + label` selector)

This PR adds a `--checked` variant class to the top-level form elements of both the radio buttons and checkboxes when they're checked so that the child elements can be targeted and styled