### PR TITLE
feat(utilities): add element-based preventDefault logic to press modier

### DIFF
--- a/test-app/tests/integration/modifiers/utilities/press-test.gts
+++ b/test-app/tests/integration/modifiers/utilities/press-test.gts
@@ -4,8 +4,10 @@ import {
   render,
   triggerKeyEvent,
   triggerEvent,
-  find
+  find,
+  click
 } from '@ember/test-helpers';
+import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { press, type PressEvent } from '@frontile/utilities';
@@ -871,6 +873,559 @@ module(
         pressStates,
         [true, false],
         'Should track press state changes when interaction is cancelled'
+      );
+    });
+
+    test('PressEvent preventDefault method is available', async function (assert) {
+      let capturedPressEvent: PressEvent | null = null;
+
+      class PreventDefaultTestComponent extends Component {
+        onPress = (event: PressEvent) => {
+          capturedPressEvent = event;
+        };
+
+        <template>
+          <button
+            data-test-id="prevent-default-target"
+            {{press onPress=this.onPress}}
+          >
+            Prevent Default Test
+          </button>
+        </template>
+      }
+
+      await render(<template><PreventDefaultTestComponent /></template>);
+
+      await triggerEvent(
+        '[data-test-id="prevent-default-target"]',
+        'pointerdown'
+      );
+      await triggerEvent(
+        '[data-test-id="prevent-default-target"]',
+        'pointerup'
+      );
+
+      assert.ok(capturedPressEvent, 'Should receive PressEvent');
+      assert.strictEqual(
+        typeof capturedPressEvent!.preventDefault,
+        'function',
+        'preventDefault should be a function'
+      );
+
+      // Test that calling the method doesn't throw an error
+      try {
+        capturedPressEvent!.preventDefault();
+        assert.ok(
+          true,
+          'preventDefault method should be callable without errors'
+        );
+      } catch (error) {
+        assert.ok(
+          false,
+          `preventDefault method should not throw errors: ${error}`
+        );
+      }
+    });
+
+    // Element-specific preventDefault behavior tests
+    test('keyboard events on regular buttons prevent default', async function (assert) {
+      // Test that press events work correctly on buttons - this indirectly confirms preventDefault logic
+      let pressCount = 0;
+
+      class RegularButtonTestComponent extends Component {
+        onPress = () => {
+          pressCount++;
+        };
+
+        <template>
+          <button
+            data-test-id="regular-button-target"
+            {{press onPress=this.onPress}}
+          >
+            Regular Button
+          </button>
+        </template>
+      }
+
+      await render(<template><RegularButtonTestComponent /></template>);
+
+      await triggerKeyEvent(
+        '[data-test-id="regular-button-target"]',
+        'keydown',
+        'Enter'
+      );
+      await triggerKeyEvent(
+        '[data-test-id="regular-button-target"]',
+        'keyup',
+        'Enter'
+      );
+
+      assert.strictEqual(
+        pressCount,
+        1,
+        'Enter key should trigger press on regular button'
+      );
+    });
+
+    test('keyboard events on submit buttons do not prevent default', async function (assert) {
+      let preventDefaultCalled = false;
+      let originalPreventDefault: () => void;
+
+      class SubmitButtonTestComponent extends Component {
+        handleKeyDown = (event: KeyboardEvent) => {
+          originalPreventDefault = event.preventDefault.bind(event);
+          event.preventDefault = () => {
+            preventDefaultCalled = true;
+            originalPreventDefault();
+          };
+        };
+
+        <template>
+          <button
+            type="submit"
+            data-test-id="submit-button-target"
+            {{on "keydown" this.handleKeyDown}}
+            {{press}}
+          >
+            Submit Button
+          </button>
+        </template>
+      }
+
+      await render(<template><SubmitButtonTestComponent /></template>);
+
+      await triggerKeyEvent(
+        '[data-test-id="submit-button-target"]',
+        'keydown',
+        'Enter'
+      );
+
+      assert.notOk(
+        preventDefaultCalled,
+        'Enter key should not prevent default on submit button'
+      );
+    });
+
+    test('keyboard events on reset buttons do not prevent default', async function (assert) {
+      let preventDefaultCalled = false;
+      let originalPreventDefault: () => void;
+
+      class ResetButtonTestComponent extends Component {
+        handleKeyDown = (event: KeyboardEvent) => {
+          originalPreventDefault = event.preventDefault.bind(event);
+          event.preventDefault = () => {
+            preventDefaultCalled = true;
+            originalPreventDefault();
+          };
+        };
+
+        <template>
+          <button
+            type="reset"
+            data-test-id="reset-button-target"
+            {{on "keydown" this.handleKeyDown}}
+            {{press}}
+          >
+            Reset Button
+          </button>
+        </template>
+      }
+
+      await render(<template><ResetButtonTestComponent /></template>);
+
+      await triggerKeyEvent(
+        '[data-test-id="reset-button-target"]',
+        'keydown',
+        'Enter'
+      );
+
+      assert.notOk(
+        preventDefaultCalled,
+        'Enter key should not prevent default on reset button'
+      );
+    });
+
+    test('keyboard events on input elements do not prevent default', async function (assert) {
+      let preventDefaultCalled = false;
+      let originalPreventDefault: () => void;
+
+      class InputTestComponent extends Component {
+        handleKeyDown = (event: KeyboardEvent) => {
+          originalPreventDefault = event.preventDefault.bind(event);
+          event.preventDefault = () => {
+            preventDefaultCalled = true;
+            originalPreventDefault();
+          };
+        };
+
+        <template>
+          <input
+            data-test-id="input-target"
+            {{on "keydown" this.handleKeyDown}}
+            {{press}}
+          />
+        </template>
+      }
+
+      await render(<template><InputTestComponent /></template>);
+
+      await triggerKeyEvent(
+        '[data-test-id="input-target"]',
+        'keydown',
+        'Enter'
+      );
+
+      assert.notOk(
+        preventDefaultCalled,
+        'Enter key should not prevent default on input element'
+      );
+    });
+
+    test('keyboard events on anchor links do not prevent default', async function (assert) {
+      let preventDefaultCalled = false;
+      let originalPreventDefault: () => void;
+
+      class AnchorTestComponent extends Component {
+        handleKeyDown = (event: KeyboardEvent) => {
+          originalPreventDefault = event.preventDefault.bind(event);
+          event.preventDefault = () => {
+            preventDefaultCalled = true;
+            originalPreventDefault();
+          };
+        };
+
+        <template>
+          <a
+            href="#test"
+            data-test-id="anchor-target"
+            {{on "keydown" this.handleKeyDown}}
+            {{press}}
+          >
+            Test Link
+          </a>
+        </template>
+      }
+
+      await render(<template><AnchorTestComponent /></template>);
+
+      await triggerKeyEvent(
+        '[data-test-id="anchor-target"]',
+        'keydown',
+        'Enter'
+      );
+
+      assert.notOk(
+        preventDefaultCalled,
+        'Enter key should not prevent default on anchor link'
+      );
+    });
+
+    test('space key on checkbox input only triggers press events', async function (assert) {
+      let preventDefaultCalled = false;
+      let pressCount = 0;
+      let originalPreventDefault: () => void;
+
+      class CheckboxTestComponent extends Component {
+        handleKeyDown = (event: KeyboardEvent) => {
+          originalPreventDefault = event.preventDefault.bind(event);
+          event.preventDefault = () => {
+            preventDefaultCalled = true;
+            originalPreventDefault();
+          };
+        };
+
+        onPress = () => {
+          pressCount++;
+        };
+
+        <template>
+          <input
+            type="checkbox"
+            data-test-id="checkbox-target"
+            {{on "keydown" this.handleKeyDown}}
+            {{press onPress=this.onPress}}
+          />
+        </template>
+      }
+
+      await render(<template><CheckboxTestComponent /></template>);
+
+      // Space should work on checkbox
+      await triggerKeyEvent('[data-test-id="checkbox-target"]', 'keydown', ' ');
+      await triggerKeyEvent('[data-test-id="checkbox-target"]', 'keyup', ' ');
+
+      assert.notOk(
+        preventDefaultCalled,
+        'Space key should not prevent default on checkbox'
+      );
+      assert.strictEqual(
+        pressCount,
+        1,
+        'Space should trigger press event on checkbox'
+      );
+
+      // Reset for Enter test
+      preventDefaultCalled = false;
+      pressCount = 0;
+
+      // Enter should prevent default and not trigger press
+      await triggerKeyEvent(
+        '[data-test-id="checkbox-target"]',
+        'keydown',
+        'Enter'
+      );
+
+      assert.ok(
+        preventDefaultCalled,
+        'Enter key should prevent default on checkbox'
+      );
+    });
+
+    test('space key on radio input only triggers press events', async function (assert) {
+      let preventDefaultCalled = false;
+      let pressCount = 0;
+      let originalPreventDefault: () => void;
+
+      class RadioTestComponent extends Component {
+        handleKeyDown = (event: KeyboardEvent) => {
+          originalPreventDefault = event.preventDefault.bind(event);
+          event.preventDefault = () => {
+            preventDefaultCalled = true;
+            originalPreventDefault();
+          };
+        };
+
+        onPress = () => {
+          pressCount++;
+        };
+
+        <template>
+          <input
+            type="radio"
+            name="test"
+            data-test-id="radio-target"
+            {{on "keydown" this.handleKeyDown}}
+            {{press onPress=this.onPress}}
+          />
+        </template>
+      }
+
+      await render(<template><RadioTestComponent /></template>);
+
+      // Space should work on radio
+      await triggerKeyEvent('[data-test-id="radio-target"]', 'keydown', ' ');
+      await triggerKeyEvent('[data-test-id="radio-target"]', 'keyup', ' ');
+
+      assert.notOk(
+        preventDefaultCalled,
+        'Space key should not prevent default on radio'
+      );
+      assert.strictEqual(
+        pressCount,
+        1,
+        'Space should trigger press event on radio'
+      );
+
+      // Reset for Enter test
+      preventDefaultCalled = false;
+      pressCount = 0;
+
+      // Enter should prevent default and not trigger press
+      await triggerKeyEvent(
+        '[data-test-id="radio-target"]',
+        'keydown',
+        'Enter'
+      );
+
+      assert.ok(
+        preventDefaultCalled,
+        'Enter key should prevent default on radio'
+      );
+    });
+
+    test('keyboard events on div elements prevent default', async function (assert) {
+      // We'll test this by checking if the press event fires when Enter is pressed
+      // If preventDefault is called correctly, the press event should still fire
+      let pressCount = 0;
+
+      class DivTestComponent extends Component {
+        onPress = () => {
+          pressCount++;
+        };
+
+        <template>
+          <div
+            data-test-id="div-target"
+            tabindex="0"
+            {{press onPress=this.onPress}}
+          >
+            Div with tabindex
+          </div>
+        </template>
+      }
+
+      await render(<template><DivTestComponent /></template>);
+
+      await triggerKeyEvent('[data-test-id="div-target"]', 'keydown', 'Enter');
+      await triggerKeyEvent('[data-test-id="div-target"]', 'keyup', 'Enter');
+
+      assert.strictEqual(
+        pressCount,
+        1,
+        'Enter key should trigger press on div element (preventDefault should be called correctly)'
+      );
+    });
+
+    test('regular button (submit type) with both press modifier and click handler', async function (assert) {
+      let pressCount = 0;
+      let clickCount = 0;
+
+      class ButtonWithClickComponent extends Component {
+        onPress = () => {
+          pressCount++;
+        };
+
+        onClick = () => {
+          clickCount++;
+        };
+
+        <template>
+          <button
+            data-test-id="button-with-click-target"
+            {{press onPress=this.onPress}}
+            {{on "click" this.onClick}}
+          >
+            Button with Press and Click
+          </button>
+        </template>
+      }
+
+      await render(<template><ButtonWithClickComponent /></template>);
+
+      // Test mouse click - both press and click should fire
+      await click('[data-test-id="button-with-click-target"]');
+
+      assert.strictEqual(
+        pressCount,
+        1,
+        'Press event should fire on mouse click'
+      );
+      assert.strictEqual(
+        clickCount,
+        1,
+        'Click event should fire on mouse click'
+      );
+
+      // Reset counters
+      pressCount = 0;
+      clickCount = 0;
+
+      // Test keyboard interaction - both should fire because regular buttons have type="submit"
+      // which means preventDefault is NOT called, allowing synthetic click events
+      await triggerKeyEvent(
+        '[data-test-id="button-with-click-target"]',
+        'keydown',
+        'Enter'
+      );
+      await triggerKeyEvent(
+        '[data-test-id="button-with-click-target"]',
+        'keyup',
+        'Enter'
+      );
+
+      assert.strictEqual(pressCount, 1, 'Press event should fire on Enter key');
+      assert.strictEqual(
+        clickCount,
+        0,
+        'Click event should NOT fire on Enter key - even though regular buttons are type="submit"'
+      );
+
+      // Reset counters
+      pressCount = 0;
+      clickCount = 0;
+
+      // Test space key - same behavior
+      await triggerKeyEvent(
+        '[data-test-id="button-with-click-target"]',
+        'keydown',
+        ' '
+      );
+      await triggerKeyEvent(
+        '[data-test-id="button-with-click-target"]',
+        'keyup',
+        ' '
+      );
+
+      assert.strictEqual(pressCount, 1, 'Press event should fire on Space key');
+      assert.strictEqual(
+        clickCount,
+        0,
+        'Click event should NOT fire on Space key - even though regular buttons are type="submit"'
+      );
+    });
+
+    test('explicit button type="button" with both press modifier and click handler', async function (assert) {
+      let pressCount = 0;
+      let clickCount = 0;
+
+      class ExplicitButtonComponent extends Component {
+        onPress = () => {
+          pressCount++;
+        };
+
+        onClick = () => {
+          clickCount++;
+        };
+
+        <template>
+          <button
+            type="button"
+            data-test-id="explicit-button-target"
+            {{press onPress=this.onPress}}
+            {{on "click" this.onClick}}
+          >
+            Explicit Button Type
+          </button>
+        </template>
+      }
+
+      await render(<template><ExplicitButtonComponent /></template>);
+
+      // Test mouse click - both should fire
+      await click('[data-test-id="explicit-button-target"]');
+
+      assert.strictEqual(
+        pressCount,
+        1,
+        'Press event should fire on mouse click'
+      );
+      assert.strictEqual(
+        clickCount,
+        1,
+        'Click event should fire on mouse click'
+      );
+
+      // Reset counters
+      pressCount = 0;
+      clickCount = 0;
+
+      // Test keyboard - only press should fire because type="button" gets preventDefault
+      await triggerKeyEvent(
+        '[data-test-id="explicit-button-target"]',
+        'keydown',
+        'Enter'
+      );
+      await triggerKeyEvent(
+        '[data-test-id="explicit-button-target"]',
+        'keyup',
+        'Enter'
+      );
+
+      assert.strictEqual(pressCount, 1, 'Press event should fire on Enter key');
+      assert.strictEqual(
+        clickCount,
+        0,
+        'Click event should NOT fire on Enter key because type="button" gets preventDefault'
       );
     });
   }


### PR DESCRIPTION

 Implement intelligent preventDefault handling in the press modifier:

 - Add preventDefault() method to PressEvent class for manual control
 - Add smart element-based preventDefault logic that:
   * Preserves native behavior for form inputs and anchor links
   * Prevents default for regular buttons but allows submit/reset
   * Handles checkbox/radio special key validation (space only)
   * Prevents default for other focusable elements
 - Add comprehensive test coverage for all element types and scenarios

 This is based on React Aria approach to the press event.