### PR TITLE
feat: Whole-form `disabled`

### DIFF
--- a/packages/forms/src/components/checkbox-group.gts
+++ b/packages/forms/src/components/checkbox-group.gts
@@ -25,7 +25,12 @@ interface Args extends FormControlSharedArgs {
 interface CheckboxGroupSignature {
   Args: Args;
   Blocks: {
-    default: [Checkbox: WithBoundArgs<typeof Checkbox, 'name' | 'onChange'>];
+    default: [
+      Checkbox: WithBoundArgs<
+        typeof Checkbox,
+        'name' | 'onChange' | 'isDisabled'
+      >
+    ];
   };
   Element: HTMLDivElement;
 }
@@ -57,7 +62,13 @@ class CheckboxGroup extends Component<CheckboxGroupSignature> {
         data-orientation={{if @orientation @orientation "vertical"}}
       >
         {{yield
-          (component Checkbox name=@name onChange=@onChange size=@size)
+          (component
+            Checkbox
+            name=@name
+            onChange=@onChange
+            size=@size
+            isDisabled=@isDisabled
+          )
           to="default"
         }}
       </div>

--- a/packages/forms/src/components/checkbox.gts
+++ b/packages/forms/src/components/checkbox.gts
@@ -64,6 +64,7 @@ class Checkbox extends Component<CheckboxSignature> {
         name={{@name}}
         checked={{this.isChecked}}
         type="checkbox"
+        disabled={{@isDisabled}}
         class={{this.classes.input class=@classes.input}}
         data-component="checkbox"
         aria-invalid={{if c.isInvalid "true"}}

--- a/packages/forms/src/components/field.gts
+++ b/packages/forms/src/components/field.gts
@@ -17,12 +17,12 @@ import type { WithBoundArgsForSignature } from './field-types';
 
 type BoundSingleSelect<S = unknown> = WithBoundArgsForSignature<
   SelectSignature<S>,
-  'name' | 'errors' | 'selectedKey'
+  'name' | 'errors' | 'selectedKey' | 'isDisabled'
 >;
 
 type BoundMultiSelect<S = unknown> = WithBoundArgsForSignature<
   SelectSignature<S>,
-  'name' | 'errors' | 'selectedKeys'
+  'name' | 'errors' | 'selectedKeys' | 'isDisabled'
 >;
 
 interface FieldSignature<T extends Record<string, unknown> = FormDataCompiled> {
@@ -34,22 +34,42 @@ interface FieldSignature<T extends Record<string, unknown> = FormDataCompiled> {
     errors?: FormErrors;
     /** The form data as key/value pairs. */
     formData?: T;
+    /** Whether the field should be disabled. */
+    disabled?: boolean;
   };
   Blocks: {
     default: [
       {
-        Checkbox: WithBoundArgs<typeof Checkbox, 'name' | 'errors' | 'checked'>;
-        CheckboxGroup: WithBoundArgs<typeof CheckboxGroup, 'name' | 'errors'>;
-        Input: WithBoundArgs<typeof Input, 'name' | 'errors' | 'value'>;
-        Radio: WithBoundArgs<typeof Radio, 'name' | 'errors' | 'value'>;
+        Checkbox: WithBoundArgs<
+          typeof Checkbox,
+          'name' | 'errors' | 'checked' | 'isDisabled'
+        >;
+        CheckboxGroup: WithBoundArgs<
+          typeof CheckboxGroup,
+          'name' | 'errors' | 'isDisabled'
+        >;
+        Input: WithBoundArgs<
+          typeof Input,
+          'name' | 'errors' | 'value' | 'isDisabled'
+        >;
+        Radio: WithBoundArgs<
+          typeof Radio,
+          'name' | 'errors' | 'value' | 'isDisabled'
+        >;
         RadioGroup: WithBoundArgs<
           typeof RadioGroup,
-          'name' | 'errors' | 'value'
+          'name' | 'errors' | 'value' | 'isDisabled'
         >;
         SingleSelect: BoundSingleSelect;
         MultiSelect: BoundMultiSelect;
-        Switch: WithBoundArgs<typeof Switch, 'name' | 'errors' | 'isSelected'>;
-        Textarea: WithBoundArgs<typeof Textarea, 'name' | 'errors' | 'value'>;
+        Switch: WithBoundArgs<
+          typeof Switch,
+          'name' | 'errors' | 'isSelected' | 'isDisabled'
+        >;
+        Textarea: WithBoundArgs<
+          typeof Textarea,
+          'name' | 'errors' | 'value' | 'isDisabled'
+        >;
       }
     ];
   };
@@ -92,9 +112,10 @@ class Field<
           errors=this.fieldErrors
           checked=this.fieldValue
           onChange=this.noop
+          isDisabled=@disabled
         )
         CheckboxGroup=(component
-          CheckboxGroup name=@name errors=this.fieldErrors
+          CheckboxGroup name=@name errors=this.fieldErrors isDisabled=@disabled
         )
         Input=(component
           Input
@@ -102,6 +123,7 @@ class Field<
           errors=this.fieldErrors
           value=this.fieldValue
           onChange=this.noop
+          isDisabled=@disabled
         )
         Radio=(component
           Radio
@@ -109,6 +131,7 @@ class Field<
           errors=this.fieldErrors
           value=this.fieldValue
           onChange=this.noop
+          isDisabled=@disabled
         )
         RadioGroup=(component
           RadioGroup
@@ -116,6 +139,7 @@ class Field<
           errors=this.fieldErrors
           value=this.fieldValue
           onChange=this.noop
+          isDisabled=@disabled
         )
         SingleSelect=(component
           Select
@@ -123,6 +147,7 @@ class Field<
           errors=this.fieldErrors
           selectedKey=this.fieldValue
           onSelectionChange=this.noop
+          isDisabled=@disabled
         )
         MultiSelect=(component
           Select
@@ -130,6 +155,7 @@ class Field<
           errors=this.fieldErrors
           selectedKeys=this.fieldValue
           onSelectionChange=this.noop
+          isDisabled=@disabled
         )
         Switch=(component
           Switch
@@ -137,6 +163,7 @@ class Field<
           errors=this.fieldErrors
           isSelected=this.fieldValue
           onChange=this.noop
+          isDisabled=@disabled
         )
         Textarea=(component
           Textarea
@@ -144,6 +171,7 @@ class Field<
           errors=this.fieldErrors
           value=this.fieldValue
           onChange=this.noop
+          isDisabled=@disabled
         )
       )
       to="default"

--- a/packages/forms/src/components/form-control.gts
+++ b/packages/forms/src/components/form-control.gts
@@ -12,6 +12,7 @@ interface FormControlSharedArgs {
   description?: string;
   errors?: string[] | string;
   isInvalid?: boolean;
+  isDisabled?: boolean;
 }
 
 interface Args extends FormControlSharedArgs {

--- a/packages/forms/src/components/form.gts
+++ b/packages/forms/src/components/form.gts
@@ -51,7 +51,7 @@ interface FormContext<T = FormDataCompiled> {
   /** The set of fields that have changed from their initial values. */
   dirty: Set<keyof T>;
   /** The `Field` component, with args bound. */
-  Field: WithBoundArgs<typeof Field, 'errors' | 'formData'>;
+  Field: WithBoundArgs<typeof Field, 'errors' | 'formData' | 'disabled'>;
 }
 
 interface FormSignature<T = FormDataCompiled> {
@@ -73,6 +73,11 @@ interface FormSignature<T = FormDataCompiled> {
      * This object receives changes as the user interacts with the form.
      */
     data?: T;
+    /**
+     * Whether the entire form and all its fields should be disabled.  This only
+     * applies when using the yielded `Field` component.
+     */
+    disabled?: boolean;
     /**
      * Optional callback invoked on input changes within the form.
      * @param result - The current form result data.
@@ -335,7 +340,12 @@ class Form<T = FormDataCompiled> extends Component<FormSignature<T>> {
           isInvalid=this.isInvalid
           errors=this.errors
           dirty=this.dirty
-          Field=(component Field errors=this.errors formData=this.currentData)
+          Field=(component
+            Field
+            errors=this.errors
+            formData=this.currentData
+            disabled=@disabled
+          )
         )
         to="default"
       }}

--- a/packages/forms/src/components/input.gts
+++ b/packages/forms/src/components/input.gts
@@ -171,6 +171,7 @@ class Input extends Component<InputSignature> {
           name={{@name}}
           value={{this.value}}
           type={{this.type}}
+          disabled={{@isDisabled}}
           class={{this.classes.input
             class=@classes.input
             hasStartContent=(has-block "startContent")

--- a/packages/forms/src/components/radio-group.gts
+++ b/packages/forms/src/components/radio-group.gts
@@ -27,7 +27,10 @@ interface RadioGroupSignature<T> {
   Args: Args<T>;
   Blocks: {
     default: [
-      Radio: WithBoundArgs<typeof Radio, 'name' | 'onChange' | 'checkedValue'>
+      Radio: WithBoundArgs<
+        typeof Radio,
+        'name' | 'onChange' | 'checkedValue' | 'isDisabled'
+      >
     ];
   };
   Element: HTMLDivElement;
@@ -64,7 +67,12 @@ class RadioGroup<T extends string | number | boolean> extends Component<
         {{! @glint-nocheck: Radio has a type param, glint cannt handle that with WithboundArgs}}
         {{yield
           (component
-            Radio name=@name onChange=@onChange size=@size checkedValue=@value
+            Radio
+            name=@name
+            onChange=@onChange
+            size=@size
+            checkedValue=@value
+            isDisabled=@isDisabled
           )
         }}
       </div>

--- a/packages/forms/src/components/radio.gts
+++ b/packages/forms/src/components/radio.gts
@@ -65,6 +65,7 @@ class Radio<T extends string | boolean | number> extends Component<
         value={{@value}}
         checked={{this.isChecked}}
         type="radio"
+        disabled={{@isDisabled}}
         class={{this.classes.input class=@classes.input}}
         data-component="radio"
         aria-invalid={{if c.isInvalid "true"}}

--- a/packages/forms/src/components/textarea.gts
+++ b/packages/forms/src/components/textarea.gts
@@ -72,6 +72,7 @@ class Textarea extends Component<TextareaSignature> {
         id={{c.id}}
         name={{@name}}
         value={{@value}}
+        disabled={{@isDisabled}}
         class={{this.classes.input class=@classes.input}}
         data-component="textarea"
         aria-invalid={{if c.isInvalid "true"}}

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -1408,6 +1408,14 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
@@ -1552,6 +1560,14 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
@@ -1629,6 +1645,14 @@ const data: ComponentDoc[] = [
         isRequired: true,
         isInternal: false,
         description: 'The name of the form field.',
+        tags: {},
+      },
+      {
+        identifier: 'disabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: 'Whether the field should be disabled.',
         tags: {},
       },
       {
@@ -1794,6 +1818,14 @@ const data: ComponentDoc[] = [
       {
         identifier: 'id',
         type: { type: '<span class="hljs-built_in">string</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
         description: '',
@@ -2132,6 +2164,15 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'disabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description:
+          'Whether the entire form and all its fields should be disabled.  This only\napplies when using the yielded `Field` component.',
+        tags: {},
+      },
+      {
         identifier: 'onChange',
         type: {
           type: '<span class="hljs-function"><span class="hljs-keyword">function</span></span>',
@@ -2455,6 +2496,14 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
@@ -2734,6 +2783,14 @@ const data: ComponentDoc[] = [
       {
         identifier: 'id',
         type: { type: '<span class="hljs-built_in">string</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
         description: '',
@@ -3134,6 +3191,14 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
@@ -3288,6 +3353,14 @@ const data: ComponentDoc[] = [
           raw: '<span class="hljs-built_in">string</span> | <span class="hljs-built_in">string</span>[]',
           items: ['string', 'string[]'],
         },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
         description: '',
@@ -4521,6 +4594,14 @@ const data: ComponentDoc[] = [
       {
         identifier: 'id',
         type: { type: '<span class="hljs-built_in">string</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+      {
+        identifier: 'isDisabled',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
         description: '',

--- a/test-app/tests/integration/components/forms/field-test.gts
+++ b/test-app/tests/integration/components/forms/field-test.gts
@@ -709,4 +709,121 @@ module('Integration | Component | @frontile/forms/Field', function (hooks) {
     assert.dom('[name="username"]').hasValue('jane');
     assert.dom('[name="email"]').hasValue('jane@example.com');
   });
+
+  /**
+   * Test that Field respects the @disabled argument
+   * When disabled, all yielded components should be disabled
+   */
+  test('it disables yielded components when @disabled={{true}}', async function (assert) {
+    assert.expect(8);
+
+    class Model {
+      @tracked isDisabled = false;
+    }
+    const model = new Model();
+
+    const items = ['Option 1', 'Option 2'];
+
+    await render(
+      <template>
+        <Field @name="input" @disabled={{model.isDisabled}} as |field|>
+          <field.Input @label="Input Field" data-test-input />
+        </Field>
+
+        <Field @name="checkbox" @disabled={{model.isDisabled}} as |field|>
+          <field.Checkbox @label="Checkbox Field" data-test-checkbox />
+        </Field>
+
+        <Field @name="select" @disabled={{model.isDisabled}} as |field|>
+          <field.SingleSelect
+            @label="Select Field"
+            @items={{items}}
+            data-test-select
+          />
+        </Field>
+
+        <Field @name="textarea" @disabled={{model.isDisabled}} as |field|>
+          <field.Textarea @label="Textarea Field" data-test-textarea />
+        </Field>
+      </template>
+    );
+
+    // Initially not disabled
+    assert.dom('[data-test-input]').isNotDisabled('Input is not disabled');
+    assert
+      .dom('[data-test-checkbox]')
+      .isNotDisabled('Checkbox is not disabled');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .isNotDisabled('Select is not disabled');
+    assert
+      .dom('[data-test-textarea]')
+      .isNotDisabled('Textarea is not disabled');
+
+    // Enable disabled state
+    model.isDisabled = true;
+    await settled();
+
+    // Now all fields should be disabled
+    assert.dom('[data-test-input]').isDisabled('Input is disabled');
+    assert.dom('[data-test-checkbox]').isDisabled('Checkbox is disabled');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .isDisabled('Select is disabled');
+    assert.dom('[data-test-textarea]').isDisabled('Textarea is disabled');
+  });
+
+  /**
+   * Test that Field respects the HTML disabled attribute
+   * This ensures that passing disabled={{true}} as a regular HTML attribute
+   * also works correctly (in addition to the @disabled argument)
+   */
+  test('it disables yielded components when HTML disabled={{true}} attribute is passed', async function (assert) {
+    assert.expect(4);
+
+    class Model {
+      @tracked isDisabled = false;
+    }
+    const model = new Model();
+
+    await render(
+      <template>
+        <Field @name="input" as |field|>
+          <field.Input
+            @label="Input Field"
+            disabled={{model.isDisabled}}
+            data-test-input
+          />
+        </Field>
+
+        <Field @name="checkbox" as |field|>
+          <field.Checkbox
+            @label="Checkbox Field"
+            disabled={{model.isDisabled}}
+            data-test-checkbox
+          />
+        </Field>
+      </template>
+    );
+
+    // Initially not disabled
+    assert
+      .dom('[data-test-input]')
+      .isNotDisabled('Input is not disabled initially');
+    assert
+      .dom('[data-test-checkbox]')
+      .isNotDisabled('Checkbox is not disabled initially');
+
+    // Enable disabled state via HTML attribute
+    model.isDisabled = true;
+    await settled();
+
+    // Now fields should be disabled via HTML attribute
+    assert
+      .dom('[data-test-input]')
+      .isDisabled('Input is disabled via HTML attribute');
+    assert
+      .dom('[data-test-checkbox]')
+      .isDisabled('Checkbox is disabled via HTML attribute');
+  });
 });


### PR DESCRIPTION
Add support for disabling an entire form by passing in `@disabled={{true}}` to the `Form` component.  Note:  in order to take advantage of whole-form disabled, fields must be expressed via the yielded `Field` component.