### PR TITLE
Add examples for forms components

### DIFF
--- a/packages/forms/src/components/checkbox-group.md
+++ b/packages/forms/src/components/checkbox-group.md
@@ -15,9 +15,10 @@ import { CheckboxGroup } from '@frontile/forms';
 ## Usage
 
 A checkbox group manages multiple related checkboxes and keeps the
-selected values in sync. The component yields a preconfigured
-`<Checkbox>` that automatically wires the `name` and `onChange`
-arguments.
+selected values in sync. The yielded `<Checkbox>` automatically wires
+the `name` and `onChange` arguments for you.
+
+### Basic Group
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -25,28 +26,68 @@ import { tracked } from '@glimmer/tracking';
 import { CheckboxGroup } from '@frontile/forms';
 
 export default class CheckboxGroupExample extends Component {
+  @tracked news = false;
   @tracked music = false;
-  @tracked iot = false;
 
+  updateNews = (v: boolean) => (this.news = v);
   updateMusic = (v: boolean) => (this.music = v);
-  updateIot = (v: boolean) => (this.iot = v);
 
   <template>
-    <CheckboxGroup @label='Interests' @orientation='horizontal' as |Checkbox|>
+    <CheckboxGroup @label='Notifications' as |Checkbox|>
+      <Checkbox
+        @name='news'
+        @label='News'
+        @checked={{this.news}}
+        @onChange={{this.updateNews}}
+      />
       <Checkbox
         @name='music'
         @label='Music'
         @checked={{this.music}}
         @onChange={{this.updateMusic}}
       />
-      <Checkbox
-        @name='iot'
-        @label='IoT'
-        @checked={{this.iot}}
-        @onChange={{this.updateIot}}
-      />
     </CheckboxGroup>
-    <p class='mt-4'>Music: {{this.music}}, IoT: {{this.iot}}</p>
+    <p class='mt-4'>News: {{this.news}}, Music: {{this.music}}</p>
+  </template>
+}
+```
+
+### Horizontal Layout
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { CheckboxGroup } from '@frontile/forms';
+
+const interests = ['Music', 'IoT', 'Gaming'];
+
+export default class HorizontalGroup extends Component {
+  @tracked selected = new Set<string>();
+
+  toggle = (label: string, value: boolean) => {
+    if (value) {
+      this.selected.add(label);
+    } else {
+      this.selected.delete(label);
+    }
+  };
+
+  <template>
+    <CheckboxGroup
+      @label='Interests'
+      @orientation='horizontal'
+      as |Checkbox|
+    >
+      {{#each interests as |label|}}
+        <Checkbox
+          @name={{label}}
+          @label={{label}}
+          @checked={{this.selected.has(label)}}
+          @onChange={{(v) => this.toggle(label, v)}}
+        />
+      {{/each}}
+    </CheckboxGroup>
+    <p class='mt-4'>Selected: {{this.selected}}</p>
   </template>
 }
 ```

--- a/packages/forms/src/components/checkbox-group.md
+++ b/packages/forms/src/components/checkbox-group.md
@@ -14,6 +14,43 @@ import { CheckboxGroup } from '@frontile/forms';
 
 ## Usage
 
+A checkbox group manages multiple related checkboxes and keeps the
+selected values in sync. The component yields a preconfigured
+`<Checkbox>` that automatically wires the `name` and `onChange`
+arguments.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { CheckboxGroup } from '@frontile/forms';
+
+export default class CheckboxGroupExample extends Component {
+  @tracked music = false;
+  @tracked iot = false;
+
+  updateMusic = (v: boolean) => (this.music = v);
+  updateIot = (v: boolean) => (this.iot = v);
+
+  <template>
+    <CheckboxGroup @label='Interests' @orientation='horizontal' as |Checkbox|>
+      <Checkbox
+        @name='music'
+        @label='Music'
+        @checked={{this.music}}
+        @onChange={{this.updateMusic}}
+      />
+      <Checkbox
+        @name='iot'
+        @label='IoT'
+        @checked={{this.iot}}
+        @onChange={{this.updateIot}}
+      />
+    </CheckboxGroup>
+    <p class='mt-4'>Music: {{this.music}}, IoT: {{this.iot}}</p>
+  </template>
+}
+```
+
 ## API
 
 <Signature @package="forms" @component="CheckboxGroup" />

--- a/packages/forms/src/components/checkbox.md
+++ b/packages/forms/src/components/checkbox.md
@@ -17,6 +17,8 @@ import { Checkbox } from '@frontile/forms';
 Checkboxes represent a boolean choice. Use the `checked` argument to
 control the state and `onChange` to be notified when it toggles.
 
+### Controlled Checkbox
+
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -36,6 +38,46 @@ export default class CheckboxExample extends Component {
     <p class='mt-4'>Accepted: {{this.accept}}</p>
   </template>
 }
+```
+
+### With Description and Error
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Checkbox } from '@frontile/forms';
+
+export default class CheckboxErrorExample extends Component {
+  @tracked value = false;
+
+  onChange = (v: boolean) => (this.value = v);
+
+  <template>
+    <Checkbox
+      @label='I agree to the terms'
+      @description='You must agree before continuing'
+      @checked={{this.value}}
+      @onChange={{this.onChange}}
+      @errors={{unless this.value "You must accept"}}
+      @isInvalid={{not this.value}}
+    />
+  </template>
+}
+```
+
+### Sizes and Disabled State
+
+```gts preview
+import { Checkbox } from '@frontile/forms';
+
+<template>
+  <div class='flex gap-4'>
+    <Checkbox @label='Small' @size='sm' />
+    <Checkbox @label='Medium' />
+    <Checkbox @label='Large' @size='lg' />
+    <Checkbox @label='Disabled' @isDisabled={{true}} />
+  </div>
+</template>
 ```
 
 ## API

--- a/packages/forms/src/components/checkbox.md
+++ b/packages/forms/src/components/checkbox.md
@@ -14,6 +14,30 @@ import { Checkbox } from '@frontile/forms';
 
 ## Usage
 
+Checkboxes represent a boolean choice. Use the `checked` argument to
+control the state and `onChange` to be notified when it toggles.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Checkbox } from '@frontile/forms';
+
+export default class CheckboxExample extends Component {
+  @tracked accept = false;
+
+  onChange = (v: boolean) => (this.accept = v);
+
+  <template>
+    <Checkbox
+      @label='Accept Terms'
+      @checked={{this.accept}}
+      @onChange={{this.onChange}}
+    />
+    <p class='mt-4'>Accepted: {{this.accept}}</p>
+  </template>
+}
+```
+
 ## API
 
 <Signature @package="forms" @component="Checkbox" />

--- a/packages/forms/src/components/form.md
+++ b/packages/forms/src/components/form.md
@@ -14,6 +14,28 @@ import { Form } from '@frontile/forms';
 
 ## Usage
 
+`<Form>` listens to `input` and `submit` events and passes a plain
+object with all form values to the provided `onChange` callback.
+
+```gts preview
+import Component from '@glimmer/component';
+import { Form, Input, Checkbox } from '@frontile/forms';
+
+export default class SimpleForm extends Component {
+  onChange = (data: FormResultData, type: 'input' | 'submit') => {
+    console.log(type, data);
+  };
+
+  <template>
+    <Form @onChange={{this.onChange}}>
+      <Input @name='firstName' @label='First name' />
+      <Checkbox @name='acceptTerms' @label='Accept terms' />
+      <button type='submit'>Submit</button>
+    </Form>
+  </template>
+}
+```
+
 ## API
 
 <Signature @package="forms" @component="Form" />

--- a/packages/forms/src/components/form.md
+++ b/packages/forms/src/components/form.md
@@ -17,6 +17,8 @@ import { Form } from '@frontile/forms';
 `<Form>` listens to `input` and `submit` events and passes a plain
 object with all form values to the provided `onChange` callback.
 
+### Basic Usage
+
 ```gts preview
 import Component from '@glimmer/component';
 import { Form, Input, Checkbox } from '@frontile/forms';
@@ -32,6 +34,32 @@ export default class SimpleForm extends Component {
       <Checkbox @name='acceptTerms' @label='Accept terms' />
       <button type='submit'>Submit</button>
     </Form>
+  </template>
+}
+```
+
+### Displaying Form Data
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Form, Input } from '@frontile/forms';
+
+export default class ShowDataForm extends Component {
+  @tracked data: FormResultData | undefined;
+
+  onChange = (d: FormResultData) => {
+    this.data = d;
+  };
+
+  <template>
+    <Form @onChange={{this.onChange}}>
+      <Input @name='email' @label='Email' />
+      <button type='submit'>Save</button>
+    </Form>
+    {{#if this.data}}
+      <pre class='mt-4'>{{JSON.stringify(this.data, null, 2)}}</pre>
+    {{/if}}
   </template>
 }
 ```

--- a/packages/forms/src/components/input.md
+++ b/packages/forms/src/components/input.md
@@ -17,6 +17,8 @@ import { Input } from '@frontile/forms';
 Inputs can be used in a controlled or uncontrolled way. They also
 support `startContent`, `endContent`, and an optional clear button.
 
+### Controlled Input
+
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -37,6 +39,59 @@ export default class InputExample extends Component {
       <:startContent>@</:startContent>
     </Input>
     <p class='mt-4'>{{this.name}}</p>
+  </template>
+}
+```
+
+### Uncontrolled Input
+
+```gts preview
+import { Input } from '@frontile/forms';
+
+<template>
+  <Input @label='Search' placeholder='Type to search...' />
+</template>
+```
+
+### Sizes and Custom Content
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Input } from '@frontile/forms';
+
+export default class InputSizes extends Component {
+  @tracked value = '';
+
+  onInput = (v: string) => (this.value = v);
+
+  <template>
+    <div class='space-y-4'>
+      <Input @label='Small' @size='sm' />
+      <Input
+        @label='With end icon'
+        @value={{this.value}}
+        @onInput={{this.onInput}}
+      >
+        <:endContent>
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            fill='none'
+            viewBox='0 0 24 24'
+            stroke-width='1.5'
+            stroke='currentColor'
+            class='w-4 h-4'
+          >
+            <path
+              stroke-linecap='round'
+              stroke-linejoin='round'
+              d='M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'
+            />
+          </svg>
+        </:endContent>
+      </Input>
+      <Input @label='Large' @size='lg' />
+    </div>
   </template>
 }
 ```

--- a/packages/forms/src/components/input.md
+++ b/packages/forms/src/components/input.md
@@ -14,6 +14,33 @@ import { Input } from '@frontile/forms';
 
 ## Usage
 
+Inputs can be used in a controlled or uncontrolled way. They also
+support `startContent`, `endContent`, and an optional clear button.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Input } from '@frontile/forms';
+
+export default class InputExample extends Component {
+  @tracked name = '';
+
+  onInput = (v: string) => (this.name = v);
+
+  <template>
+    <Input
+      @label='Name'
+      @value={{this.name}}
+      @onInput={{this.onInput}}
+      @isClearable={{true}}
+    >
+      <:startContent>@</:startContent>
+    </Input>
+    <p class='mt-4'>{{this.name}}</p>
+  </template>
+}
+```
+
 ## API
 
 <Signature @package="forms" @component="Input" />

--- a/packages/forms/src/components/radio-group.md
+++ b/packages/forms/src/components/radio-group.md
@@ -14,6 +14,35 @@ import { RadioGroup } from '@frontile/forms';
 
 ## Usage
 
+`<RadioGroup>` coordinates a set of radio buttons. The yielded
+`<Radio>` component already has the group `name` and change handler
+bound for you.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { RadioGroup } from '@frontile/forms';
+
+export default class RadioGroupExample extends Component {
+  @tracked value = 'music';
+
+  onChange = (v: string) => (this.value = v);
+
+  <template>
+    <RadioGroup
+      @label='Interests'
+      @value={{this.value}}
+      @onChange={{this.onChange}}
+      as |Radio|
+    >
+      <Radio @value='music' @label='Music' />
+      <Radio @value='iot' @label='IoT' />
+    </RadioGroup>
+    <p class='mt-4'>Selected: {{this.value}}</p>
+  </template>
+}
+```
+
 ## API
 
 <Signature @package="forms" @component="RadioGroup" />

--- a/packages/forms/src/components/radio-group.md
+++ b/packages/forms/src/components/radio-group.md
@@ -18,6 +18,8 @@ import { RadioGroup } from '@frontile/forms';
 `<Radio>` component already has the group `name` and change handler
 bound for you.
 
+### Controlled Group
+
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -39,6 +41,37 @@ export default class RadioGroupExample extends Component {
       <Radio @value='iot' @label='IoT' />
     </RadioGroup>
     <p class='mt-4'>Selected: {{this.value}}</p>
+  </template>
+}
+```
+
+### Horizontal Layout
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { RadioGroup } from '@frontile/forms';
+
+const options = ['Small', 'Medium', 'Large'];
+
+export default class HorizontalRadioGroup extends Component {
+  @tracked size = 'Medium';
+
+  onChange = (v: string) => (this.size = v);
+
+  <template>
+    <RadioGroup
+      @label='T-Shirt Size'
+      @orientation='horizontal'
+      @value={{this.size}}
+      @onChange={{this.onChange}}
+      as |Radio|
+    >
+      {{#each options as |o|}}
+        <Radio @value={{o}} @label={{o}} />
+      {{/each}}
+    </RadioGroup>
+    <p class='mt-4'>Size: {{this.size}}</p>
   </template>
 }
 ```

--- a/packages/forms/src/components/radio.md
+++ b/packages/forms/src/components/radio.md
@@ -17,6 +17,8 @@ import { Radio } from '@frontile/forms';
 Radios represent a single choice within a group. They are typically
 used inside `<RadioGroup>` but can also be used standalone.
 
+### Standalone Radio
+
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -37,6 +39,46 @@ export default class RadioExample extends Component {
     <p class='mt-4'>Selected: {{this.selected}}</p>
   </template>
 }
+```
+
+### With Description and Error
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Radio } from '@frontile/forms';
+
+export default class RadioErrorExample extends Component {
+  @tracked value: string | undefined;
+
+  onChange = (v: string) => (this.value = v);
+
+  <template>
+    <Radio
+      @label='Subscribe'
+      @description='Choose yes to receive updates'
+      @value='yes'
+      @checkedValue={{this.value}}
+      @onChange={{this.onChange}}
+      @errors={{unless this.value "Please select yes"}}
+      @isInvalid={{not this.value}}
+    />
+  </template>
+}
+```
+
+### Sizes
+
+```gts preview
+import { Radio } from '@frontile/forms';
+
+<template>
+  <div class='flex gap-4'>
+    <Radio @label='Small' @value='sm' @size='sm' />
+    <Radio @label='Medium' @value='md' />
+    <Radio @label='Large' @value='lg' @size='lg' />
+  </div>
+</template>
 ```
 
 ## API

--- a/packages/forms/src/components/radio.md
+++ b/packages/forms/src/components/radio.md
@@ -14,6 +14,31 @@ import { Radio } from '@frontile/forms';
 
 ## Usage
 
+Radios represent a single choice within a group. They are typically
+used inside `<RadioGroup>` but can also be used standalone.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Radio } from '@frontile/forms';
+
+export default class RadioExample extends Component {
+  @tracked selected: string | undefined;
+
+  onChange = (v: string) => (this.selected = v);
+
+  <template>
+    <Radio
+      @label='Option'
+      @value='option'
+      @checkedValue={{this.selected}}
+      @onChange={{this.onChange}}
+    />
+    <p class='mt-4'>Selected: {{this.selected}}</p>
+  </template>
+}
+```
+
 ## API
 
 <Signature @package="forms" @component="Radio" />

--- a/packages/forms/src/components/textarea.md
+++ b/packages/forms/src/components/textarea.md
@@ -14,6 +14,30 @@ import { Textarea } from '@frontile/forms';
 
 ## Usage
 
+`<Textarea>` behaves similarly to `<Input>` but allows multiline text.
+Use `onInput` or `onChange` to control the value.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Textarea } from '@frontile/forms';
+
+export default class TextareaExample extends Component {
+  @tracked bio = '';
+
+  onInput = (v: string) => (this.bio = v);
+
+  <template>
+    <Textarea
+      @label='Bio'
+      @value={{this.bio}}
+      @onInput={{this.onInput}}
+    />
+    <p class='mt-4'>{{this.bio}}</p>
+  </template>
+}
+```
+
 ## API
 
 <Signature @package="forms" @component="Textarea" />

--- a/packages/forms/src/components/textarea.md
+++ b/packages/forms/src/components/textarea.md
@@ -17,6 +17,8 @@ import { Textarea } from '@frontile/forms';
 `<Textarea>` behaves similarly to `<Input>` but allows multiline text.
 Use `onInput` or `onChange` to control the value.
 
+### Controlled Textarea
+
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -34,6 +36,31 @@ export default class TextareaExample extends Component {
       @onInput={{this.onInput}}
     />
     <p class='mt-4'>{{this.bio}}</p>
+  </template>
+}
+```
+
+### With Error and Sizes
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Textarea } from '@frontile/forms';
+
+export default class TextareaErrorExample extends Component {
+  @tracked value = '';
+
+  onChange = (v: string) => (this.value = v);
+
+  <template>
+    <Textarea
+      @label='Comment'
+      @value={{this.value}}
+      @onChange={{this.onChange}}
+      @size='lg'
+      @errors={{unless this.value "Please write something"}}
+      @isInvalid={{this.value === ''}}
+    />
   </template>
 }
 ```


### PR DESCRIPTION
## Summary
- document CheckboxGroup usage
- document Checkbox usage
- document Form component with onChange example
- document Input usage and clear button
- document RadioGroup and Radio
- document Textarea usage

## Testing
- `CHROME_BIN=$(which chrome) CI=true pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_687adf5e99e88329ac8c8f7f2b0b0ff4