### PR TITLE
refactor: Use camelCase for semantic contrast colors

### DIFF
--- a/packages/theme/src/colors/semantic.ts
+++ b/packages/theme/src/colors/semantic.ts
@@ -15,115 +15,115 @@ import type { ThemeColors } from './types';
 
 const themeColorsLight: ThemeColors = {
   neutral: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     strong: absolute.black,
     medium: `${absolute.black}c9`,
     DEFAULT: `${absolute.black}c9`,
     soft: `${absolute.black}73`,
     subtle: `${absolute.black}0f`,
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   success: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${lightPalette.green['400']}80`,
     medium: lightPalette.green['800'],
     DEFAULT: lightPalette.green['800'],
     strong: lightPalette.green['900'],
     soft: lightPalette.green['600'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   inverse: {
-    'contrast-1': absolute.black,
+    contrastPrimary: absolute.black,
     subtle: `${absolute.white}24`,
     soft: `${absolute.white}4f`,
     medium: `${absolute.white}c4`,
     DEFAULT: `${absolute.white}c4`,
     strong: absolute.white,
-    'contrast-2': absolute.white
+    contrastSecondary: absolute.white
   },
   brand: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${lightPalette.blue['800']}0d`,
     medium: lightPalette.blue['800'],
     DEFAULT: lightPalette.blue['800'],
     soft: lightPalette.blue['500'],
     strong: lightPalette.blue['1000'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   danger: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${lightPalette.red['800']}1a`,
     soft: lightPalette.red['500'],
     medium: lightPalette.red['800'],
     DEFAULT: lightPalette.red['800'],
     strong: lightPalette.red['900'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   warning: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${lightPalette.orange['700']}1a`,
     soft: lightPalette.orange['600'],
     medium: lightPalette.orange['700'],
     DEFAULT: lightPalette.orange['700'],
     strong: lightPalette.orange['800'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   }
 };
 
 const themeColorsDark: ThemeColors = {
   neutral: {
-    'contrast-1': absolute.black,
+    contrastPrimary: absolute.black,
     subtle: `${absolute.white}24`,
     soft: `${absolute.white}4f`,
     medium: `${absolute.white}c4`,
     DEFAULT: `${absolute.white}c4`,
     strong: absolute.white,
-    'contrast-2': absolute.white
+    contrastSecondary: absolute.white
   },
   success: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${darkPalette.green['1000']}33`,
     soft: darkPalette.green['600'],
     medium: darkPalette.green['900'],
     DEFAULT: darkPalette.green['900'],
     strong: darkPalette.green['1000'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   inverse: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${absolute.black}0f`,
     soft: `${absolute.black}73`,
     medium: `${absolute.black}c9`,
     DEFAULT: `${absolute.black}c9`,
     strong: absolute.black,
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   brand: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${darkPalette.blue['1000']}33`,
     soft: darkPalette.blue['700'],
     medium: darkPalette.blue['800'],
     DEFAULT: darkPalette.blue['800'],
     strong: darkPalette.blue['1000'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   danger: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${darkPalette.red['1000']}59`,
     soft: darkPalette.red['500'],
     medium: darkPalette.red['800'],
     DEFAULT: darkPalette.red['800'],
     strong: darkPalette.red['1000'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   },
   warning: {
-    'contrast-1': absolute.white,
+    contrastPrimary: absolute.white,
     subtle: `${darkPalette.orange['1000']}59`,
     soft: darkPalette.orange['800'],
     medium: darkPalette.orange['900'],
     DEFAULT: darkPalette.orange['900'],
     strong: darkPalette.orange['1000'],
-    'contrast-2': absolute.black
+    contrastSecondary: absolute.black
   }
 };
 

--- a/packages/theme/src/colors/types.ts
+++ b/packages/theme/src/colors/types.ts
@@ -34,8 +34,8 @@ export type SemanticBaseColors = {
 };
 
 export interface SemanticColorCategory {
-  'contrast-1': string;
-  'contrast-2': string;
+  contrastPrimary: string;
+  contrastSecondary: string;
   subtle: string;
   medium: string;
   strong: string;


### PR DESCRIPTION
Changes semantic color contrast property naming from kebab-case with numbers to camelCase for consistency with the Underline Design System token contract.

## Summary

Updates the semantic colors v2 spec to use `contrastPrimary`/`contrastSecondary` instead of `'contrast-1'`/`'contrast-2'`. This eliminates the need for transformation logic in the design system's Frontile generator and establishes a cleaner contract between the two systems.

## Changes

- **types.ts**: Updated `SemanticColorCategory` interface to use camelCase keys
- **semantic.ts**: Updated all 12 color definitions (6 categories × 2 themes) to use camelCase properties

## Rationale

The Underline Design System uses `contrastPrimary`/`contrastSecondary` naming in its source tokens. PR #186 introduced mapping logic to transform these to `'contrast-1'`/`'contrast-2'` for Frontile compatibility. By standardizing on camelCase across both systems, we eliminate this transformation layer and establish a more maintainable contract.

## Related

- Builds on #420 (Semantic colors v2)
- Coordinated with Underline Design System PR #186