### PR TITLE
Add basic form component docs

### DIFF
--- a/packages/forms/src/components/checkbox-group.md
+++ b/packages/forms/src/components/checkbox-group.md
@@ -3,6 +3,9 @@ label: New
 ---
 # Checkbox Group
 
+`CheckboxGroup` renders a label and arranges a set of `Checkbox` components.
+It manages each checkbox value individually and can display error messages
+like other form controls.
 
 ## Import 
 
@@ -11,6 +14,17 @@ import { CheckboxGroup } from '@frontile/forms';
 ```
 
 ## Usage
+
+```gts preview
+import { CheckboxGroup } from '@frontile/forms';
+
+<template>
+  <CheckboxGroup @label='Interests' as |C|>
+    <C.Checkbox @label='Music' />
+    <C.Checkbox @label='IoT' />
+  </CheckboxGroup>
+</template>
+```
 
 ## API
 

--- a/packages/forms/src/components/checkbox.md
+++ b/packages/forms/src/components/checkbox.md
@@ -3,6 +3,8 @@ label: New
 ---
 # Checkbox
 
+The `Checkbox` component manages a boolean value and integrates with
+`FormControl` to provide labels and error feedback.
 
 ## Import 
 
@@ -11,6 +13,37 @@ import { Checkbox } from '@frontile/forms';
 ```
 
 ## Usage
+
+```gts preview
+import { Checkbox } from '@frontile/forms';
+
+<template>
+  <Checkbox @label='Accept terms' />
+</template>
+```
+
+### Controlled checkbox
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Checkbox } from '@frontile/forms';
+
+export default class ControlledCheckbox extends Component {
+  @tracked agree = false;
+
+  update = (val: boolean) => (this.agree = val);
+
+  <template>
+    <Checkbox
+      @label='Accept terms'
+      @checked={{this.agree}}
+      @onChange={{this.update}}
+    />
+    <p class='mt-2'>Accepted: {{this.agree}}</p>
+  </template>
+}
+```
 
 ## API
 

--- a/packages/forms/src/components/form-control.md
+++ b/packages/forms/src/components/form-control.md
@@ -1,0 +1,33 @@
+---
+label: New
+---
+# FormControl
+
+Wrapper component that wires a label, description and feedback around a form
+field. It yields helpers for generating accessible IDs.
+
+## Import
+```js
+import { FormControl } from '@frontile/forms';
+```
+
+## Usage
+```gts preview
+import { FormControl, Input } from '@frontile/forms';
+
+<template>
+  <FormControl @label='Email' as |fc|>
+    <Input
+      id={{fc.id}}
+      aria-describedby={{fc.describedBy(true, true)}}
+      @isInvalid={{fc.isInvalid}}
+    />
+    <fc.Description id='email-desc'>We'll never share it.</fc.Description>
+    <fc.Feedback @messages='Invalid email' />
+  </FormControl>
+</template>
+```
+
+## API
+
+<Signature @package="forms" @component="FormControl" />

--- a/packages/forms/src/components/form-description.md
+++ b/packages/forms/src/components/form-description.md
@@ -1,0 +1,24 @@
+---
+label: New
+---
+# FormDescription
+
+Provides helper text for a form control. Usually used inside `FormControl`.
+
+## Import
+```js
+import { FormDescription } from '@frontile/forms';
+```
+
+## Usage
+```gts preview
+import { FormDescription } from '@frontile/forms';
+
+<template>
+  <FormDescription id='desc'>Enter your full name</FormDescription>
+</template>
+```
+
+## API
+
+<Signature @package="forms" @component="FormDescription" />

--- a/packages/forms/src/components/form-feedback.md
+++ b/packages/forms/src/components/form-feedback.md
@@ -1,0 +1,24 @@
+---
+label: New
+---
+# FormFeedback
+
+Displays validation messages for a form control.
+
+## Import
+```js
+import { FormFeedback } from '@frontile/forms';
+```
+
+## Usage
+```gts preview
+import { FormFeedback } from '@frontile/forms';
+
+<template>
+  <FormFeedback @messages='This field is required' />
+</template>
+```
+
+## API
+
+<Signature @package="forms" @component="FormFeedback" />

--- a/packages/forms/src/components/form.md
+++ b/packages/forms/src/components/form.md
@@ -3,6 +3,8 @@ label: New
 ---
 # Form
 
+`Form` collects values from its form controls and passes them to callbacks for
+`onChange` and `onSubmit` events.
 
 ## Import 
 
@@ -11,6 +13,17 @@ import { Form } from '@frontile/forms';
 ```
 
 ## Usage
+
+```gts preview
+import { Form, Input } from '@frontile/forms';
+
+<template>
+  <Form @onChange={{fn (data) (console.log data)}}>
+    <Input @name='firstName' />
+    <button type='submit'>Submit</button>
+  </Form>
+</template>
+```
 
 ## API
 

--- a/packages/forms/src/components/input.md
+++ b/packages/forms/src/components/input.md
@@ -3,6 +3,9 @@ label: New
 ---
 # Input
 
+The `Input` component wraps a native `<input>` element with a label and
+error feedback support. It can be used in controlled or uncontrolled modes
+and exposes slots to prepend or append custom content.
 
 ## Import 
 
@@ -11,6 +14,50 @@ import { Input } from '@frontile/forms';
 ```
 
 ## Usage
+
+```gts preview
+import { Input } from '@frontile/forms';
+
+<template>
+  <Input @label='Name' />
+</template>
+```
+
+### Controlled value
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Input } from '@frontile/forms';
+
+export default class ControlledExample extends Component {
+  @tracked name = '';
+
+  update = (val: string) => (this.name = val);
+
+  <template>
+    <Input @label='Name' @value={{this.name}} @onInput={{this.update}} />
+    <p class='mt-2'>{{this.name}}</p>
+  </template>
+}
+```
+
+### With start and end content
+
+```gts preview
+import { Input } from '@frontile/forms';
+
+<template>
+  <Input @label='Search'>
+    <:startContent>
+      <span class='mr-2'>🔍</span>
+    </:startContent>
+    <:endContent>
+      <span class='ml-2'>⌧</span>
+    </:endContent>
+  </Input>
+</template>
+```
 
 ## API
 

--- a/packages/forms/src/components/label.md
+++ b/packages/forms/src/components/label.md
@@ -1,0 +1,24 @@
+---
+label: New
+---
+# Label
+
+A styled `<label>` element used by `FormControl`.
+
+## Import
+```js
+import { Label } from '@frontile/forms';
+```
+
+## Usage
+```gts preview
+import { Label } from '@frontile/forms';
+
+<template>
+  <Label for='name'>Name</Label>
+</template>
+```
+
+## API
+
+<Signature @package="forms" @component="Label" />

--- a/packages/forms/src/components/radio-group.md
+++ b/packages/forms/src/components/radio-group.md
@@ -3,6 +3,8 @@ label: New
 ---
 # Radio Group
 
+`RadioGroup` groups multiple `Radio` components allowing the user to pick a
+single value.
 
 ## Import 
 
@@ -11,6 +13,17 @@ import { RadioGroup } from '@frontile/forms';
 ```
 
 ## Usage
+
+```gts preview
+import { RadioGroup } from '@frontile/forms';
+
+<template>
+  <RadioGroup @label='Interests' as |R|>
+    <R.Radio @label='Music' @value='music' />
+    <R.Radio @label='IoT' @value='iot' />
+  </RadioGroup>
+</template>
+```
 
 ## API
 

--- a/packages/forms/src/components/radio.md
+++ b/packages/forms/src/components/radio.md
@@ -3,6 +3,8 @@ label: New
 ---
 # Radio
 
+`Radio` represents a single option within a `RadioGroup`. Use it to
+select one value from a set.
 
 ## Import 
 
@@ -11,6 +13,14 @@ import { Radio } from '@frontile/forms';
 ```
 
 ## Usage
+
+```gts preview
+import { Radio } from '@frontile/forms';
+
+<template>
+  <Radio @label='Option' @value='option' />
+</template>
+```
 
 ## API
 

--- a/packages/forms/src/components/textarea.md
+++ b/packages/forms/src/components/textarea.md
@@ -3,6 +3,8 @@ label: New
 ---
 # Textarea
 
+`Textarea` works similarly to `Input` but renders a multiline `<textarea>`
+element.
 
 ## Import 
 
@@ -11,6 +13,14 @@ import { Textarea } from '@frontile/forms';
 ```
 
 ## Usage
+
+```gts preview
+import { Textarea } from '@frontile/forms';
+
+<template>
+  <Textarea @label='Bio' />
+</template>
+```
 
 ## API
 


### PR DESCRIPTION
## Summary
- document `Input` component with examples
- document `Checkbox` and `CheckboxGroup`
- document `Radio` and `RadioGroup`
- document `Textarea`
- document `Form` usage
- add docs for `FormControl`, `FormDescription`, `FormFeedback` and `Label`

## Testing
- `pnpm build`
- `pnpm test` *(fails: Browser exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_b_687ac0d7616c83299854bfd43e45699c