### PR TITLE
chore: add separate actions for onChange and onSubmit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /packages/**/libpeerconnection.log
 /packages/**/npm-debug.log*
 /packages/**/testem.log
+.DS_Store
 yarn-error.log
 
 # ember-try

--- a/docs/migration/changeset-form.md
+++ b/docs/migration/changeset-form.md
@@ -570,7 +570,10 @@ const FormSchema = v.object({
 ### Step 3: Modern Form Implementation
 
 ```hbs
-<Form @onChange={{this.handleFormChange}}>
+<Form
+  @onChange={{this.handleFormChange}}
+  @onSubmit={{this.handleFormSubmit}}
+>
   <div class='flex flex-col gap-4'>
     <Input
       @name='firstName'
@@ -647,18 +650,13 @@ export default class MyFormComponent extends Component {
     )
   });
 
-  handleFormChange = (data, eventType) => {
+  handleFormChange = (data: FormResultData, event: Event) => {
     this.formData = data;
-
-    if (eventType === 'submit') {
-      this.handleSubmit(data);
-    } else {
-      // Real-time validation
-      this.validateForm(data);
-    }
+    // Real-time validation
+    this.validateForm(data);
   };
 
-  validateForm = (data) => {
+  validateForm = (data: FormResultData) => {
     const validationData = {
       ...data,
       country: this.selectedCountry
@@ -689,7 +687,7 @@ export default class MyFormComponent extends Component {
     }
   };
 
-  handleSubmit = async (data) => {
+  handleFormSubmit = async (data: FormResultData, event: SubmitEvent) => {
     this.isSubmitting = true;
     this.errors = {};
 
@@ -719,7 +717,7 @@ export default class MyFormComponent extends Component {
     }
   };
 
-  formatValiError(valiError) {
+  formatValiError(valiError: v.ValiError) {
     const errors = {};
 
     for (const issue of valiError.issues) {
@@ -735,7 +733,7 @@ export default class MyFormComponent extends Component {
     return errors;
   }
 
-  setSelectedCountry = (key) => {
+  setSelectedCountry = (key: string | null) => {
     this.selectedCountry = key;
     // Clear country errors when selection is made
     if (key && this.errors.country) {

--- a/docs/migration/forms-legacy.md
+++ b/docs/migration/forms-legacy.md
@@ -496,7 +496,10 @@ onChange = (key) => {
 The new Form component provides automatic form data extraction and handling.
 
 ```hbs
-<Form @onChange={{this.handleFormChange}} @onSubmit={{this.handleSubmit}}>
+<Form
+  @onChange={{this.handleFormChange}}
+  @onSubmit={{this.handleFormSubmit}}
+>
   <Input @name='firstName' @label='First Name' />
   <Input @name='lastName' @label='Last Name' />
   <Textarea @name='bio' @label='Bio' />
@@ -506,17 +509,13 @@ The new Form component provides automatic form data extraction and handling.
 ```
 
 ```js
-handleFormChange = (data, eventType) => {
+handleFormChange = (data) => {
   // data contains all form field values automatically
-  console.log(data); // { firstName: "John", lastName: "Doe", bio: "..." }
-
-  if (eventType === 'input') {
-    // Handle real-time changes
-    this.formData = data;
-  }
+  this.formData = data;
+  console.log('Realtime data:', data);
 };
 
-handleSubmit = (data) => {
+handleFormSubmit = (data) => {
   // Handle form submission
   console.log('Submitting:', data);
 };

--- a/packages/forms/src/components/form.gts
+++ b/packages/forms/src/components/form.gts
@@ -8,10 +8,7 @@ type FormResultData = ReturnType<typeof dataFrom>;
 interface FormSignature {
   Element: HTMLFormElement;
   Args: {
-    onChange?: (
-      data: FormResultData,
-      event: Event
-    ) => void;
+    onChange?: (data: FormResultData, event: Event) => void;
 
     onSubmit: (
       data: FormResultData,
@@ -41,7 +38,7 @@ class Form extends Component<FormSignature> {
       const data = dataFrom(event);
       await this.args.onSubmit(data, event);
     }
-  };
+  }
 
   <template>
     <form

--- a/packages/forms/src/components/form.md
+++ b/packages/forms/src/components/form.md
@@ -6,7 +6,7 @@ imports:
 
 # Form
 
-A powerful form wrapper component that automatically handles form data extraction and provides real-time updates on both input and submit events. It uses `form-data-utils` under the hood to serialize form data efficiently and supports all native HTML form elements as well as Frontile form components.
+A powerful form wrapper component that automatically handles form data extraction and provides real-time updates via dedicated `@onChange` and `@onSubmit` callbacks. It uses `form-data-utils` under the hood to serialize form data efficiently and supports all native HTML form elements as well as Frontile form components.
 
 ## Import
 
@@ -28,6 +28,7 @@ import { Button } from '@frontile/buttons';
 
 export default class BasicForm extends Component {
   @tracked formData: FormResultData = {};
+  @tracked submittedData: FormResultData = {};
   @tracked selectedCountry: string | null = null;
 
   countries = [
@@ -37,9 +38,14 @@ export default class BasicForm extends Component {
     { label: 'Australia', key: 'au' }
   ];
 
-  handleFormChange = (data: FormResultData, eventType: 'input' | 'submit') => {
+  handleFormChange = (data: FormResultData, event: Event) => {
     this.formData = data;
-    console.log(`Form ${eventType}:`, data);
+    console.log('Form input:', { data, event });
+  };
+
+  handleFormSubmit = (data: FormResultData, event: SubmitEvent) => {
+    this.submittedData = data;
+    console.log('Form submit:', { data, event });
   };
 
   handleCountryChange = (selectedKey: string | null) => {
@@ -48,7 +54,10 @@ export default class BasicForm extends Component {
 
   <template>
     <div class='flex flex-col gap-4 w-80'>
-      <Form @onChange={{this.handleFormChange}}>
+      <Form
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+      >
         <div class='flex flex-col gap-4'>
           <Input @name='firstName' @label='First Name' />
           <Input @name='lastName' @label='Last Name' />
@@ -69,9 +78,16 @@ export default class BasicForm extends Component {
         </div>
       </Form>
 
-      <div class='p-4 bg-default-50 rounded'>
-        <h4 class='font-medium mb-2'>Current Form Data:</h4>
-        <pre class='text-sm'>{{JSON.stringify this.formData null 2}}</pre>
+      <div class='grid gap-4'>
+        <div class='p-4 bg-default-50 rounded'>
+          <h4 class='font-medium mb-2'>Current Form Data:</h4>
+          <pre class='text-sm'>{{JSON.stringify this.formData null 2}}</pre>
+        </div>
+
+        <div class='p-4 bg-success-50 rounded'>
+          <h4 class='font-medium mb-2'>Last Submitted Data:</h4>
+          <pre class='text-sm'>{{JSON.stringify this.submittedData null 2}}</pre>
+        </div>
       </div>
     </div>
   </template>
@@ -106,16 +122,14 @@ export default class RealtimeForm extends Component {
     { label: 'Guest', key: 'guest' }
   ];
 
-  handleFormChange = (
-    data: FormResultData,
-    eventType: 'input' | 'submit',
-    event: Event | SubmitEvent
-  ) => {
-    if (eventType === 'input') {
-      this.inputData = data;
-    } else {
-      this.submitData = data;
-    }
+  handleFormChange = (data: FormResultData, event: Event) => {
+    this.inputData = data;
+    console.log('Input event:', { data, event });
+  };
+
+  handleFormSubmit = (data: FormResultData, event: SubmitEvent) => {
+    this.submitData = data;
+    console.log('Submit event:', { data, event });
   };
 
   handleRoleChange = (selectedKey: string | null) => {
@@ -124,7 +138,10 @@ export default class RealtimeForm extends Component {
 
   <template>
     <div class='flex flex-col gap-4'>
-      <Form @onChange={{this.handleFormChange}}>
+      <Form
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+      >
         <div class='flex flex-col gap-4'>
           <Input
             @name='username'
@@ -225,9 +242,16 @@ export default class ComprehensiveForm extends Component {
     { label: 'Expert (10+ years)', key: 'expert' }
   ];
 
-  handleFormChange = (data: FormResultData, eventType: 'input' | 'submit') => {
+  handleFormChange = (data: FormResultData, event: Event) => {
     this.formData = data;
-    this.lastEventType = eventType;
+    this.lastEventType = 'input';
+    console.log('Form input:', { data, event });
+  };
+
+  handleFormSubmit = (data: FormResultData, event: SubmitEvent) => {
+    this.formData = data;
+    this.lastEventType = 'submit';
+    console.log('Form submit:', { data, event });
   };
 
   handleSkillLevelChange = (selectedKey: string | null) => {
@@ -236,7 +260,10 @@ export default class ComprehensiveForm extends Component {
 
   <template>
     <div class='flex flex-col gap-4'>
-      <Form @onChange={{this.handleFormChange}}>
+      <Form
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+      >
         <div class='flex flex-col gap-4'>
 
           <div class='grid grid-cols-1 md:grid-cols-2 gap-4'>
@@ -379,15 +406,11 @@ export default class ValidatedForm extends Component {
     )
   });
 
-  handleFormChange = (data: FormResultData, eventType: 'input' | 'submit') => {
+  handleFormChange = (data: FormResultData, event: Event) => {
     this.formData = data;
-
-    if (eventType === 'submit') {
-      this.handleSubmit(data);
-    } else {
-      // Real-time validation on input changes
-      this.validateField(data);
-    }
+    // Real-time validation on input changes
+    this.validateField(data);
+    console.log('Form input:', { data, event });
   };
 
   validateField = (data: FormResultData) => {
@@ -422,10 +445,12 @@ export default class ValidatedForm extends Component {
     }
   };
 
-  handleSubmit = async (data: FormResultData) => {
+  handleFormSubmit = async (data: FormResultData, event: SubmitEvent) => {
+    this.formData = data;
     this.isSubmitting = true;
     this.errors = {};
     this.submitMessage = '';
+    console.log('Form submit:', { data, event });
 
     // Prepare data for validation
     const validationData = {
@@ -481,7 +506,10 @@ export default class ValidatedForm extends Component {
 
   <template>
     <div class='flex flex-col gap-4 w-80'>
-      <Form @onChange={{this.handleFormChange}}>
+      <Form
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+      >
         <div class='flex flex-col gap-4'>
 
           <Input
@@ -565,25 +593,28 @@ export default class CustomHandlingForm extends Component {
   @tracked isSubmitting = false;
   @tracked submitCount = 0;
 
-  handleFormChange = (
-    data: FormResultData,
-    eventType: 'input' | 'submit',
-    event: Event | SubmitEvent
-  ) => {
+  handleFormChange = (data: FormResultData, event: Event) => {
     this.formData = data;
 
-    console.log('Form event:', {
-      eventType,
+    console.log('Form input event:', {
       data,
       timestamp: new Date(),
       target: event.target
     });
 
-    if (eventType === 'input') {
-      this.handleRealTimeValidation(data);
-    } else if (eventType === 'submit') {
-      this.handleFormSubmission(data, event as SubmitEvent);
-    }
+    this.handleRealTimeValidation(data);
+  };
+
+  handleFormSubmit = async (data: FormResultData, event: SubmitEvent) => {
+    this.formData = data;
+
+    console.log('Form submit event:', {
+      data,
+      timestamp: new Date(),
+      target: event.target
+    });
+
+    await this.handleFormSubmission(data, event);
   };
 
   handleRealTimeValidation = (data: FormResultData) => {
@@ -683,7 +714,10 @@ export default class CustomHandlingForm extends Component {
 
   <template>
     <div class='flex flex-col gap-4'>
-      <Form @onChange={{this.handleFormChange}}>
+      <Form
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+      >
         <div class='flex flex-col gap-4'>
 
           <Input
@@ -739,9 +773,9 @@ export default class CustomHandlingForm extends Component {
 
 ### Event Handling
 
-- **Input Events**: Fired on every form input change for real-time updates
-- **Submit Events**: Fired when the form is submitted, with `preventDefault()` called automatically
-- Access to the original DOM event for advanced use cases
+- **`@onChange`**: Fired on every form input change for real-time updates and receives `(data, event)`
+- **`@onSubmit`**: Fired when the form is submitted with `preventDefault()` applied and receives `(data, submitEvent)`
+- Access to the original DOM event for advanced use cases in both handlers
 
 ### Data Types Support
 
@@ -771,14 +805,14 @@ FormSchema = v.object({
 });
 
 // Validate on both input and submit events
-handleFormChange = (data: FormResultData, eventType: 'input' | 'submit') => {
-  if (eventType === 'input') {
-    // Real-time validation for better UX
-    this.validateField(data);
-  } else {
-    // Comprehensive validation on submit
-    this.validateAndSubmit(data);
-  }
+handleFormChange = (data: FormResultData) => {
+  // Real-time validation for better UX
+  this.validateField(data);
+};
+
+handleFormSubmit = async (data: FormResultData) => {
+  // Comprehensive validation on submit
+  await this.validateAndSubmit(data);
 };
 
 validateAndSubmit = async (data: FormResultData) => {

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -1964,12 +1964,23 @@ const data: ComponentDoc[] = [
     fileName: 'packages/forms/declarations/components/form.d.ts',
     Args: [
       {
+        identifier: 'onSubmit',
+        type: {
+          type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
+          raw: '(data: Data, <span class="hljs-attr">event</span>: SubmitEvent) => <span class="hljs-built_in">void</span> | <span class="hljs-built_in">Promise</span>&#x3C;<span class="hljs-built_in">void</span>>',
+        },
+        isRequired: true,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
         identifier: 'onChange',
         type: {
           type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
-          raw: '(data: Data, <span class="hljs-attr">eventType</span>: <span class="hljs-string">\'submit\'</span> | <span class="hljs-string">\'input\'</span>, <span class="hljs-attr">event</span>: Event | SubmitEvent) => <span class="hljs-built_in">void</span>',
+          raw: '(data: Data, <span class="hljs-attr">event</span>: Event) => <span class="hljs-built_in">void</span>',
         },
-        isRequired: true,
+        isRequired: false,
         isInternal: false,
         description: '',
         tags: {},

--- a/test-app/tests/integration/components/forms/from-test.gts
+++ b/test-app/tests/integration/components/forms/from-test.gts
@@ -38,11 +38,7 @@ module('Integration | Component | @frontile/forms/Form', function (hooks) {
   hooks.beforeEach(async function () {
     await render(
       <template>
-        <Form
-          data-test-form
-          @onChange={{onChange}}
-          @onSubmit={{onSubmit}}
-        >
+        <Form data-test-form @onChange={{onChange}} @onSubmit={{onSubmit}}>
           <Input @name="firstName" />
           <Checkbox @name="acceptTerms" />
           <RadioGroup @name="interests" as |Radio|>

--- a/test-app/tests/integration/components/forms/from-test.gts
+++ b/test-app/tests/integration/components/forms/from-test.gts
@@ -25,16 +25,12 @@ module('Integration | Component | @frontile/forms/Form', function (hooks) {
 
   const inputData = cell<FormResultData>();
   const submitData = cell<FormResultData>();
-  const onChange = (
-    data: FormResultData,
-    eventType: 'input' | 'submit',
-    _event: Event | SubmitEvent
-  ) => {
-    if (eventType === 'input') {
-      inputData.current = data;
-    } else {
-      submitData.current = data;
-    }
+  const onChange = (data: FormResultData, _event: Event) => {
+    inputData.current = data;
+  };
+
+  const onSubmit = async (data: FormResultData, _event: SubmitEvent) => {
+    submitData.current = data;
   };
 
   const countries = ['Argentina', 'Brazil', 'Chile', 'United States'];
@@ -42,7 +38,11 @@ module('Integration | Component | @frontile/forms/Form', function (hooks) {
   hooks.beforeEach(async function () {
     await render(
       <template>
-        <Form data-test-form @onChange={{onChange}}>
+        <Form
+          data-test-form
+          @onChange={{onChange}}
+          @onSubmit={{onSubmit}}
+        >
           <Input @name="firstName" />
           <Checkbox @name="acceptTerms" />
           <RadioGroup @name="interests" as |Radio|>


### PR DESCRIPTION
This PR separates the actions for `onChange` and `onSubmit`, where previously they were combined.  Now, `input` events are routed to `handleInput` (and subsequently the component argument `onChange`).  `submit` events are routed to `handleSubmit` (and subsequently the component argument `onSubmit`).