### PR TITLE
fix: NotificationOptions & NotificationsService import

### DIFF
--- a/packages/notifications/docs/notifications-usage-demo/demo.md
+++ b/packages/notifications/docs/notifications-usage-demo/demo.md
@@ -89,7 +89,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-import {
+import type {
   NotificationOptions,
   NotificationsService
 } from '@frontile/notifications';


### PR DESCRIPTION
- They have to be imported as type.
- Otherwise TS gives following warning:

![Screenshot 2025-01-23 at 10 48 47](https://github.com/user-attachments/assets/0ea9c9a0-4f32-44b2-b6cf-519b9011ed10)
