### PR TITLE
Don't use add-on in path for power select import

### DIFF
--- a/packages/forms/addon/components/form-select.ts
+++ b/packages/forms/addon/components/form-select.ts
@@ -5,7 +5,7 @@ import { assert } from '@ember/debug';
 import {
   PowerSelectArgs,
   Select
-} from 'ember-power-select/addon/components/power-select';
+} from 'ember-power-select/components/power-select';
 
 export interface FormSelectArgs extends PowerSelectArgs {
   /** The input field label */


### PR DESCRIPTION
When add-on is in the path Glint will complain about every usage of power select within the application. 

Please note. I was able to test this change locally and verified it worked, but when I point to my fork then there are complaints about importing the add-on in general. Not sure if there is an extra step required to test this sort of package layout. 