### PR TITLE
fix: form input user selection highlight color in dark mode

### DIFF
--- a/packages/theme/src/components/forms/form-field.ts
+++ b/packages/theme/src/components/forms/form-field.ts
@@ -61,6 +61,7 @@ const input = tv({
     'focus:ring',
     'focus:outline-none',
     'focus:border-primary-400',
+    'selection:bg-content3',
     'disabled:border-default-200 disabled:text-default-500',
     'aria-invalid:border-danger-400',
     'aria-invalid:focus:ring-danger-400'


### PR DESCRIPTION
Adds a selection highlight color so that user selection text has color contrast in dark mode (and light)

### Before
![image](https://github.com/josemarluedke/frontile/assets/17834212/21f1390d-c1a0-4772-ab3c-5fc147f501dd)

### After
dark:
![image](https://github.com/josemarluedke/frontile/assets/17834212/049ecfd4-1c88-4e5e-b802-69c9320d1d1e)
light:
![image](https://github.com/josemarluedke/frontile/assets/17834212/003b6c9d-6910-4413-89e5-cfb495c7f3b2)

#### Note
Tried `bg-content4` but it was to dark for light mode

