### PR TITLE
chore: remove power-select export type Select

### DIFF
--- a/packages/forms-legacy/src/components/form-select.gts
+++ b/packages/forms-legacy/src/components/form-select.gts
@@ -10,7 +10,6 @@ import PowerSelectMultiple from 'ember-power-select/components/power-select-mult
 import FormField from './form-field';
 import { concat } from '@ember/helper';
 import { useStyles } from '@frontile/theme';
-export type { Select } from 'ember-power-select/components/power-select';
 
 export interface FormSelectArgs extends PowerSelectArgs {
   /** The input field label */


### PR DESCRIPTION
consuming apps end up with this:

```
WARNING in ../../.pnpm/@frontile+forms-legacy@0.17.0-alpha.14_@babel+core@7.25.7_@babel+runtime@7.25.7_@ember+string_heycksfjnhind7y3z4pbaaobum/node_modules/@frontile/forms-legacy/dist/components/form-select.js 10:0-68
export 'Select' (reexported as 'Select') was not found in 'ember-power-select/components/power-select' (possible exports: default)
 @ ../../.pnpm/@frontile+forms-legacy@0.17.0-alpha.14_@babel+core@7.25.7_@babel+runtime@7.25.7_@ember+string_heycksfjnhind7y3z4pbaaobum/node_modules/@frontile/forms-legacy/dist/_app_/components/form-select.js 1:0-72 1:0-72
 ```