### PR TITLE
fix: prevent double-triggering of onPress in mobile Safari

### DIFF
--- a/packages/utilities/src/modifiers/press.ts
+++ b/packages/utilities/src/modifiers/press.ts
@@ -169,6 +169,16 @@ const press = modifier<PressSignature>(
         return true;
       }
 
+      // In mobile Safari, both pointer and mouse events can fire for the same touch.
+      // If we have pointer event support, ignore mouse events entirely on touch devices
+      if (
+        eventPointerType === 'mouse' &&
+        'PointerEvent' in window &&
+        'ontouchstart' in window
+      ) {
+        return true;
+      }
+
       return false;
     };
 


### PR DESCRIPTION
Mobile Safari fires both pointer and mouse events for touch interactions, causing onPress handlers to trigger twice. This fix ignores mouse events on touch devices when pointer events are supported, preventing the double-trigger while maintaining compatibility.

Fixes #383.