### PR TITLE
feat(overlays): change closeOnOverlayElementClick default from fals…

### DIFF
--- a/packages/overlays/src/components/overlay.gts
+++ b/packages/overlays/src/components/overlay.gts
@@ -109,8 +109,10 @@ interface Args
 
   /**
    * Whether to close when the overlay element is clicked, used for modal and drawer components.
+   * This is set to true by default to allow "outside click" functionality to work properly.
+   * Most overlay content is wrapped with an inner element, preventing accidental closure.
    *
-   * @defaultValue false
+   * @defaultValue true
    */
   closeOnOverlayElementClick?: boolean;
 
@@ -170,7 +172,7 @@ class Overlay extends Component<OverlaySignature> {
   @action handleContentClick(event: MouseEvent): void {
     if (
       this.args.closeOnOutsideClick !== false &&
-      this.args.closeOnOverlayElementClick === true &&
+      this.args.closeOnOverlayElementClick !== false &&
       event.target === this.contentElement &&
       this.mouseDownContentElement == this.contentElement &&
       !hasNestedPortals(this.contentElement) &&
@@ -195,7 +197,7 @@ class Overlay extends Component<OverlaySignature> {
 
   @action
   handleContentMouseDown(event: MouseEvent): void {
-    if (this.args.closeOnOverlayElementClick === true) {
+    if (this.args.closeOnOverlayElementClick !== false) {
       this.mouseDownContentElement = event.target;
     }
   }

--- a/packages/overlays/src/components/overlay.md
+++ b/packages/overlays/src/components/overlay.md
@@ -500,6 +500,90 @@ export default class AnimationsAndTransitions extends Component {
 }
 ```
 
+### Outside Click vs Overlay Element Click
+
+The Overlay component has two different click-to-close mechanisms that work together:
+
+- **`@closeOnOutsideClick`** (default: `true`): Closes when clicking the backdrop/outside area
+- **`@closeOnOverlayElementClick`** (default: `true`): Closes when clicking the overlay element itself
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { Overlay } from '@frontile/overlays';
+import { Button } from '@frontile/buttons';
+import { on } from '@ember/modifier';
+
+export default class OverlayElementClick extends Component {
+  @tracked defaultOpen = false;
+  @tracked disabledOpen = false;
+
+  @action toggleDefault() {
+    this.defaultOpen = !this.defaultOpen;
+  }
+
+  @action toggleDisabled() {
+    this.disabledOpen = !this.disabledOpen;
+  }
+
+  <template>
+    <div class='flex flex-col gap-4'>
+      <div class='flex gap-2'>
+        <Button {{on 'click' this.toggleDefault}}>
+          Default Behavior
+        </Button>
+        <Button {{on 'click' this.toggleDisabled}}>
+          Overlay Element Click Disabled
+        </Button>
+      </div>
+
+      <div class='text-sm space-y-2'>
+        <p><strong>Default Behavior:</strong>
+          Try clicking on the overlay element (the outer container) vs the inner
+          content card.</p>
+        <p><strong>Disabled:</strong>
+          Only the backdrop (outside area) will close the overlay.</p>
+      </div>
+
+      <Overlay @isOpen={{this.defaultOpen}} @onClose={{this.toggleDefault}}>
+        <div class='bg-content1 p-6 rounded-lg shadow-lg max-w-md'>
+          <h3 class='font-semibold mb-2'>Default Behavior</h3>
+          <p class='mb-4 text-sm'>
+            <code>@closeOnOverlayElementClick={{true}}</code>
+            (default)
+          </p>
+          <p class='mb-4'>Clicking anywhere on the overlay element will close
+            it, but clicking this inner content card won't.</p>
+          <Button {{on 'click' this.toggleDefault}}>Close</Button>
+        </div>
+      </Overlay>
+
+      <Overlay
+        @isOpen={{this.disabledOpen}}
+        @onClose={{this.toggleDisabled}}
+        @closeOnOverlayElementClick={{false}}
+      >
+        <div class='bg-content1 p-6 rounded-lg shadow-lg max-w-md'>
+          <h3 class='font-semibold mb-2'>Overlay Element Click Disabled</h3>
+          <p class='mb-4 text-sm'>
+            <code>@closeOnOverlayElementClick={{false}}</code>
+          </p>
+          <p class='mb-4'>Only clicking the backdrop (outside area) will not
+            close this overlay because the overlay content element is on top of
+            backdrop.</p>
+          <Button {{on 'click' this.toggleDisabled}}>Close</Button>
+        </div>
+      </Overlay>
+    </div>
+  </template>
+}
+```
+
+> **Why is `@closeOnOverlayElementClick` `true` by default?**
+>
+> This option is set to `true` by default to make "outside click" functionality work intuitively. Most overlay content is wrapped with an inner element (like a card or dialog), which prevents accidental closure when clicking on the actual content. The overlay element itself acts as part of the "outside" area, allowing users to click anywhere around the content to dismiss the overlay.
+
 ## Important Notes
 
 ### Focus Requirements

--- a/packages/overlays/src/components/popover.gts
+++ b/packages/overlays/src/components/popover.gts
@@ -428,6 +428,7 @@ class Content extends Component<ContentSignature> {
       @class={{this.classNames}}
       @preventFocusRestore={{@preventFocusRestore}}
       @preventAutoFocus={{@preventAutoFocus}}
+      @closeOnOverlayElementClick={{false}}
       id={{@id}}
       ...attributes
       {{this.updateTriggerWidth @triggerWidth}}

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -590,7 +590,7 @@ const data: ComponentDoc[] = [
       {
         identifier: 'flipOptions',
         type: {
-          type: '{ mainAxis?: <span class="hljs-built_in">boolean</span>; crossAxis?: <span class="hljs-built_in">boolean</span>; fallbackPlacements?: Placement[]; fallbackStrategy?: <span class="hljs-string">\'bestFit\'</span> | <span class="hljs-string">\'initialPlacement\'</span>; fallbackAxisSideDirection?: <span class="hljs-string">\'none\'</span> | <span class="hljs-string">\'start\'</span> | <span class="hljs-string">\'end\'</span>; ... <span class="hljs-number">5</span> more ...; boundary?: Boundary; }',
+          type: '{ mainAxis?: <span class="hljs-built_in">boolean</span>; crossAxis?: <span class="hljs-built_in">boolean</span> | <span class="hljs-string">\'alignment\'</span>; fallbackPlacements?: Placement[]; fallbackStrategy?: <span class="hljs-string">\'bestFit\'</span> | <span class="hljs-string">\'initialPlacement\'</span>; fallbackAxisSideDirection?: <span class="hljs-string">\'none\'</span> | ... <span class="hljs-number">1</span> more ... | <span class="hljs-string">\'end\'</span>; ... <span class="hljs-number">5</span> more ...; boundary?: Boundary; }',
         },
         isRequired: false,
         isInternal: false,
@@ -1940,7 +1940,7 @@ const data: ComponentDoc[] = [
         identifier: 'onChange',
         type: {
           type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
-          raw: '(data: FormResultData, <span class="hljs-attr">eventType</span>: <span class="hljs-string">\'submit\'</span> | <span class="hljs-string">\'input\'</span>, <span class="hljs-attr">event</span>: Event | SubmitEvent) => <span class="hljs-built_in">void</span>',
+          raw: '(data: Data, <span class="hljs-attr">eventType</span>: <span class="hljs-string">\'submit\'</span> | <span class="hljs-string">\'input\'</span>, <span class="hljs-attr">event</span>: Event | SubmitEvent) => <span class="hljs-built_in">void</span>',
         },
         isRequired: true,
         isInternal: false,
@@ -3239,7 +3239,7 @@ const data: ComponentDoc[] = [
       {
         identifier: 'flipOptions',
         type: {
-          type: '{ mainAxis?: <span class="hljs-built_in">boolean</span>; crossAxis?: <span class="hljs-built_in">boolean</span>; fallbackPlacements?: Placement[]; fallbackStrategy?: <span class="hljs-string">\'bestFit\'</span> | <span class="hljs-string">\'initialPlacement\'</span>; fallbackAxisSideDirection?: <span class="hljs-string">\'none\'</span> | <span class="hljs-string">\'start\'</span> | <span class="hljs-string">\'end\'</span>; ... <span class="hljs-number">5</span> more ...; boundary?: Boundary; }',
+          type: '{ mainAxis?: <span class="hljs-built_in">boolean</span>; crossAxis?: <span class="hljs-built_in">boolean</span> | <span class="hljs-string">\'alignment\'</span>; fallbackPlacements?: Placement[]; fallbackStrategy?: <span class="hljs-string">\'bestFit\'</span> | <span class="hljs-string">\'initialPlacement\'</span>; fallbackAxisSideDirection?: <span class="hljs-string">\'none\'</span> | ... <span class="hljs-number">1</span> more ... | <span class="hljs-string">\'end\'</span>; ... <span class="hljs-number">5</span> more ...; boundary?: Boundary; }',
         },
         isRequired: false,
         isInternal: false,
@@ -7899,9 +7899,9 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          'Whether to close when the overlay element is clicked, used for modal and drawer components.',
-        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
-        defaultValue: '<span class="hljs-literal">false</span>',
+          'Whether to close when the overlay element is clicked, used for modal and drawer components.\nThis is set to true by default to allow "outside click" functionality to work properly.\nMost overlay content is wrapped with an inner element, preventing accidental closure.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'true' } },
+        defaultValue: '<span class="hljs-literal">true</span>',
       },
       {
         identifier: 'customContentModifier',
@@ -8196,7 +8196,7 @@ const data: ComponentDoc[] = [
       {
         identifier: 'flipOptions',
         type: {
-          type: '{ mainAxis?: <span class="hljs-built_in">boolean</span>; crossAxis?: <span class="hljs-built_in">boolean</span>; fallbackPlacements?: Placement[]; fallbackStrategy?: <span class="hljs-string">\'bestFit\'</span> | <span class="hljs-string">\'initialPlacement\'</span>; fallbackAxisSideDirection?: <span class="hljs-string">\'none\'</span> | <span class="hljs-string">\'start\'</span> | <span class="hljs-string">\'end\'</span>; ... <span class="hljs-number">5</span> more ...; boundary?: Boundary; }',
+          type: '{ mainAxis?: <span class="hljs-built_in">boolean</span>; crossAxis?: <span class="hljs-built_in">boolean</span> | <span class="hljs-string">\'alignment\'</span>; fallbackPlacements?: Placement[]; fallbackStrategy?: <span class="hljs-string">\'bestFit\'</span> | <span class="hljs-string">\'initialPlacement\'</span>; fallbackAxisSideDirection?: <span class="hljs-string">\'none\'</span> | ... <span class="hljs-number">1</span> more ... | <span class="hljs-string">\'end\'</span>; ... <span class="hljs-number">5</span> more ...; boundary?: Boundary; }',
         },
         isRequired: false,
         isInternal: false,


### PR DESCRIPTION
…e to true

  - Update Overlay component to default closeOnOverlayElementClick to true
  - Improve "outside click" UX by allowing clicks on overlay element to close
  - Add comprehensive documentation section explaining the behavior
  - Include interactive examples showing default vs disabled behavior

  BREAKING CHANGE: closeOnOverlayElementClick now defaults to true instead of false.
  Set @closeOnOverlayElementClick={{false}} to restore previous behavior.