### PR TITLE
fix: component Element signature

### DIFF
--- a/packages/notifications/addon/components/notification-card.ts
+++ b/packages/notifications/addon/components/notification-card.ts
@@ -21,7 +21,7 @@ export interface NotificationCardArgs {
 
 export interface NotificationCardSignature {
   Args: NotificationCardArgs;
-  Element: HTMLDivElement | null;
+  Element: HTMLDivElement;
 }
 
 export default class NotificationCard extends Component<NotificationCardSignature> {

--- a/packages/notifications/addon/components/notifications-container.ts
+++ b/packages/notifications/addon/components/notifications-container.ts
@@ -28,7 +28,7 @@ export interface NotificationsContainerArgs {
 
 export interface NotificationsContainerSignature {
   Args: NotificationsContainerArgs;
-  Element: HTMLDivElement | null;
+  Element: HTMLDivElement;
 }
 
 export default class NotificationsContainer extends Component<NotificationsContainerSignature> {

--- a/packages/overlays/addon/components/drawer/body.ts
+++ b/packages/overlays/addon/components/drawer/body.ts
@@ -6,7 +6,7 @@ export interface DrawerBodyArgs
 
 export interface DrawerBodySignature {
   Args: DrawerBodyArgs;
-  Element: HTMLDivElement | null;
+  Element: HTMLDivElement;
 }
 
 export default class DrawerBody extends Component<DrawerBodySignature> {}

--- a/packages/overlays/addon/components/drawer/footer.ts
+++ b/packages/overlays/addon/components/drawer/footer.ts
@@ -6,7 +6,7 @@ export interface DrawerFooterArgs
 
 export interface DrawerFooterSignature {
   Args: DrawerFooterArgs;
-  Element: HTMLDivElement | null;
+  Element: HTMLDivElement;
 }
 
 export default class DrawerFooter extends Component<DrawerFooterSignature> {}

--- a/packages/overlays/addon/components/drawer/index.ts
+++ b/packages/overlays/addon/components/drawer/index.ts
@@ -64,7 +64,7 @@ export interface DrawerSignature {
       }
     ];
   };
-  Element: HTMLDivElement | null;
+  Element: HTMLDivElement;
 }
 
 export default class Drawer extends Component<DrawerSignature> {

--- a/packages/overlays/addon/components/modal/index.ts
+++ b/packages/overlays/addon/components/modal/index.ts
@@ -62,7 +62,7 @@ export interface ModalSignature {
       }
     ];
   };
-  Element: HTMLDivElement | null;
+  Element: HTMLDivElement;
 }
 
 export default class Modal extends Component<ModalSignature> {

--- a/packages/overlays/addon/components/overlay.ts
+++ b/packages/overlays/addon/components/overlay.ts
@@ -107,7 +107,7 @@ export interface OverlayArgs {
 
 export interface OverlaySignature {
   Args: OverlayArgs;
-  Element: HTMLDivElement | null;
+  Element: HTMLDivElement;
 }
 
 export default class Overlay extends Component<OverlaySignature> {


### PR DESCRIPTION
Sometimes there are condition when the element is rendered like `isRenderless` so technically there might be a case where its not really rendered. 
But the issue is that by adding the `| null` to the rendered element definition is  breaking glint. 
Because `HTMLDivElement | null`  can't have any attributes that are not component argument