### PR TITLE
feat: refactor theme plugin for TailwindCSS v4 compatibility

### DIFF
--- a/packages/theme/src/colors/semantic.ts
+++ b/packages/theme/src/colors/semantic.ts
@@ -1,12 +1,8 @@
-import resolveConfig from 'tailwindcss/resolveConfig';
-import tailwindConfig from 'tailwindcss/defaultConfig';
 import { readableColor } from 'color2k';
 import { swapColorValues } from './util';
 import { gray, blue, green, red, yellow } from './defaults';
 
 import type { ThemeColors, SemanticBaseColors } from './types';
-
-const tw = resolveConfig(tailwindConfig).theme;
 
 const base: SemanticBaseColors = {
   light: {
@@ -103,7 +99,7 @@ const themeColorsLight: ThemeColors = {
   },
   danger: {
     ...red,
-    foreground: tw.colors.white,
+    foreground: '#ffffff',
     DEFAULT: red[600]
   }
 };
@@ -122,7 +118,7 @@ const themeColorsDark: ThemeColors = {
   },
   success: {
     ...swapColorValues(green),
-    foreground: tw.colors.white,
+    foreground: '#ffffff',
     DEFAULT: green[500]
   },
   warning: {


### PR DESCRIPTION
## Summary
- Remove usage of deprecated `resolveConfig` function that was removed in TailwindCSS v4
- Update semantic color definitions to work without TailwindCSS config resolution
- Replace `tw.colors.white` references with direct `#ffffff` values

## Changes
- **src/colors/semantic.ts**: Remove `resolveConfig` and `tailwindConfig` imports
- **src/colors/semantic.ts**: Replace `tw.colors.white` with `'#ffffff'` in danger and success color definitions

## Test plan
- [ ] Verify the theme plugin builds without errors
- [ ] Test that semantic colors (danger, success) still render correctly
- [ ] Confirm compatibility with both TailwindCSS v3 and v4

🤖 Generated with [Claude Code](https://claude.ai/code)