### PR TITLE
feat!: implement selectedKey/selectedKeys API for Select components

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,14 +17,14 @@
       "Bash(pnpm --filter utilities build)",
       "Bash(mkdir:*)",
       "Bash(mv:*)",
-      "Bash(pnpm --filter test-app test --filter \"PressEvent has correct structure\")",
-      "Bash(pnpm --filter test-app test --filter \"PressEvent continuePropagation\")",
-      "Bash(pnpm --filter test-app test --filter \"provides correct pointer type for keyboard\")",
-      "Bash(pnpm --filter test-app test --filter \"Modifier | press\" --reporter=verbose)",
       "Bash(npm test:*)",
-      "Bash(pnpm --filter test-app test -- --filter=\"NotificationCard\")",
       "Bash(pnpm --filter @frontile/notifications build)",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(rm:*)",
+      "Bash(pnpm --filter @frontile/forms build)",
+      "Bash(pnpm --filter @frontile/forms run lint:js)",
+      "Bash(pnpm --filter @frontile/forms run lint:js --fix)",
+      "Bash(pntml --filter @frontile/forms run lint:js)"
     ],
     "deny": []
   }

--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ const options = [
 ];
 
 export default class Example extends Component {
-  selectedKeys = [];
+  selectedKey = null;
 
-  onSelectionChange = (keys) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key) => {
+    this.selectedKey = key;
   };
 
   <template>
     <Select
       @items={{options}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
       @isFilterable={{true}}
     />

--- a/packages/forms/src/components/form.md
+++ b/packages/forms/src/components/form.md
@@ -28,7 +28,7 @@ import { Button } from '@frontile/buttons';
 
 export default class BasicForm extends Component {
   @tracked formData: FormResultData = {};
-  @tracked selectedCountry: string[] = [];
+  @tracked selectedCountry: string | null = null;
 
   countries = [
     { label: 'United States', key: 'us' },
@@ -42,8 +42,8 @@ export default class BasicForm extends Component {
     console.log(`Form ${eventType}:`, data);
   };
 
-  handleCountryChange = (selectedKeys: string[]) => {
-    this.selectedCountry = selectedKeys;
+  handleCountryChange = (selectedKey: string | null) => {
+    this.selectedCountry = selectedKey;
   };
 
   <template>
@@ -59,7 +59,7 @@ export default class BasicForm extends Component {
             @label='Country'
             @items={{this.countries}}
             @placeholder='Select your country'
-            @selectedKeys={{this.selectedCountry}}
+            @selectedKey={{this.selectedCountry}}
             @onSelectionChange={{this.handleCountryChange}}
           />
 
@@ -97,7 +97,7 @@ import { Button } from '@frontile/buttons';
 export default class RealtimeForm extends Component {
   @tracked inputData: FormResultData = {};
   @tracked submitData: FormResultData = {};
-  @tracked selectedRole: string[] = [];
+  @tracked selectedRole: string | null = null;
 
   roles = [
     { label: 'User', key: 'user' },
@@ -118,8 +118,8 @@ export default class RealtimeForm extends Component {
     }
   };
 
-  handleRoleChange = (selectedKeys: string[]) => {
-    this.selectedRole = selectedKeys;
+  handleRoleChange = (selectedKey: string | null) => {
+    this.selectedRole = selectedKey;
   };
 
   <template>
@@ -144,7 +144,7 @@ export default class RealtimeForm extends Component {
             @label='User Role'
             @items={{this.roles}}
             @placeholder='Select your role'
-            @selectedKeys={{this.selectedRole}}
+            @selectedKey={{this.selectedRole}}
             @onSelectionChange={{this.handleRoleChange}}
           />
 
@@ -208,7 +208,7 @@ import { Button } from '@frontile/buttons';
 export default class ComprehensiveForm extends Component {
   @tracked formData: FormResultData = {};
   @tracked lastEventType = '';
-  @tracked selectedSkillLevel: string[] = [];
+  @tracked selectedSkillLevel: string | null = null;
 
   countries = [
     'United States',
@@ -230,8 +230,8 @@ export default class ComprehensiveForm extends Component {
     this.lastEventType = eventType;
   };
 
-  handleSkillLevelChange = (selectedKeys: string[]) => {
-    this.selectedSkillLevel = selectedKeys;
+  handleSkillLevelChange = (selectedKey: string | null) => {
+    this.selectedSkillLevel = selectedKey;
   };
 
   <template>
@@ -265,7 +265,7 @@ export default class ComprehensiveForm extends Component {
             @label='Skill Level'
             @items={{this.skillLevels}}
             @placeholder='Select your skill level'
-            @selectedKeys={{this.selectedSkillLevel}}
+            @selectedKey={{this.selectedSkillLevel}}
             @onSelectionChange={{this.handleSkillLevelChange}}
           />
 
@@ -341,7 +341,7 @@ export default class ValidatedForm extends Component {
   @tracked errors: Record<string, string[]> = {};
   @tracked isSubmitting = false;
   @tracked submitMessage = '';
-  @tracked selectedAccountType: string[] = [];
+  @tracked selectedAccountType: string | null = null;
 
   accountTypes = [
     { label: 'Personal', key: 'personal' },
@@ -370,8 +370,8 @@ export default class ValidatedForm extends Component {
       v.regex(/\d/, 'Password must contain at least one number')
     ),
     accountType: v.pipe(
-      v.array(v.string()),
-      v.minLength(1, 'Please select an account type')
+      v.string(),
+      v.nonEmpty('Please select an account type')
     ),
     terms: v.pipe(
       v.boolean(),
@@ -469,10 +469,10 @@ export default class ValidatedForm extends Component {
     return this.submitMessage.includes('success');
   }
 
-  handleAccountTypeChange = (selectedKeys: string[]) => {
-    this.selectedAccountType = selectedKeys;
+  handleAccountTypeChange = (selectedKey: string | null) => {
+    this.selectedAccountType = selectedKey;
     // Clear errors when selection is made
-    if (selectedKeys.length > 0 && this.errors.accountType) {
+    if (selectedKey && this.errors.accountType) {
       const newErrors = { ...this.errors };
       delete newErrors.accountType;
       this.errors = newErrors;
@@ -513,7 +513,7 @@ export default class ValidatedForm extends Component {
             @label='Account Type'
             @items={{this.accountTypes}}
             @placeholder='Select account type'
-            @selectedKeys={{this.selectedAccountType}}
+            @selectedKey={{this.selectedAccountType}}
             @onSelectionChange={{this.handleAccountTypeChange}}
             @errors={{this.errors.accountType}}
             @isRequired={{true}}

--- a/packages/forms/src/components/select.md
+++ b/packages/forms/src/components/select.md
@@ -26,20 +26,20 @@ import { Select } from '@frontile/forms';
 const options = ['Option 1', 'Option 2', 'Option 3'];
 
 export default class BasicSingleSelect extends Component {
-  @tracked selectedKeys: string[] = [];
+  @tracked selectedKey: string | null = null;
 
-  onSelectionChange = (keys: string[]) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
   };
 
   <template>
     <Select
       @placeholder='Select an option'
       @items={{options}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
     />
-    <p>Selected: {{this.selectedKeys}}</p>
+    <p>Selected: {{this.selectedKey}}</p>
   </template>
 }
 ```
@@ -105,10 +105,10 @@ const countries = [
 ];
 
 export default class FilterableSelectExample extends Component {
-  @tracked selectedKeys: string[] = [];
+  @tracked selectedKey: string | null = null;
 
-  onSelectionChange = (keys: string[]) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
   };
 
   <template>
@@ -116,10 +116,10 @@ export default class FilterableSelectExample extends Component {
       @isFilterable={{true}}
       @placeholder='Select a country'
       @items={{countries}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
     />
-    <p>Selected: {{this.selectedKeys}}</p>
+    <p>Selected: {{this.selectedKey}}</p>
   </template>
 }
 ```
@@ -150,10 +150,10 @@ import { tracked } from '@glimmer/tracking';
 import { Select } from '@frontile/forms';
 
 export default class CustomUserSelect extends Component {
-  @tracked selectedKeys: string[] = [];
+  @tracked selectedKey: string | null = null;
 
-  onSelectionChange = (keys: string[]) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
   };
 
   <template>
@@ -161,7 +161,7 @@ export default class CustomUserSelect extends Component {
       @isFilterable={{true}}
       @placeholder='Select a user'
       @items={{users}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
     >
       <:item as |o|>
@@ -180,7 +180,7 @@ export default class CustomUserSelect extends Component {
         </o.Item>
       </:item>
     </Select>
-    <p class='mt-4'>Selected: {{this.selectedKeys}}</p>
+    <p class='mt-4'>Selected: {{this.selectedKey}}</p>
   </template>
 }
 
@@ -267,21 +267,21 @@ import { Select } from '@frontile/forms';
 const colors = ['Red', 'Green', 'Blue'];
 
 export default class ClearableSelectExample extends Component {
-  @tracked selectedKeys: string[] = [];
+  @tracked selectedKey: string | null = null;
 
-  onSelectionChange = (keys: string[]) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
   };
 
   <template>
     <Select
       @placeholder='Select a color'
       @items={{colors}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
       @isClearable={{true}}
     />
-    <p>Selected: {{this.selectedKeys}}</p>
+    <p>Selected: {{this.selectedKey}}</p>
   </template>
 }
 ```
@@ -298,21 +298,21 @@ import { Select } from '@frontile/forms';
 const sizes = ['Small', 'Medium', 'Large'];
 
 export default class LoadingSelectExample extends Component {
-  @tracked selectedKeys: string[] = [];
+  @tracked selectedKey: string | null = null;
 
-  onSelectionChange = (keys: string[]) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
   };
 
   <template>
     <Select
       @placeholder='Select a size'
       @items={{sizes}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
       @isLoading={{true}}
     />
-    <p>Selected: {{this.selectedKeys}}</p>
+    <p>Selected: {{this.selectedKey}}</p>
   </template>
 }
 ```
@@ -329,10 +329,10 @@ import { Select } from '@frontile/forms';
 const fruits = ['Apple', 'Banana', 'Cherry', 'Date'];
 
 export default class CustomContentBlocksSelect extends Component {
-  @tracked selectedKeys: string[] = [];
+  @tracked selectedKey: string | null = null;
 
-  onSelectionChange = (keys: string[]) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
   };
 
   <template>
@@ -340,7 +340,7 @@ export default class CustomContentBlocksSelect extends Component {
       @isFilterable={{true}}
       @placeholder='Search fruits...'
       @items={{fruits}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
     >
       <:startContent>
@@ -355,7 +355,7 @@ export default class CustomContentBlocksSelect extends Component {
         </div>
       </:emptyContent>
     </Select>
-    <p>Selected: {{this.selectedKeys}}</p>
+    <p>Selected: {{this.selectedKey}}</p>
   </template>
 }
 ```
@@ -374,20 +374,20 @@ import { NativeSelect } from '@frontile/forms';
 const options = ['Option 1', 'Option 2', 'Option 3'];
 
 export default class NativeSelectExample extends Component {
-  @tracked selectedKeys: string[] = [];
+  @tracked selectedKey: string | null = null;
 
-  onSelectionChange = (keys: string[]) => {
-    this.selectedKeys = keys;
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
   };
 
   <template>
     <NativeSelect
       @placeholder='Select an option'
       @items={{options}}
-      @selectedKeys={{this.selectedKeys}}
+      @selectedKey={{this.selectedKey}}
       @onSelectionChange={{this.onSelectionChange}}
     />
-    <p class='mt-4'>Selected: {{this.selectedKeys}}</p>
+    <p class='mt-4'>Selected: {{this.selectedKey}}</p>
   </template>
 }
 ```

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -2426,7 +2426,7 @@ const data: ComponentDoc[] = [
         identifier: 'onSelectionChange',
         type: {
           type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
-          raw: '(key: <span class="hljs-built_in">string</span>[]) => <span class="hljs-built_in">void</span>',
+          raw: '(<span class="hljs-function">(<span class="hljs-params">key: <span class="hljs-built_in">string</span></span>) =></span> <span class="hljs-built_in">void</span>) | (<span class="hljs-function">(<span class="hljs-params">keys: <span class="hljs-built_in">string</span>[]</span>) =></span> <span class="hljs-built_in">void</span>)',
         },
         isRequired: false,
         isInternal: false,
@@ -2440,6 +2440,14 @@ const data: ComponentDoc[] = [
         isInternal: false,
         description:
           'Placeholder text used when `allowEmpty` is set to `true`.',
+        tags: {},
+      },
+      {
+        identifier: 'selectedKey',
+        type: { type: '<span class="hljs-built_in">string</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
         tags: {},
       },
       {
@@ -3458,11 +3466,12 @@ const data: ComponentDoc[] = [
         identifier: 'onSelectionChange',
         type: {
           type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
-          raw: '(key: <span class="hljs-built_in">string</span>[]) => <span class="hljs-built_in">void</span>',
+          raw: '(<span class="hljs-function">(<span class="hljs-params">key: <span class="hljs-built_in">string</span></span>) =></span> <span class="hljs-built_in">void</span>) | (<span class="hljs-function">(<span class="hljs-params">keys: <span class="hljs-built_in">string</span>[]</span>) =></span> <span class="hljs-built_in">void</span>)',
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Callback fired when the selection changes in single mode.\nCallback fired when the selection changes in multiple mode.',
         tags: {},
       },
       {
@@ -3527,6 +3536,19 @@ const data: ComponentDoc[] = [
         defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
+        identifier: 'selectedKey',
+        type: { type: '<span class="hljs-built_in">string</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: 'The currently selected key for single selection mode.',
+        tags: {
+          deprecated: {
+            name: 'deprecated',
+            value: 'Use selectedKeys for multiple selection mode',
+          },
+        },
+      },
+      {
         identifier: 'selectedKeys',
         type: {
           type: '<span class="hljs-built_in">Array</span>',
@@ -3534,8 +3556,13 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description: 'The currently selected keys for multiple selection mode.',
+        tags: {
+          deprecated: {
+            name: 'deprecated',
+            value: 'Use selectedKey for single selection mode',
+          },
+        },
       },
       {
         identifier: 'selectionMode',
@@ -3547,7 +3574,7 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          "Determines the selection mode of the select component.\n- 'single': Only one item can be selected at a time.\n- 'multiple': Allows multiple selections.",
+          "Determines the selection mode of the select component.\n- 'single': Only one item can be selected at a time.\nDetermines the selection mode of the select component.\n- 'multiple': Allows multiple selections.",
         tags: { defaultValue: { name: 'defaultValue', value: "'single'" } },
         defaultValue: '<span class="hljs-string">\'single\'</span>',
       },
@@ -6472,7 +6499,9 @@ const data: ComponentDoc[] = [
     Args: [
       {
         identifier: 'notification',
-        type: { type: 'Notification' },
+        type: {
+          type: 'Notification&#x3C;Record&#x3C;<span class="hljs-built_in">string</span>, unknown>>',
+        },
         isRequired: true,
         isInternal: false,
         description: '',
@@ -6531,6 +6560,17 @@ const data: ComponentDoc[] = [
         isInternal: false,
         description:
           'Custom class name, it will override the default ones using Tailwind Merge library.',
+        tags: {},
+      },
+      {
+        identifier: 'onDismiss',
+        type: {
+          type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
+          raw: '(notification: Notification&#x3C;Record&#x3C;<span class="hljs-built_in">string</span>, unknown>>) => <span class="hljs-built_in">void</span>',
+        },
+        isRequired: false,
+        isInternal: false,
+        description: 'Callback called when a notification is dismissed',
         tags: {},
       },
       {
@@ -9024,6 +9064,14 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'description',
+        type: { type: '<span class="hljs-built_in">string</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: 'The content to display as the description.',
+        tags: {},
+      },
+      {
         identifier: 'formatOptions',
         type: {
           type: '<span class="hljs-built_in">Object</span>',
@@ -9126,14 +9174,6 @@ const data: ComponentDoc[] = [
         isInternal: false,
         description:
           'The display format of the value.\nValues are formatted as a percentage by default.',
-        tags: {},
-      },
-      {
-        identifier: 'hint',
-        type: { type: '<span class="hljs-built_in">string</span>' },
-        isRequired: false,
-        isInternal: false,
-        description: 'The content to display as the hint.',
         tags: {},
       },
       {

--- a/test-app/app/components/forms/select.gts
+++ b/test-app/app/components/forms/select.gts
@@ -40,9 +40,9 @@ const animalsAsOject = [
 ];
 
 export default class Example extends Component {
-  @tracked selectedKeys: string[] = [];
-  @tracked selectedKeys2: string[] = ['elephant'];
-  @tracked selectedKeys3: string[] = [];
+  @tracked selectedKeys: string[] = []; // Multiple selection
+  @tracked selectedKey2: string | null = 'elephant'; // Single selection
+  @tracked selectedKey3: string | null = null; // Single selection
 
   @action
   onAction(key: string) {
@@ -56,13 +56,13 @@ export default class Example extends Component {
   }
 
   @action
-  onSelectionChange2(keys: string[]) {
-    this.selectedKeys2 = keys;
+  onSelectionChange2(key: string | null) {
+    this.selectedKey2 = key;
   }
 
   @action
-  onSelectionChange3(keys: string[]) {
-    this.selectedKeys3 = keys;
+  onSelectionChange3(key: string | null) {
+    this.selectedKey3 = key;
   }
 
   <template>
@@ -90,18 +90,18 @@ export default class Example extends Component {
       @selectionMode="single"
       @items={{animalsAsOject}}
       @intent="primary"
-      @selectedKeys={{this.selectedKeys2}}
+      @selectedKey={{this.selectedKey2}}
       @onAction={{this.onAction}}
       @onSelectionChange={{this.onSelectionChange2}}
     />
     Values:
-    {{this.selectedKeys2}}
+    {{this.selectedKey2}}
     <Divider @class="my-8" />
     <Select
       @disableTransitions={{true}}
       @onAction={{this.onAction}}
       @disabledKeys={{(array "notifications")}}
-      @selectedKeys={{this.selectedKeys3}}
+      @selectedKey={{this.selectedKey3}}
       @onSelectionChange={{this.onSelectionChange3}}
       @isDisabled={{true}}
       as |l|
@@ -132,6 +132,6 @@ export default class Example extends Component {
       </l.Item>
     </Select>
     Values:
-    {{this.selectedKeys3}}
+    {{this.selectedKey3}}
   </template>
 }


### PR DESCRIPTION
Closes #378

BREAKING CHANGE: Select and NativeSelect components now use discriminated union types for selection:

- Single selection mode: Use `selectedKey` (string | null) instead of `selectedKeys` (string[])
- Multiple selection mode: Use `selectedKeys` (string[]) with `selectionMode="multiple"`
- Updated TypeScript interfaces enforce correct usage at compile time
- Added runtime warnings for incorrect API usage during migration
- Updated all tests, documentation, and examples to use new API

Migration guide:
- Replace `@selectedKeys={{array}}` with `@selectedKey={{string}}` for single selection
- Replace `onSelectionChange(keys: string[])` with `onSelectionChange(key: string | null)` for single selection
- Add `@selectionMode="multiple"` when using `selectedKeys` for multiple selections