### PR TITLE
Fix issue where the spread operator was used on an error string

### DIFF
--- a/packages/changeset-form/src/components/changeset-form/fields/base.ts
+++ b/packages/changeset-form/src/components/changeset-form/fields/base.ts
@@ -53,7 +53,11 @@ export default class ChangesetFormFieldsBase<
       if (Array.isArray(error.validation)) {
         const results = [...errors];
         error.validation.forEach((err) => {
-          results.push(...err);
+          if (typeof err === 'string') {
+            results.push(err);
+          } else if (Array.isArray(err)) {
+            results.push(...err);
+          }
         });
         return results;
       } else {


### PR DESCRIPTION
I updated from 0.14 -> 0.16.2 and all my validation errors from `ChangesetForm` started displaying as "e;r;r;o;r".  I didn't see a release branch for a hotfix, and it would be nice to get a 0.16.x patch out for this IMO.