### PR TITLE
Adds push dist so a developer can point to the main branch of this repo

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,19 @@
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wyvox/action-setup-pnpm@v3
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v2.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: frontile


### PR DESCRIPTION
With the v2 add-on format we can't easily point to the main branch of an add-on. The builds a dist branch after merges similar to other v2 add-ons. 