### PR TITLE
fix: use setTimeout instead of requestAnimationFrame for reliability in headless browsers

### DIFF
--- a/packages/forms/src/utils/index.ts
+++ b/packages/forms/src/utils/index.ts
@@ -5,7 +5,7 @@ function triggerFormInputEvent(element?: HTMLElement | null): void {
   if (!element) return;
   const waiterToken = waiter.beginAsync();
 
-  requestAnimationFrame(() => {
+  setTimeout(() => {
     let parent = element.parentElement;
     while (parent) {
       if (parent.tagName === 'FORM') {
@@ -18,7 +18,7 @@ function triggerFormInputEvent(element?: HTMLElement | null): void {
     }
 
     waiter.endAsync(waiterToken);
-  });
+  }, 0);
 }
 
 export { triggerFormInputEvent };


### PR DESCRIPTION
The trigger-input form helper moves away from using `requestAnimationFrame` to using `setTimeout` for greater reliability.  When a browser is in a `hidden` visibility state, `requestAnimationFrame` calls are not executed.  Sometimes, Ember's headless browser enters a `hidden` state, which made this function unreliable.  `setTimeout` is always executed regardless of visibility, solving the problem for some test runs.