### PR TITLE
Fix selectOptionByKey reselect behavior

### DIFF
--- a/packages/forms/src/test-support.ts
+++ b/packages/forms/src/test-support.ts
@@ -39,7 +39,12 @@ function changeOption(
     );
   }
 
-  const option = select.querySelector(`[data-key="${key}"]`) as
+  const escapedKey =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+      ? CSS.escape(key)
+      : key;
+
+  const option = select.querySelector(`[data-key="${escapedKey}"]`) as
     | HTMLOptionElement
     | undefined;
   if (!option) {

--- a/test-app/tests/integration/components/forms/native-select-test.gts
+++ b/test-app/tests/integration/components/forms/native-select-test.gts
@@ -169,6 +169,37 @@ module(
       assert.equal(selectedKeys.current.length, 0);
     });
 
+    test('selectOptionByKey handles selecting the same option twice', async function (
+      assert
+    ) {
+      const animals = ['cheetah "fast"', 'crocodile'];
+      const selectedKey = cell<string | null>('cheetah "fast"');
+      const calls: (string | null)[] = [];
+
+      const onSelectionChange = (key: string | null) => {
+        calls.push(key);
+        selectedKey.current = key;
+      };
+
+      await render(
+        <template>
+          <NativeSelect
+            @items={{animals}}
+            @selectedKey={{selectedKey.current}}
+            @onSelectionChange={{onSelectionChange}}
+          />
+        </template>
+      );
+
+      await selectOptionByKey('[data-test-id="native-select"]', 'cheetah "fast"');
+
+      assert.deepEqual(
+        calls,
+        ['cheetah "fast"'],
+        'should trigger selection even when the option is already selected'
+      );
+    });
+
     test('it render dynamic items yielding of item', async function (assert) {
       const animals = [
         { key: 'cheetah-key', value: 'cheetah-value' },


### PR DESCRIPTION
## Summary
- escape option lookup keys with `CSS.escape` in the test-support helpers so special characters are handled safely
- add a regression test ensuring `selectOptionByKey` re-selects an already selected option without errors

## Testing
- `CI=1 pnpm --filter test-app test -- --filter "selectOptionByKey handles selecting the same option twice" --reporter dot`


------
https://chatgpt.com/codex/tasks/task_b_68cc87b3b5088329a022cb95c07bd666