### PR TITLE
feat: add startContent and endContent named blocks to input

### DIFF
--- a/packages/forms/src/components/input.gts
+++ b/packages/forms/src/components/input.gts
@@ -25,6 +25,10 @@ interface Args extends FormControlSharedArgs {
 
 interface InputSignature {
   Args: Args;
+  Blocks: {
+    startContent: [];
+    endContent: [];
+  };
   Element: HTMLInputElement;
 }
 
@@ -72,19 +76,35 @@ class Input extends Component<InputSignature> {
       @class={{this.classes.base class=@classes.base}}
       as |c|
     >
-      <input
-        {{on "input" this.handleOnInput}}
-        {{on "change" this.handleOnChange}}
-        id={{c.id}}
-        name={{@name}}
-        value={{@value}}
-        type={{this.type}}
-        class={{this.classes.input class=@classes.input}}
-        data-component="input"
-        aria-invalid={{if c.isInvalid "true"}}
-        aria-describedby={{c.describedBy @description c.isInvalid}}
-        ...attributes
-      />
+      <div class={{this.classes.innerContainer class=@classes.innerContainer}}>
+        {{#if (has-block "startContent")}}
+          <div class={{this.classes.startContent class=@classes.startContent}}>
+            {{yield to="startContent"}}
+          </div>
+        {{/if}}
+        <input
+          {{on "input" this.handleOnInput}}
+          {{on "change" this.handleOnChange}}
+          id={{c.id}}
+          name={{@name}}
+          value={{@value}}
+          type={{this.type}}
+          class={{this.classes.input
+            class=@classes.input
+            hasStartContent=(has-block "startContent")
+            hasEndContent=(has-block "endContent")
+          }}
+          data-component="input"
+          aria-invalid={{if c.isInvalid "true"}}
+          aria-describedby={{c.describedBy @description c.isInvalid}}
+          ...attributes
+        />
+        {{#if (has-block "endContent")}}
+          <div class={{this.classes.endContent class=@classes.endContent}}>
+            {{yield to="endContent"}}
+          </div>
+        {{/if}}
+      </div>
     </FormControl>
   </template>
 }

--- a/packages/forms/src/components/label.gts
+++ b/packages/forms/src/components/label.gts
@@ -44,21 +44,10 @@ class Label extends Component<LabelSignature> {
     });
   }
 
-  get baseClasses() {
-    const val = [];
-    if (this.args.class) val.push(this.args.class);
-    if (this.classes.base && Array.isArray(this.classes.base)) {
-      val.push(...this.classes.base);
-    } else if (this.classes.base) {
-      val.push(this.classes.base);
-    }
-    return val;
-  }
-
   <template>
     <label
       for={{@for}}
-      class={{this.classes.base class=this.baseClasses}}
+      class={{this.classes.base class=@class}}
       data-component="label"
       ...attributes
     >

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -58,6 +58,11 @@ const formFeedback = tv({
 const input = tv({
   slots: {
     base: '',
+    innerContainer: 'relative flex',
+    startContent:
+      'absolute inset-y-0 left-0 flex items-center pointer-events-none',
+    endContent:
+      'absolute inset-y-0 right-0 flex items-center pointer-events-none',
     input: [
       'appearance-none',
       'flex-1',
@@ -81,9 +86,15 @@ const input = tv({
   },
   variants: {
     size: {
-      sm: { input: 'p-2' },
-      md: { input: 'p-3' },
-      lg: { input: 'p-4' }
+      sm: { input: 'p-2', startContent: 'pl-2', endContent: 'pr-2' },
+      md: { input: 'p-3', startContent: 'pl-3', endContent: 'pr-3' },
+      lg: { input: 'p-4', startContent: 'pl-4', endContent: 'pr-4' }
+    },
+    hasStartContent: {
+      true: { input: 'ps-8' }
+    },
+    hasEndContent: {
+      true: { input: 'pe-10' }
     }
   },
   defaultVariants: {

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -1953,7 +1953,7 @@ const data: ComponentDoc[] = [
       {
         identifier: 'classes',
         type: {
-          type: 'SlotsToClasses&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span>>'
+          type: 'SlotsToClasses&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span> | <span class="hljs-string">\'innerContainer\'</span> | <span class="hljs-string">\'startContent\'</span> | <span class="hljs-string">\'endContent\'</span>>'
         },
         isRequired: false,
         isInternal: false,
@@ -2063,7 +2063,32 @@ const data: ComponentDoc[] = [
         tags: {}
       }
     ],
-    Blocks: [],
+    Blocks: [
+      {
+        identifier: 'startContent',
+        type: {
+          type: '<span class="hljs-built_in">Array</span>',
+          raw: '[]',
+          items: []
+        },
+        isRequired: true,
+        isInternal: false,
+        description: '',
+        tags: {}
+      },
+      {
+        identifier: 'endContent',
+        type: {
+          type: '<span class="hljs-built_in">Array</span>',
+          raw: '[]',
+          items: []
+        },
+        isRequired: true,
+        isInternal: false,
+        description: '',
+        tags: {}
+      }
+    ],
     Element: {
       identifier: 'Element',
       type: { type: 'HTMLInputElement' },
@@ -2166,7 +2191,7 @@ const data: ComponentDoc[] = [
       {
         identifier: 'classes',
         type: {
-          type: 'SlotsToClasses&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span>>'
+          type: 'SlotsToClasses&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span> | <span class="hljs-string">\'innerContainer\'</span> | <span class="hljs-string">\'startContent\'</span> | <span class="hljs-string">\'endContent\'</span>>'
         },
         isRequired: false,
         isInternal: false,
@@ -3534,7 +3559,7 @@ const data: ComponentDoc[] = [
       {
         identifier: 'classes',
         type: {
-          type: 'SlotsToClasses&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span>>'
+          type: 'SlotsToClasses&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span> | <span class="hljs-string">\'innerContainer\'</span> | <span class="hljs-string">\'startContent\'</span> | <span class="hljs-string">\'endContent\'</span>>'
         },
         isRequired: false,
         isInternal: false,
@@ -7440,6 +7465,17 @@ const data: ComponentDoc[] = [
         isInternal: true,
         description: '',
         tags: { internal: { name: 'internal', value: '' } }
+      },
+      {
+        identifier: 'internalDidClose',
+        type: {
+          type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
+          raw: '() => <span class="hljs-built_in">void</span>'
+        },
+        isRequired: true,
+        isInternal: false,
+        description: '',
+        tags: { ignore: { name: 'ignore', value: '' } }
       },
       {
         identifier: 'isOpen',

--- a/test-app/app/components/forms/form-example.gts
+++ b/test-app/app/components/forms/form-example.gts
@@ -13,6 +13,7 @@ import {
   RadioGroup,
   CheckboxGroup
 } from '@frontile/forms';
+import { Spinner } from '@frontile/utilities';
 
 const animals = [
   'cheetah',
@@ -45,6 +46,15 @@ export default class FormExample extends Component<FormExampleArgs> {
 
   <template>
     <Form @onChange={{this.onChange}} class="flex flex-1 flex-col gap-4">
+      <Input @name="field-0" @label="field 0">
+        <:startContent>
+          @
+        </:startContent>
+        <:endContent>
+          <Spinner @size="sm" />
+        </:endContent>
+      </Input>
+
       <Input
         @name="field-1"
         @label={{MyCustomLabel}}

--- a/test-app/tests/integration/components/forms/input-test.gts
+++ b/test-app/tests/integration/components/forms/input-test.gts
@@ -53,17 +53,24 @@ module('Integration | Component | @frontile/forms/Input', function (hooks) {
     assert.dom('[data-component="label"]').hasAttribute('for', id);
   });
 
-  // test('it renders yielded block next to input', async function (assert) {
-  //   await render(
-  //     <template>
-  //       <Input @label="Name" data-test-input>
-  //         <button type="submit">My Button</button>
-  //       </Input>
-  //     </template>
-  //   );
+  test('it renders named blocks startContent and endContent', async function (assert) {
+    const classes = { innerContainer: 'input-container' };
+    await render(
+      <template>
+        <Input @label="Name" @classes={{classes}}>
+          <:startContent>Start</:startContent>
+          <:endContent>End</:endContent>
+        </Input>
+      </template>
+    );
 
-  //   assert.dom('[data-test-input] + button').exists();
-  // });
+    assert.dom('[data-component="input"]').exists();
+    assert.dom('.input-container div:first-child').exists();
+    assert.dom('.input-container div:first-child').hasTextContaining('Start');
+
+    assert.dom('.input-container div:last-child').exists();
+    assert.dom('.input-container div:last-child').hasTextContaining('End');
+  });
 
   test('should mutate the value using onInput action', async function (assert) {
     const myInputValue = cell('Josemar');


### PR DESCRIPTION
allows rendering content before and after the input

<img width="525" alt="image" src="https://github.com/josemarluedke/frontile/assets/230476/5f650652-a454-49d2-9774-eec046a3686d">

Note, if content needs to be interactable, the following class needs to be added to the element `pointer-events-auto`.