### PR TITLE
feature: standard schema validation utility

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -75,6 +75,7 @@
     "@glint/environment-ember-template-imports": "1.5.2",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-node-resolve": "^16.0.0",
+    "@standard-schema/spec": "^1.0.0",
     "@tsconfig/ember": "^3.0.9",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^9.1.0",

--- a/packages/forms/src/components/form.gts
+++ b/packages/forms/src/components/form.gts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { dataFrom } from 'form-data-utils';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 
 type FormResultData = ReturnType<typeof dataFrom>;
 
@@ -17,6 +18,10 @@ interface FormContext {
 interface FormSignature {
   Element: HTMLFormElement;
   Args: {
+    /**
+     * The standard schema to validate form data against.
+     */
+    schema?: StandardSchemaV1;
     /**
      * Optional callback invoked on input changes within the form.
      */

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -12,3 +12,4 @@ export * from './components/radio';
 export * from './components/radio-group';
 export * from './components/form-control';
 export * from './components/switch';
+export * from './utils/standard-validator';

--- a/packages/forms/src/utils/standard-validator.ts
+++ b/packages/forms/src/utils/standard-validator.ts
@@ -1,0 +1,235 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
+/**
+ * The issues collection returned by a Standard Schema validation failure.
+ */
+export type Issues = readonly StandardSchemaV1.Issue[];
+
+/**
+ * The return type of a validator function.
+ * Resolves to the issues (when validation fails) or undefined
+ * (when it succeeds).
+ */
+export type ValidatorReturn = Promise<Issues | undefined>;
+
+/**
+ * A custom validator function.
+ * If there are errors, they are returned by the validator as
+ * StandardSchemaV1 issues.  If there are no errors, nothing is returned.
+ */
+export type CustomValidatorFn<Input = unknown> = (
+  input: Input
+) => ValidatorReturn | Issues | undefined;
+
+/**
+ * Provides convenience methods for validating data using Standard Schema.
+ * Also supports custom validator functions that return issues in the
+ * Standard Schema format.
+ *
+ * Most of the time you should use `validateAll` or `validateFieldAll` to
+ * validate data.  Schema and custom validation are optional arguments
+ * to these methods.  This is useful because schema and custom validation
+ * must both be optional in the form component, which is the primary use
+ * case for this class.
+ *
+ * Note:  all methods are static, so you do not need to instantiate
+ * this class.
+ *
+ * @see https://standardschema.dev/
+ */
+class StandardValidator {
+  /**
+   * Validates data against the provided standard schema.
+   * If there are errors, they are returned.  Otherwise, nothing is returned.
+   * This provides a boolean indication of outcome:  if there is a return
+   * value, validation failed.  Otherwise, validation succeeded.
+   * @see https://standardschema.dev/
+   *
+   * @example
+   * const input = …; // your data to validate
+   * const schema = …; // your standard schema
+   * const issues = await StandardValidator.validate(input, schema);
+   *
+   * @param input The input to validate.
+   * @param schema The standard schema to validate against.
+   * @return The issues if validation failed, otherwise undefined.
+   */
+  static async validate<I, O>(
+    input: I,
+    schema: StandardSchemaV1<I, O>
+  ): ValidatorReturn {
+    const result = await schema['~standard'].validate(input);
+    return result.issues;
+  }
+
+  /**
+   * Validates a single field within the input data using the provided
+   * standard schema.  If there are issues related to the specified field,
+   * they are returned.  Otherwise, nothing is returned.
+   *
+   * Note:  because standard schema does not provide a way to validate
+   * individual fields, this method filters the issues returned by the
+   * schema validation to find those related to the specified field.
+   * @see https://standardschema.dev/
+   *
+   * @param input The input data to validate.
+   * @param fieldName The name of the field to validate.
+   * @param schema The standard schema to validate against.
+   * @returns The issues related to the specified field if validation failed,
+   *          otherwise undefined.
+   */
+  static async validateField<I, O>(
+    input: I,
+    fieldName: string,
+    schema: StandardSchemaV1<I, O>
+  ): ValidatorReturn {
+    const issues = await StandardValidator.validate(input, schema);
+    if (issues) {
+      return StandardValidator.filterFieldIssues(issues, fieldName);
+    }
+  }
+
+  /**
+   * Validates input using a custom validator function.
+   * If there are errors, they are returned by the validator as
+   * StandardSchemaV1 issues. If there are no errors, nothing is returned.
+   * @see https://standardschema.dev/
+   *
+   * @param input The input data to validate.
+   * @param customValidator The custom validator function to use.
+   * @returns The issues if validation failed, otherwise undefined.
+   */
+  static async validateCustom<I>(
+    input: I,
+    customValidator: CustomValidatorFn<I>
+  ): ValidatorReturn {
+    const customIssues = await customValidator(input);
+    return customIssues;
+  }
+
+  /**
+   * Validates a single field within the input data using a custom validator
+   * function.  If there are issues related to the specified field, they are
+   * returned.  Otherwise, nothing is returned.
+   *
+   * Note:  because custom validators may return issues for multiple fields,
+   * this method filters the issues returned by the custom validator to find
+   * those related to the specified field.
+   * @see https://standardschema.dev/
+   *
+   * @param input The input data to validate.
+   * @param fieldName The name of the field to validate.
+   * @param customValidator The custom validator function to use.
+   * @returns The issues related to the specified field if validation failed,
+   *          otherwise undefined.
+   */
+  static async validateFieldCustom<I>(
+    input: I,
+    fieldName: string,
+    customValidator: CustomValidatorFn<I>
+  ): ValidatorReturn {
+    const issues = await StandardValidator.validateCustom(
+      input,
+      customValidator
+    );
+    if (issues) {
+      return StandardValidator.filterFieldIssues(issues, fieldName);
+    }
+  }
+
+  /**
+   * Validates input data using both a standard schema and a custom validator
+   * function, merging any issues found by either method.  If there are issues,
+   * they are returned. Otherwise, nothing is returned.  This method runs both
+   * validations in parallel.
+   *
+   * Note:  `schema` and `customValidator` are both optional.  If either the
+   * schema or custom validator is not provided, that validation is skipped.
+   * @see https://standardschema.dev/
+   *
+   * @param input The input data to validate.
+   * @param schema Optional standard schema to validate against.
+   * @param customValidator Optional custom validator function to use.
+   * @returns issues if validation failed, otherwise undefined.
+   */
+  static async validateAll<I, O>(
+    input: I,
+    schema?: StandardSchemaV1<I, O>,
+    customValidator?: CustomValidatorFn<I>
+  ): ValidatorReturn {
+    const standardIssues = schema && StandardValidator.validate(input, schema);
+    const customIssues =
+      customValidator &&
+      StandardValidator.validateCustom(input, customValidator);
+    const [s, c] = await Promise.all([standardIssues, customIssues]);
+    if (s || c) {
+      return [...(s ?? []), ...(c ?? [])];
+    }
+  }
+
+  /**
+   * Validates a single field within the input data using both a standard
+   * schema and a custom validator function, merging any issues found by
+   * either method. If there are issues related to the specified field,
+   * they are returned. Otherwise, nothing is returned. This method runs
+   * both validations in parallel.
+   *
+   * Note: `schema` and `customValidator` are both optional. If either the
+   * schema or custom validator is not provided, that validation is skipped.
+   * @see https://standardschema.dev/
+   *
+   * @param input The input data to validate.
+   * @param fieldName The name of the field to validate.
+   * @param schema Optional standard schema to validate against.
+   * @param customValidator Optional custom validator function to use.
+   * @returns The issues related to the specified field if validation failed,
+   *          otherwise undefined.
+   */
+  static async validateFieldAll<I, O>(
+    input: I,
+    fieldName: string,
+    schema?: StandardSchemaV1<I, O>,
+    customValidator?: CustomValidatorFn<I>
+  ): ValidatorReturn {
+    const standardIssues =
+      schema && StandardValidator.validateField(input, fieldName, schema);
+    const customIssues =
+      customValidator &&
+      StandardValidator.validateFieldCustom(input, fieldName, customValidator);
+    const [s, c] = await Promise.all([standardIssues, customIssues]);
+    if (s || c) {
+      return [...(s ?? []), ...(c ?? [])];
+    }
+  }
+
+  /**
+   * Filters issues to those related to the specified field name.
+   *
+   * @param issues The issues to filter.
+   * @param fieldName The name of the field to filter by.
+   * @returns The issues related to the specified field, or undefined if
+   *          there are none.
+   */
+  static filterFieldIssues(
+    issues: Issues,
+    fieldName: string
+  ): Issues | undefined {
+    const fieldIssues = issues.filter((issue) => {
+      if (!issue.path) {
+        return false;
+      }
+      return issue.path.some((segment) => {
+        if (typeof segment === 'object' && 'key' in segment) {
+          return segment.key === fieldName;
+        }
+        return segment === fieldName;
+      });
+    });
+    if (fieldIssues.length > 0) {
+      return fieldIssues;
+    }
+  }
+}
+
+export { StandardValidator };
+export default StandardValidator;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.0
         version: 16.0.1(rollup@4.46.2)
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@tsconfig/ember':
         specifier: ^3.0.9
         version: 3.0.11
@@ -1548,6 +1551,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.8.3
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
       webpack:
         specifier: ^5.99.9
         version: 5.101.0
@@ -3421,6 +3427,9 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@szmarczak/http-timer@1.1.2':
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
@@ -14059,6 +14068,8 @@ snapshots:
   '@sinonjs/text-encoding@0.7.3': {}
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@szmarczak/http-timer@1.1.2':
     dependencies:

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -80,6 +80,7 @@
     "tailwind-variants": "^0.3.0",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.7.3",
+    "valibot": "^1.1.0",
     "webpack": "^5.99.9"
   },
   "exports": {

--- a/test-app/tests/unit/forms/utils/standard-validator-test.ts
+++ b/test-app/tests/unit/forms/utils/standard-validator-test.ts
@@ -1,0 +1,613 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { StandardValidator } from '@frontile/forms';
+import * as v from 'valibot';
+
+module('Unit | Forms | StandardValidator', function (hooks) {
+  setupTest(hooks);
+
+  test('validate data against a schema', async function (assert) {
+    assert.expect(5);
+
+    const UserSchema = v.object({
+      name: v.string(),
+      email: v.pipe(v.string(), v.email()),
+      age: v.pipe(v.number(), v.minValue(18))
+    });
+
+    const validData = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      age: 25
+    };
+
+    const invalidData = {
+      name: 'Jane Doe',
+      email: 'invalid-email',
+      age: 15
+    };
+
+    // Assert that validation passes with valid data
+    const validResult = await StandardValidator.validate(validData, UserSchema);
+    // (this is a little unintuitive as a valid result returns undefined)
+    assert.ok(!validResult, 'Validation should pass with valid data');
+
+    // ...and fails with invalid data.
+    const invalidResult = await StandardValidator.validate(
+      invalidData,
+      UserSchema
+    );
+    // (whereas an invalid result returns an array of issues)
+    assert.ok(invalidResult, 'Validation should fail with invalid data');
+    assert.ok(invalidResult?.length, 'Should have validation issues');
+
+    // Check that we have issues for email and age
+    const emailIssue = invalidResult?.find((issue) =>
+      issue.path?.some((p) =>
+        typeof p === 'object' && 'key' in p ? p.key === 'email' : p === 'email'
+      )
+    );
+    const ageIssue = invalidResult?.find((issue) =>
+      issue.path?.some((p) =>
+        typeof p === 'object' && 'key' in p ? p.key === 'age' : p === 'age'
+      )
+    );
+
+    assert.ok(emailIssue, 'Should have an issue for invalid email');
+    assert.ok(ageIssue, 'Should have an issue for age below minimum');
+  });
+
+  test('validateField returns undefined for valid field data', async function (assert) {
+    assert.expect(3);
+    const UserSchema = v.object({
+      name: v.pipe(v.string(), v.minLength(3)),
+      email: v.pipe(v.string(), v.email()),
+      age: v.pipe(v.number(), v.minValue(18), v.maxValue(100))
+    });
+
+    const validData = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      age: 25
+    };
+
+    const nameResult = await StandardValidator.validateField(
+      validData,
+      'name',
+      UserSchema
+    );
+    assert.ok(!nameResult, 'Should return undefined for valid name field');
+
+    const emailResult = await StandardValidator.validateField(
+      validData,
+      'email',
+      UserSchema
+    );
+    assert.ok(!emailResult, 'Should return undefined for valid email field');
+
+    const ageResult = await StandardValidator.validateField(
+      validData,
+      'age',
+      UserSchema
+    );
+    assert.ok(!ageResult, 'Should return undefined for valid age field');
+  });
+
+  test('validateField returns only specified field errors when multiple fields are invalid', async function (assert) {
+    assert.expect(9);
+    const UserSchema = v.object({
+      name: v.pipe(v.string(), v.minLength(3)),
+      email: v.pipe(v.string(), v.email()),
+      age: v.pipe(v.number(), v.minValue(18), v.maxValue(100))
+    });
+
+    // Data with multiple invalid fields
+    const invalidData = {
+      name: 'Jo', // Too short (min 3 chars)
+      email: 'not-an-email', // Invalid email format
+      age: 150 // Too high (max 100)
+    };
+
+    // Validate email field - should only get email errors
+    const emailResult = await StandardValidator.validateField(
+      invalidData,
+      'email',
+      UserSchema
+    );
+    assert.ok(emailResult, 'Should have issues for invalid email');
+    assert.strictEqual(
+      emailResult?.length,
+      1,
+      'Should have exactly one email issue'
+    );
+    assert.ok(
+      emailResult?.[0]?.path?.some((p) =>
+        typeof p === 'object' && 'key' in p ? p.key === 'email' : p === 'email'
+      ),
+      'Issue should be for email field only'
+    );
+
+    // Validate name field - should only get name errors
+    const nameResult = await StandardValidator.validateField(
+      invalidData,
+      'name',
+      UserSchema
+    );
+    assert.ok(nameResult, 'Should have issues for invalid name');
+    assert.strictEqual(
+      nameResult?.length,
+      1,
+      'Should have exactly one name issue'
+    );
+    assert.ok(
+      nameResult?.[0]?.path?.some((p) =>
+        typeof p === 'object' && 'key' in p ? p.key === 'name' : p === 'name'
+      ),
+      'Issue should be for name field only'
+    );
+
+    // Validate age field - should only get age errors
+    const ageResult = await StandardValidator.validateField(
+      invalidData,
+      'age',
+      UserSchema
+    );
+    assert.ok(ageResult, 'Should have issues for invalid age');
+    assert.strictEqual(
+      ageResult?.length,
+      1,
+      'Should have exactly one age issue'
+    );
+    assert.ok(
+      ageResult?.[0]?.path?.some((p) =>
+        typeof p === 'object' && 'key' in p ? p.key === 'age' : p === 'age'
+      ),
+      'Issue should be for age field only'
+    );
+  });
+
+  test('validateField returns undefined for valid fields even when other fields are invalid', async function (assert) {
+    assert.expect(5);
+    const UserSchema = v.object({
+      name: v.pipe(v.string(), v.minLength(3)),
+      email: v.pipe(v.string(), v.email()),
+      age: v.pipe(v.number(), v.minValue(18), v.maxValue(100))
+    });
+
+    const mixedData = {
+      name: 'John Doe', // Valid
+      email: 'invalid-email', // Invalid
+      age: 150 // Invalid
+    };
+
+    // Valid field should return undefined
+    const nameResult = await StandardValidator.validateField(
+      mixedData,
+      'name',
+      UserSchema
+    );
+    assert.ok(
+      !nameResult,
+      'Should return undefined for valid name field despite other invalid fields'
+    );
+
+    // Invalid fields should return issues
+    const emailResult = await StandardValidator.validateField(
+      mixedData,
+      'email',
+      UserSchema
+    );
+    assert.ok(emailResult, 'Should return issues for invalid email field');
+    assert.strictEqual(
+      emailResult?.length,
+      1,
+      'Should have exactly one email issue'
+    );
+
+    const ageResult = await StandardValidator.validateField(
+      mixedData,
+      'age',
+      UserSchema
+    );
+    assert.ok(ageResult, 'Should return issues for invalid age field');
+    assert.strictEqual(
+      ageResult?.length,
+      1,
+      'Should have exactly one age issue'
+    );
+  });
+
+  test('validateCustom works for valid and invalid data', async function (assert) {
+    assert.expect(7);
+    // Custom validator that checks if age is between 18 and 65
+    const ageRangeValidator = async (data: { age: number }) => {
+      if (data.age < 18 || data.age > 65) {
+        return [
+          {
+            message: 'Age must be between 18 and 65',
+            path: [{ key: 'age' }]
+          }
+        ];
+      }
+      return undefined;
+    };
+
+    // Test valid data
+    const validData = { age: 30 };
+    const validResult = await StandardValidator.validateCustom(
+      validData,
+      ageRangeValidator
+    );
+    assert.ok(!validResult, 'Should return undefined for valid age');
+
+    // Test invalid data - too young
+    const tooYoung = { age: 15 };
+    const youngResult = await StandardValidator.validateCustom(
+      tooYoung,
+      ageRangeValidator
+    );
+    assert.ok(youngResult, 'Should return issues for age below 18');
+    assert.strictEqual(youngResult?.length, 1, 'Should have exactly one issue');
+    assert.strictEqual(
+      youngResult?.[0]?.message,
+      'Age must be between 18 and 65'
+    );
+
+    // Test invalid data - too old
+    const tooOld = { age: 70 };
+    const oldResult = await StandardValidator.validateCustom(
+      tooOld,
+      ageRangeValidator
+    );
+    assert.ok(oldResult, 'Should return issues for age above 65');
+    assert.strictEqual(oldResult?.length, 1, 'Should have exactly one issue');
+    assert.strictEqual(
+      oldResult?.[0]?.message,
+      'Age must be between 18 and 65'
+    );
+  });
+
+  test('validateFieldCustom returns only specified field errors', async function (assert) {
+    assert.expect(6);
+    // Custom validator that returns errors for multiple fields
+    const validator = async (data: { username?: string; email?: string }) => {
+      const issues = [];
+
+      if (data.username && data.username.length < 3) {
+        issues.push({
+          message: 'Username too short',
+          path: [{ key: 'username' }]
+        });
+      }
+
+      if (data.email && !data.email.includes('@')) {
+        issues.push({
+          message: 'Invalid email',
+          path: [{ key: 'email' }]
+        });
+      }
+
+      return issues.length > 0 ? issues : undefined;
+    };
+
+    // Data with both fields invalid
+    const data = {
+      username: 'ab', // Too short
+      email: 'notanemail' // Missing @
+    };
+
+    // Validate only username field
+    const usernameResult = await StandardValidator.validateFieldCustom(
+      data,
+      'username',
+      validator
+    );
+    assert.ok(usernameResult, 'Should have username issues');
+    assert.strictEqual(
+      usernameResult?.length,
+      1,
+      'Should have exactly one issue'
+    );
+    assert.strictEqual(usernameResult?.[0]?.message, 'Username too short');
+
+    // Validate only email field
+    const emailResult = await StandardValidator.validateFieldCustom(
+      data,
+      'email',
+      validator
+    );
+    assert.ok(emailResult, 'Should have email issues');
+    assert.strictEqual(emailResult?.length, 1, 'Should have exactly one issue');
+    assert.strictEqual(emailResult?.[0]?.message, 'Invalid email');
+  });
+
+  test('validateAll merges schema and custom validation errors', async function (assert) {
+    assert.expect(4);
+    // Schema validation
+    const schema = v.object({
+      email: v.pipe(v.string(), v.email()),
+      age: v.pipe(v.number(), v.minValue(18))
+    });
+
+    // Custom validation with additional rules
+    const customValidator = async (data: { email?: string }) => {
+      if (data.email && !data.email.endsWith('@company.com')) {
+        return [
+          {
+            message: 'Must use company email',
+            path: [{ key: 'email' }]
+          }
+        ];
+      }
+      return undefined;
+    };
+
+    // Invalid data that fails both validations
+    const data = {
+      email: 'invalid', // Fails schema (not valid email format)
+      age: 16 // Fails schema (below 18)
+    };
+
+    const result = await StandardValidator.validateAll(
+      data,
+      schema,
+      customValidator
+    );
+
+    assert.ok(result, 'Should have validation issues');
+    assert.strictEqual(
+      result?.length,
+      3,
+      'Should have 3 issues total (2 from schema, 1 from custom)'
+    );
+
+    // Verify we have both schema and custom errors
+    const hasSchemaError = result?.some((issue) =>
+      issue.path?.some((p) =>
+        typeof p === 'object' && 'key' in p ? p.key === 'age' : p === 'age'
+      )
+    );
+    const hasCustomError = result?.some(
+      (issue) => issue.message === 'Must use company email'
+    );
+
+    assert.ok(hasSchemaError, 'Should include schema validation errors');
+    assert.ok(hasCustomError, 'Should include custom validation errors');
+  });
+
+  test('validateAll works with only custom validator (no schema)', async function (assert) {
+    assert.expect(3);
+
+    // Custom validator without a schema
+    const customValidator = async (data: {
+      username?: string;
+      age?: number;
+    }) => {
+      const issues = [];
+
+      if (data.username && data.username.length < 5) {
+        issues.push({
+          message: 'Username must be at least 5 characters',
+          path: [{ key: 'username' }]
+        });
+      }
+
+      if (data.age && data.age < 21) {
+        issues.push({
+          message: 'Must be 21 or older',
+          path: [{ key: 'age' }]
+        });
+      }
+
+      return issues.length > 0 ? issues : undefined;
+    };
+
+    // Test data that fails custom validation
+    const invalidData = {
+      username: 'joe',
+      age: 18
+    };
+
+    // Validate with only custom validator (no schema)
+    const result = await StandardValidator.validateAll(
+      invalidData,
+      undefined, // No schema provided
+      customValidator
+    );
+
+    assert.ok(result, 'Should have validation issues from custom validator');
+    assert.strictEqual(
+      result?.length,
+      2,
+      'Should have 2 issues from custom validator'
+    );
+
+    // Verify the issues are from custom validator
+    const messages = result?.map((issue) => issue.message);
+    assert.deepEqual(
+      messages,
+      ['Username must be at least 5 characters', 'Must be 21 or older'],
+      'Should have the expected custom validation messages'
+    );
+  });
+
+  test('validateAll works with only schema (no custom validator)', async function (assert) {
+    assert.expect(6);
+
+    const UserSchema = v.object({
+      name: v.pipe(v.string(), v.minLength(2)),
+      email: v.pipe(v.string(), v.email()),
+      age: v.pipe(v.number(), v.minValue(18), v.maxValue(120))
+    });
+
+    // Test with valid data
+    const validData = {
+      name: 'John Doe',
+      email: 'john@example.com',
+      age: 25
+    };
+
+    const validResult = await StandardValidator.validateAll(
+      validData,
+      UserSchema
+      // No custom validator provided
+    );
+
+    assert.ok(
+      !validResult,
+      'Should return undefined for valid data with schema only'
+    );
+
+    // Test with invalid data
+    const invalidData = {
+      name: 'J', // Too short
+      email: 'invalid-email', // Invalid format
+      age: 16 // Below minimum
+    };
+
+    const invalidResult = await StandardValidator.validateAll(
+      invalidData,
+      UserSchema
+      // No custom validator provided
+    );
+
+    assert.ok(invalidResult, 'Should have validation issues from schema');
+    assert.strictEqual(
+      invalidResult?.length,
+      3,
+      'Should have 3 issues from schema validation'
+    );
+
+    // Verify all expected fields have errors
+    const fieldErrors = ['name', 'email', 'age'];
+    fieldErrors.forEach((field) => {
+      const hasFieldError = invalidResult?.some((issue) =>
+        issue.path?.some((p) =>
+          typeof p === 'object' && 'key' in p ? p.key === field : p === field
+        )
+      );
+      assert.ok(hasFieldError, `Should have error for ${field} field`);
+    });
+  });
+
+  test('validateAll works with neither schema nor custom validator', async function (assert) {
+    assert.expect(1);
+    const data = { name: 'John', email: 'invalid' };
+    const result = await StandardValidator.validateAll(data);
+    assert.ok(
+      !result,
+      'Should return undefined when no validation is provided'
+    );
+  });
+
+  test('validateFieldAll merges schema and custom errors for single field only', async function (assert) {
+    assert.expect(5);
+    // Schema validation
+    const schema = v.object({
+      email: v.pipe(v.string(), v.email()),
+      username: v.pipe(v.string(), v.minLength(3))
+    });
+
+    // Custom validator for multiple fields
+    const customValidator = async (data: {
+      email?: string;
+      username?: string;
+    }) => {
+      const issues = [];
+
+      if (data.email && !data.email.endsWith('@company.com')) {
+        issues.push({
+          message: 'Must use company email',
+          path: [{ key: 'email' }]
+        });
+      }
+
+      if (data.username && data.username === 'admin') {
+        issues.push({
+          message: 'Username reserved',
+          path: [{ key: 'username' }]
+        });
+      }
+
+      return issues.length > 0 ? issues : undefined;
+    };
+
+    // Data that fails both fields in both validators
+    const data = {
+      email: 'invalid', // Fails both schema and custom
+      username: 'ad' // Fails schema only (too short)
+    };
+
+    // Validate only email field - should get email errors from both validators
+    const emailResult = await StandardValidator.validateFieldAll(
+      data,
+      'email',
+      schema,
+      customValidator
+    );
+
+    assert.ok(emailResult, 'Should have email validation issues');
+    assert.strictEqual(
+      emailResult?.length,
+      2,
+      'Should have 2 email issues (1 schema + 1 custom)'
+    );
+
+    // Verify both types of errors are present for email
+    const hasSchemaEmailError = emailResult?.some(
+      (issue) =>
+        issue.path?.some((p) =>
+          typeof p === 'object' && 'key' in p
+            ? p.key === 'email'
+            : p === 'email'
+        ) && !issue.message?.includes('company')
+    );
+    const hasCustomEmailError = emailResult?.some(
+      (issue) => issue.message === 'Must use company email'
+    );
+
+    assert.ok(hasSchemaEmailError, 'Should have schema email error');
+    assert.ok(hasCustomEmailError, 'Should have custom email error');
+
+    // Verify no username errors are included
+    const hasUsernameError = emailResult?.some((issue) =>
+      issue.path?.some((p) =>
+        typeof p === 'object' && 'key' in p
+          ? p.key === 'username'
+          : p === 'username'
+      )
+    );
+    assert.notOk(
+      hasUsernameError,
+      'Should not include username errors when validating email field'
+    );
+  });
+
+  test('filterFieldIssues returns only issues for specified field', function (assert) {
+    assert.expect(6);
+    const issues = [
+      { message: 'Invalid email', path: [{ key: 'email' }] },
+      { message: 'Name too short', path: [{ key: 'name' }] },
+      { message: 'Email required', path: [{ key: 'email' }] },
+      { message: 'Age too low', path: [{ key: 'age' }] }
+    ];
+
+    // Filter for email issues
+    const emailIssues = StandardValidator.filterFieldIssues(issues, 'email');
+    assert.strictEqual(emailIssues?.length, 2, 'Should return 2 email issues');
+    assert.strictEqual(emailIssues?.[0]?.message, 'Invalid email');
+    assert.strictEqual(emailIssues?.[1]?.message, 'Email required');
+
+    // Filter for name issues
+    const nameIssues = StandardValidator.filterFieldIssues(issues, 'name');
+    assert.strictEqual(nameIssues?.length, 1, 'Should return 1 name issue');
+    assert.strictEqual(nameIssues?.[0]?.message, 'Name too short');
+
+    // Filter for non-existent field
+    const phoneIssues = StandardValidator.filterFieldIssues(issues, 'phone');
+    assert.notOk(
+      phoneIssues,
+      'Should return undefined for field with no issues'
+    );
+  });
+});


### PR DESCRIPTION
Add a `StandardValidator` utility to the forms package which provides validation conveniences for schemas in [Standard Schema](https://standardschema.dev/) form.

`StandardValidator` provides the following conveniences:
* Validates arbitrary data against a standard schema.
* Validates single fields against a standard schema.
* Validates arbitrary data against a custom validator function.
* Validates single fields against a custom validator function.
* Validates against either/or schema and custom validator, if desired.
* Typed, with a basis in Standard Schema.