### PR TITLE
fix: overelay to handle power-select or any content in basic dropdown wormhole

### DIFF
--- a/packages/overlays/src/components/overlay.gts
+++ b/packages/overlays/src/components/overlay.gts
@@ -52,6 +52,18 @@ function hasNextSibblingOverlay(element: HTMLElement): boolean {
   return false;
 }
 
+// finds if the el has a parent with the id `ember-basic-dropdown-wormhole`
+function hasWormholeParentElement(el: HTMLElement) {
+  let parent = el.parentElement;
+  while (parent) {
+    if (parent.id === 'ember-basic-dropdown-wormhole') {
+      return true;
+    }
+    parent = parent.parentElement;
+  }
+  return false;
+}
+
 interface OverlaySignature {
   Args: {
     /**
@@ -97,7 +109,7 @@ interface OverlaySignature {
     /**
      * Focus trap options
      *
-     * @defaultValue { allowOutsideClick: true }
+     * @defaultValue { clickOutsideDeactivates: true, allowOutsideClick: true }
      */
     focusTrapOptions?: unknown;
 
@@ -206,7 +218,8 @@ class Overlay extends Component<OverlaySignature> {
     if (
       this.args.closeOnOutsideClick !== false &&
       this.contentElement &&
-      !hasNextSibblingOverlay(this.contentElement)
+      !hasNextSibblingOverlay(this.contentElement) &&
+      !hasWormholeParentElement(e.target as HTMLElement)
     ) {
       this.handleClose();
       e.preventDefault();
@@ -295,6 +308,7 @@ class Overlay extends Component<OverlaySignature> {
   get focusTrapOptions(): unknown {
     return (
       this.args.focusTrapOptions || {
+        clickOutsideDeactivates: true,
         allowOutsideClick: true
       }
     );


### PR DESCRIPTION
This minimizes the impact of modals and drawers that have the Power Select or any other content from the basic dropdown. Before this change, we would close the overlay if when clicked on the power select options. Considering this as bug, but really is a feature focus in that set of addons. 