### PR TITLE
Add ids and events to notifications

### DIFF
--- a/packages/notifications/addon/-private/evented.ts
+++ b/packages/notifications/addon/-private/evented.ts
@@ -1,0 +1,38 @@
+import EmberObject from '@ember/object';
+import EmberEvented from '@ember/object/evented';
+
+/**
+ * Partial wrapper for Ember's Evented Mixin, enabling
+ * a pure class-based derivation
+ * @private
+ */
+
+export default class Evented {
+  eventManager = EmberObject.extend(EmberEvented).create();
+
+  on(name: string, target: object, method?: string | Function): this {
+    //@ts-ignore
+    this.eventManager.on(name, target, method);
+    return this;
+  }
+
+  off(name: string, target: object, method?: string | Function): this {
+    //@ts-ignore
+    this.eventManager.off(name, target, method);
+    return this;
+  }
+
+  one(name: string, target: object, method?: string | Function): this {
+    //@ts-ignore
+    this.eventManager.one(name, target, method);
+    return this;
+  }
+
+  has(name: string): boolean {
+    return this.eventManager.has(name);
+  }
+
+  trigger(name: string, ...args: any[]): void {
+    this.eventManager.trigger(name, ...args);
+  }
+}

--- a/packages/notifications/addon/-private/manager.ts
+++ b/packages/notifications/addon/-private/manager.ts
@@ -4,8 +4,9 @@ import { NotificationOptions } from './types';
 import { getConfigOption } from './get-config';
 import { tracked } from '@glimmer/tracking';
 import { later } from '@ember/runloop';
+import Evented from './evented';
 
-export default class NotificationsManager {
+export default class NotificationsManager extends Evented {
   @tracked notifications: Notification[] = [];
 
   add(message: string, options: NotificationOptions = {}): Notification {
@@ -26,6 +27,8 @@ export default class NotificationsManager {
     if (preserve === false) {
       this.setupAutoRemoval(notification, notification.duration);
     }
+
+    this.trigger('add', notification);
     return notification;
   }
 
@@ -45,6 +48,7 @@ export default class NotificationsManager {
       },
       notification.transitionDuration
     );
+    this.trigger('remove', notification);
   }
 
   removeAll(): void {

--- a/packages/notifications/addon/-private/notification.ts
+++ b/packages/notifications/addon/-private/notification.ts
@@ -10,6 +10,7 @@ export default class Notification {
   readonly customActions?: CustomAction[];
   readonly allowClosing: boolean;
   readonly duration: number;
+  readonly id?: string;
 
   @tracked timer?: Timer;
   @tracked isRemoving = false;
@@ -30,6 +31,8 @@ export default class Notification {
     } else {
       this.allowClosing = true;
     }
+
+    this.id = options.id;
   }
 
   remove(): void {

--- a/packages/notifications/addon/-private/types.ts
+++ b/packages/notifications/addon/-private/types.ts
@@ -52,6 +52,14 @@ export interface NotificationOptions {
    * @defaultValue undefined
    */
   customActions?: CustomAction[];
+
+  /**
+   * The unique id of the notification
+   *
+   * @defaultValue undefined
+   */
+
+  id?: string;
 }
 
 export interface DefaultConfig extends NotificationOptions {

--- a/packages/notifications/addon/components/notification-card.hbs
+++ b/packages/notifications/addon/components/notification-card.hbs
@@ -13,6 +13,7 @@
       {{css-transition (concat "notification-transition--slide-from-" @placement) isEnabled=true}}
       class={{use-frontile-class "notification-card" @notification.appearance}}
       style="{{this.styles}}"
+      data-notification-id={{@notification.id}}
       ...attributes
     >
       <div class={{use-frontile-class "notification-card" @notification.appearance part="message"}}>

--- a/test-app/tests/integration/components/notifications/notification-card-test.ts
+++ b/test-app/tests/integration/components/notifications/notification-card-test.ts
@@ -192,5 +192,18 @@ module(
       await triggerEvent('[data-test-notification]', 'mouseenter');
       await triggerEvent('[data-test-notification]', 'mouseleave');
     });
+
+    test('it renders an identifier if notification has id attribute', async function (assert) {
+      assert.expect(1);
+
+      this.set(
+        'notification',
+        new Notification('My message', { transitionDuration: 1, id: 'abc123' })
+      );
+
+      await render(template);
+
+      assert.dom('[data-notification-id="abc123"]').exists({ count: 1 });
+    });
   }
 );

--- a/test-app/tests/unit/notifications/services/notifications-test.ts
+++ b/test-app/tests/unit/notifications/services/notifications-test.ts
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { NotificationsService, Timer } from '@frontile/notifications';
 import { waitUntil } from '@ember/test-helpers';
+import { Notification } from '@frontile/notifications';
 
 module(
   'Unit | Service | @frontile/notifications/notifications',
@@ -150,6 +151,37 @@ module(
         },
         { timeout: 500 }
       );
+    });
+
+    test('it allows subscriptions to additions and removals', async function (assert) {
+      assert.expect(5);
+
+      const service = this.owner.lookup(
+        'service:notifications'
+      ) as NotificationsService;
+
+      assert.equal(service.notifications.length, 0);
+
+      const ids = ['123', '456'];
+
+      service.manager.on('add', (notification: Notification) => {
+        assert.true(ids.includes(notification.id!));
+      });
+
+      service.manager.on('remove', (notification: Notification) => {
+        assert.true(ids.includes(notification.id!));
+      });
+
+      ids.forEach((id) => {
+        service.add('Notification', {
+          id,
+          duration: 1,
+          transitionDuration: 0,
+          preserve: true
+        });
+      });
+
+      service.removeAll();
     });
   }
 );


### PR DESCRIPTION
I wanted to be able to mark a notification record as read on the backend when a user closed a (frontile) notification on the frontend, and this PR opens up that possibility.

- Adds an `id` attribute to the notification object in frontile, and that `id` is output as a `data-notification-id` attribute on the Notification component. 
- When a notification is added or removed on the frontend, an event is fired on the manager object, allowing consumers to tie into that. 

An example of this in use: 

```javascript
...
  @service cable;
  @service notifications

  subscribeToUpdates(user) {
    this.subscribeToNotificationsChannel(user);

    this.notifications.manager.on('remove', this.notificationRead.bind(this));
  }

  notificationRead(notification) {
    if (this.subscriptions.notificationsChannel) {
      this.subscriptions.notificationsChannel.perform('mark_as_read', {
        ids: [notification.id],
      });
    }
  }
...

```