### PR TITLE
feat: add default export for TailwindCSS v4 compatibility

### DIFF
--- a/packages/theme/src/plugin.ts
+++ b/packages/theme/src/plugin.ts
@@ -112,3 +112,4 @@ const checkboxIcon = `<svg viewBox="0 0 16 16" fill="white" xmlns="http://www.w3
 const radioIcon = `<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="6" stroke="white" stroke-width="3" fill="none" /></svg>`;
 
 export { frontile };
+export default frontile;


### PR DESCRIPTION
## Summary
- Add default export alongside named export in plugin.ts
- Ensures compatibility with TailwindCSS v4 module loading

## Test plan
- [ ] Verify plugin works with TailwindCSS v3
- [ ] Verify plugin works with TailwindCSS v4
- [ ] Check both CommonJS and ES module imports

🤖 Generated with [Claude Code](https://claude.ai/code)