### PR TITLE
Fix typo in example code

### DIFF
--- a/packages/collections/src/components/dropdown.md
+++ b/packages/collections/src/components/dropdown.md
@@ -37,7 +37,7 @@ export default class Example extends Component {
 
       <d.Menu @onAction={{this.onAction}} @intent="primary" as |Item|>
         <Item @key="profile" @description="View my profile">
-          My Provile
+          My Profile
         </Item>
         <Item @key="settings" @shortcut="⌘⇧S">Settings</Item>
         <Item @key="notifications" @shortcut="⌘⇧N" @withDivider={{true}}>

--- a/packages/collections/src/components/listbox.md
+++ b/packages/collections/src/components/listbox.md
@@ -104,7 +104,7 @@ export default class DemoComponent extends Component {
         as |l|
       >
         <l.Item @key="profile" @description="View my profile">
-          My Provile
+          My Profile
         </l.Item>
         <l.Item @key="settings" @shortcut="⌘⇧S">Settings</l.Item>
         <l.Item @key="notifications" @shortcut="⌘⇧N" @withDivider={{true}}>

--- a/packages/forms/src/components/select.md
+++ b/packages/forms/src/components/select.md
@@ -124,7 +124,7 @@ export default class Example extends Component {
       as |l|
     >
       <l.Item @key="profile" @description="View my profile">
-        My Provile
+        My Profile
       </l.Item>
       <l.Item @key="settings" @shortcut="⌘⇧S">Settings</l.Item>
       <l.Item @key="notifications" @shortcut="⌘⇧N" @withDivider={{true}}>

--- a/test-app/app/components/buttons/dropdown.gts
+++ b/test-app/app/components/buttons/dropdown.gts
@@ -20,7 +20,7 @@ export default class Example extends Component {
 
       <d.Menu @onAction={{this.onAction}} @intent="primary" as |Item|>
         <Item @key="profile" @description="View my profile">
-          My Provile
+          My Profile
         </Item>
         <Item @key="settings" @shortcut="⌘⇧S">Settings</Item>
         <Item @key="notifications" @shortcut="⌘⇧N" @withDivider={{true}}>

--- a/test-app/app/components/buttons/listbox.gts
+++ b/test-app/app/components/buttons/listbox.gts
@@ -79,7 +79,7 @@ export default class Example extends Component {
       >
         <:default as |l|>
           <l.Item @key="profile" @description="View my profile">
-            My Provile
+            My Profile
           </l.Item>
           <l.Item @key="settings" @shortcut="⌘⇧S">Settings</l.Item>
           <l.Item @key="notifications" @shortcut="⌘⇧N" @withDivider={{true}}>

--- a/test-app/app/components/forms/select.gts
+++ b/test-app/app/components/forms/select.gts
@@ -106,7 +106,7 @@ export default class Example extends Component {
       as |l|
     >
       <l.Item @key="profile" @description="View my profile">
-        My Provile
+        My Profile
       </l.Item>
       <l.Item @key="settings" @shortcut="⌘⇧S">Settings</l.Item>
       <l.Item @key="notifications" @shortcut="⌘⇧N" @withDivider={{true}}>

--- a/test-app/tests/integration/components/collections/dropdown-test.ts
+++ b/test-app/tests/integration/components/collections/dropdown-test.ts
@@ -41,7 +41,7 @@ module(
               @disableTransitions={{true}}
               as |Item|
             >
-              <Item @key="profile">My Provile</Item>
+              <Item @key="profile">My Profile</Item>
               <Item @key="settings">Settings</Item>
             </d.Menu>
           </Dropdown>`
@@ -72,7 +72,7 @@ module(
               @destinationElementId="my-destination"
               as |Item|
             >
-              <Item @key="profile">My Provile</Item>
+              <Item @key="profile">My Profile</Item>
               <Item @key="settings">Settings</Item>
             </d.Menu>
           </Dropdown>`
@@ -110,7 +110,7 @@ module(
               @destinationElementId="my-destination"
               as |Item|
             >
-              <Item @key="profile">My Provile</Item>
+              <Item @key="profile">My Profile</Item>
               <Item @key="settings">Settings</Item>
             </d.Menu>
           </Dropdown>`
@@ -142,7 +142,7 @@ module(
               @destinationElementId="my-destination"
               as |Item|
             >
-              <Item @key="profile">My Provile</Item>
+              <Item @key="profile">My Profile</Item>
               <Item @key="settings">Settings</Item>
             </d.Menu>
           </Dropdown>`
@@ -169,7 +169,7 @@ module(
               @destinationElementId="my-destination"
               as |Item|
             >
-              <Item @key="profile">My Provile</Item>
+              <Item @key="profile">My Profile</Item>
               <Item @key="settings">Settings</Item>
             </d.Menu>
           </Dropdown>`
@@ -200,7 +200,7 @@ module(
               @destinationElementId="my-destination"
               as |Item|
             >
-              <Item @key="profile">My Provile</Item>
+              <Item @key="profile">My Profile</Item>
               <Item @key="settings">Settings</Item>
             </d.Menu>
           </Dropdown>`
@@ -227,7 +227,7 @@ module(
               @destinationElementId="my-destination"
               as |Item|
             >
-              <Item @key="profile">My Provile</Item>
+              <Item @key="profile">My Profile</Item>
               <Item @key="settings">Settings</Item>
             </d.Menu>
           </Dropdown>`


### PR DESCRIPTION
Changed Provile to Profile.

This pull request focuses on correcting a typo across multiple components and test files. The typo "My Provile" has been corrected to "My Profile" for consistency and accuracy.

Typo Corrections:

* [`packages/collections/src/components/dropdown.md`](diffhunk://#diff-2dfaeb01a608f5b596cbd988d369a83d4b3475acb2c3515d0c905ce9c7040ea4L40-R40): Corrected "My Provile" to "My Profile".
* [`packages/collections/src/components/listbox.md`](diffhunk://#diff-bfedd699806e03bfd749e21ebbb07d3dd24e107d5d8fb77e4231f4084a1c4424L107-R107): Corrected "My Provile" to "My Profile".
* [`packages/forms/src/components/select.md`](diffhunk://#diff-3067d3d1bf5dea49c699c2072e7e63353d256f49c9fda6a9f292695c4f046d1eL127-R127): Corrected "My Provile" to "My Profile".
* [`test-app/app/components/buttons/dropdown.gts`](diffhunk://#diff-a10f1b1409f6afe77da2514572d9224497c17057aefdfcef40c032697313a883L23-R23): Corrected "My Provile" to "My Profile".
* [`test-app/app/components/buttons/listbox.gts`](diffhunk://#diff-66a3c388136dba82ddd0b00075a492909018ea884359a2297fa811c8d19d40a2L82-R82): Corrected "My Provile" to "My Profile".
* [`test-app/app/components/forms/select.gts`](diffhunk://#diff-51e82599b5edc344407f9af1a046fbc6b9af4fd32fa88ac23e63dc477bde699dL109-R109): Corrected "My Provile" to "My Profile".

Test File Updates:

* [`test-app/tests/integration/components/collections/dropdown-test.ts`](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL44-R44): Corrected "My Provile" to "My Profile" in multiple test cases. [[1]](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL44-R44) [[2]](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL75-R75) [[3]](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL113-R113) [[4]](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL145-R145) [[5]](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL172-R172) [[6]](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL203-R203) [[7]](diffhunk://#diff-3782b48427bfcbf85666f4a80e725f591c4c3313277346b0955fde79cd666eedL230-R230)