### PR TITLE
bug: render non-breaking space on select when no placeholder is given

### DIFF
--- a/packages/forms/src/components/select.gts
+++ b/packages/forms/src/components/select.gts
@@ -483,7 +483,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                       class=@classes.placeholder
                     }}
                   >
-                    {{@placeholder}}
+                    {{#if @placeholder}}{{@placeholder}}{{else}}&nbsp;{{/if}}
                   </span>
                 {{/if}}
               </button>


### PR DESCRIPTION
This fixes the Select trigger height when no placeholder or selected item is given.