### PR TITLE
Implement hint for ProgressBar

### DIFF
--- a/packages/status/src/components/progress-bar.gts
+++ b/packages/status/src/components/progress-bar.gts
@@ -93,7 +93,7 @@ class ProgressBar extends Component<ProgressBarSignature> {
   get classNames() {
     const { progressBar } = useStyles();
 
-    const { base, progress, label } = progressBar({
+    const { base, progress, label, hint } = progressBar({
       intent: this.args.intent || 'default',
       size: this.args.size,
       radius: this.args.radius,
@@ -103,7 +103,8 @@ class ProgressBar extends Component<ProgressBarSignature> {
     return {
       base: base({ class: this.args.class }),
       progress: progress(),
-      label: label()
+      label: label(),
+      hint: hint()
     };
   }
 
@@ -179,6 +180,11 @@ class ProgressBar extends Component<ProgressBarSignature> {
               {{this.formattedValueLabel}}
             </div>
           {{/if}}
+        </div>
+      {{/if}}
+      {{#if @hint}}
+        <div class={{this.classNames.hint}}>
+          {{@hint}}
         </div>
       {{/if}}
       <div class={{this.classNames.base}}>

--- a/packages/status/src/components/progress-bar.md
+++ b/packages/status/src/components/progress-bar.md
@@ -19,9 +19,7 @@ import { ProgressBar } from '@frontile/status';
 ```gjs preview
 import { ProgressBar } from '@frontile/status';
 
-<template>
-  <ProgressBar @progress={{50}} @label='Progress' />
-</template>
+<template><ProgressBar @progress={{50}} @label='Progress' /></template>
 ```
 
 ## ProgressBar Intents
@@ -154,6 +152,20 @@ import { hash } from '@ember/helper';
       @formatOptions={{(hash style='currency' currency='USD')}}
     />
   </div>
+</template>
+```
+
+## ProgressBar Hint
+
+```gjs preview
+import { ProgressBar } from '@frontile/status';
+
+<template>
+  <ProgressBar
+    @progress={{50}}
+    @label='Uploading'
+    @hint='Estimated time left'
+  />
 </template>
 ```
 

--- a/packages/theme/src/components/progress-bar.ts
+++ b/packages/theme/src/components/progress-bar.ts
@@ -4,7 +4,8 @@ const progressBar = tv({
   slots: {
     base: ['overflow-hidden w-full bg-content3 dark:bg-content2'],
     label: ['flex justify-between pb-1 gap-2 leading-tight'],
-    progress: ['']
+    progress: [''],
+    hint: ['text-default-400 text-xs pb-1']
   },
   variants: {
     isIndeterminate: {
@@ -33,12 +34,14 @@ const progressBar = tv({
       xs: {
         base: 'h-1',
         progress: 'h-1',
-        label: 'text-xs'
+        label: 'text-xs',
+        hint: 'text-xs'
       },
       sm: {
         base: 'h-2',
         progress: 'h-2',
-        label: 'text-sm'
+        label: 'text-sm',
+        hint: 'text-sm'
       },
       md: {
         base: 'h-4',
@@ -47,7 +50,8 @@ const progressBar = tv({
       lg: {
         base: 'h-8',
         progress: 'h-8',
-        label: 'text-lg'
+        label: 'text-lg',
+        hint: 'text-lg'
       }
     },
     radius: {


### PR DESCRIPTION
## Summary
- add hint slot to progress-bar styles
- render hint text in ProgressBar component
- document new `@hint` argument

## Testing
- `pnpm test` *(fails: Cleanup error)*

## Other

Attempt fixing #351

------
https://chatgpt.com/codex/tasks/task_b_683c75d6d75c832987c6e47a8748fbc0