### PR TITLE
CSS-first theme configuration with Tailwind v4

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,20 +36,17 @@ With modern build tools and explicit imports (`.gts`/`.gjs`), only the component
 
 ## Setup Theme
 
-### Tailwind CSS v4 (Recommended)
-
-#### Using Default Theme
+### Using Default Theme
 
 For the default theme, add this to your `app/styles/app.css`:
 
 ```css
 @import 'tailwindcss' source('../../');
 @plugin "@frontile/theme/plugin/default";
-@source '../../node_modules/@frontile';
-@custom-variant dark (&:is(.dark *));
+@import "@frontile/theme";
 ```
 
-#### Customizing Frontile Theme
+### Customizing Frontile Theme
 
 To customize the frontile theme, create a file in the root of your project named `frontile.js` with the following content:
 
@@ -66,33 +63,7 @@ Then update your `app/styles/app.css` to use the custom configuration:
 ```css
 @import 'tailwindcss' source('../../');
 @plugin "./../../frontile.js";
-@source '../../node_modules/@frontile';
+@import "@frontile/theme";
 ```
 
-### Tailwind CSS v3 (Legacy)
-
-For projects still using Tailwind CSS v3, add `frontile` plugin to your `tailwind.config.js`, add options to `content` and `safelist`.
-
-```js
-// tailwind.config.js
-const { frontile, safelist } = require('@frontile/theme/plugin');
-
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  darkMode: 'class',
-  plugins: [frontile()],
-
-  content: [
-    // ....
-    './node_modules/@frontile/theme/dist/**/*.{js,ts}'
-  ],
-
-  safelist: [
-    ...safelist,
-
-    // Power Select
-    { pattern: /^ember-power-select/ }
-  ]
-  // ...
-};
-```
+For more advanced configuration options, see the [Theme documentation](/docs/theme/overview).

--- a/docs/theme/overview.md
+++ b/docs/theme/overview.md
@@ -21,21 +21,17 @@ ember install @frontile/theme
 
 ## Configuration
 
-### Tailwind CSS v4
-
-#### Using Default Theme
+### Using Default Theme
 
 Add this to your `app/styles/app.css`:
 
 ```css
 @import 'tailwindcss' source('../../');
 @plugin "@frontile/theme/plugin/default";
-@source '../../node_modules/@frontile';
-@custom-variant dark (&:is(.dark *, .light .theme-inverse *):not(.dark .theme-inverse *));
-@custom-variant light (&:is(.light *, .dark .theme-inverse *):not(.light .theme-inverse *));
+@import "@frontile/theme";
 ```
 
-#### Custom Theme Configuration
+### Custom Theme Configuration
 
 Create `frontile.js` in your project root:
 
@@ -52,9 +48,7 @@ Then update `app/styles/app.css`:
 ```css
 @import 'tailwindcss' source('../../');
 @plugin "./../../frontile.js";
-@source '../../node_modules/@frontile';
-@custom-variant dark (&:is(.dark *, .light .theme-inverse *):not(.dark .theme-inverse *));
-@custom-variant light (&:is(.light *, .dark .theme-inverse *):not(.light .theme-inverse *));
+@import "@frontile/theme";
 ```
 
 ## Key Concepts
@@ -99,6 +93,26 @@ Toggle between light and dark themes by adding or removing the `dark` class on a
 
 Remove the `dark` class to revert to light theme. You can also explicitly use the `light` class if needed.
 
+### How Theme Classes Work
+
+Frontile uses custom CSS variants that intelligently apply theme-specific styles:
+
+- **`.dark`** - When present on a parent element, all descendant elements use dark theme colors
+- **`.light`** - When present on a parent element, all descendant elements use light theme colors (default)
+- **`.theme-inverse`** - Inverts the current theme for a section and its descendants
+
+The theme system uses sophisticated CSS selectors to ensure proper inheritance:
+
+```css
+/* Light theme applies to .light elements and .theme-inverse within .dark */
+.light *, .dark .theme-inverse *
+
+/* Dark theme applies to .dark elements and .theme-inverse within .light */
+.dark *, .light .theme-inverse *
+```
+
+This means you can nest themes and use theme-inverse sections anywhere in your application, and the colors will automatically adapt.
+
 ## Theme Inverse
 
 Create sections with inverted theme colors using the `theme-inverse` utility class. In light mode, these sections display dark theme colors, and vice versa.
@@ -134,13 +148,80 @@ Frontile provides six semantic color categories:
 - **Success** - Positive states and actions (green)
 - **Danger** - Errors and destructive actions (red)
 - **Warning** - Warnings and cautions (orange)
-- **Inverse** - High-contrast overlays
 
-Each category has intuitive levels: `on-{color}-{level}`, `subtle`, `soft`, `medium`, and `strong`. The `on-` prefix automatically provides optimal contrasting text colors (black or white) for accessibility.
+Each category has intuitive levels: `subtle`, `soft`, `medium`, and `strong`. The `on-{color}-{level}` prefix automatically provides optimal contrasting text colors (black or white) for accessibility.
 
 <ColorPaletteGrid @category="brand" @showDescription={{false}} />
 <ColorPaletteGrid @category="success" @showDescription={{false}} />
 <ColorPaletteGrid @category="danger" @showDescription={{false}} />
+
+### How Colors Adapt to Themes
+
+Colors automatically adapt based on the current theme (`.dark`, `.light`, or `.theme-inverse`). Frontile uses CSS variables that change their values based on the theme context:
+
+```css
+/* Example: brand-medium adapts to the theme */
+.light {
+  --brand-medium: 220 90% 50%;  /* Bright blue in light mode */
+}
+
+.dark {
+  --brand-medium: 220 90% 60%;  /* Lighter blue in dark mode */
+}
+```
+
+When you use `bg-brand-medium`, the actual color value comes from the CSS variable, which automatically switches based on whether the element is in a `.light` or `.dark` context.
+
+### Using Colors in Your CSS
+
+You can use semantic colors in custom CSS using the Tailwind `theme()` function or CSS variables:
+
+```css
+/* Using Tailwind theme function */
+.my-component {
+  background-color: theme(colors.brand.medium);
+  color: theme(colors.on-brand.medium);
+}
+
+/* Using CSS variables directly */
+.my-component {
+  background-color: hsl(var(--brand-medium));
+  color: hsl(var(--on-brand-medium));
+}
+```
+
+### Customizing Colors
+
+You can customize semantic colors using the JavaScript plugin configuration:
+
+```js
+const { frontile } = require('@frontile/theme/plugin');
+
+module.exports = frontile({
+  themes: {
+    light: {
+      colors: {
+        brand: {
+          subtle: '#eff6ff',
+          soft: '#93c5fd',
+          medium: '#3b82f6',
+          strong: '#1e40af'
+        }
+      }
+    },
+    dark: {
+      colors: {
+        brand: {
+          subtle: '#1e3a8a',
+          soft: '#3b82f6',
+          medium: '#60a5fa',
+          strong: '#dbeafe'
+        }
+      }
+    }
+  }
+});
+```
 
 [Learn more about semantic colors →](/docs/theme/colors)
 
@@ -204,6 +285,126 @@ module.exports = frontile({
     // ... your themes
   }
 });
+```
+
+## Advanced Configuration
+
+### Customizing with CSS Variables
+
+The recommended approach for Tailwind v4 is to customize theme values directly using CSS variables. This provides fine-grained control without JavaScript configuration and better performance.
+
+#### Override Theme Defaults
+
+Add your customizations in your `app/styles/app.css` after importing the theme:
+
+```css
+@import 'tailwindcss' source('../../');
+@plugin "@frontile/theme/plugin/default";
+@import "@frontile/theme";
+
+/* Override Tailwind theme utilities */
+@theme {
+  /* Custom border radius values */
+  --radius: 0.75rem;        /* Change default radius */
+  --radius-pill: 2rem;      /* Custom pill radius */
+
+  /* Custom opacity values */
+  --opacity-hover: .9;
+  --opacity-disabled: .4;
+}
+
+/* Override component-specific values */
+:root {
+  /* Modal sizes */
+  --modal-md: 32rem;
+  --modal-lg: 48rem;
+
+  /* Drawer sizes */
+  --drawer-md: 32rem;
+  --drawer-lg: 48rem;
+}
+```
+
+#### Theme-Specific Customization
+
+Customize layout values for specific themes using the `.dark` and `.light` classes. **Important:** To properly target all instances of a theme including `.theme-inverse` sections, use both selectors:
+
+```css
+@import "@frontile/theme";
+
+/* Light theme customization - targets .light AND .theme-inverse within .dark */
+.light,
+.dark .theme-inverse {
+  --opacity-hover: .85;
+}
+
+/* Dark theme customization - targets .dark AND .theme-inverse within .light */
+.dark,
+.light .theme-inverse {
+  --opacity-hover: .75;
+  --modal-lg: 56rem;
+}
+```
+
+**Why both selectors?**
+- `.light` targets elements in light mode
+- `.dark .theme-inverse` targets inverted sections within dark mode (which display light theme)
+- This ensures your customizations apply consistently across both regular theme usage and theme-inverse sections
+
+> **Note:** Variables in the `@theme` block automatically generate Tailwind utilities (e.g., `--radius-xl` creates `rounded-xl` class). Variables in `:root` or theme-specific selectors are for component-specific values that don't need utility classes. **Colors should be customized using the JavaScript plugin configuration, not CSS variables.**
+
+### JavaScript Configuration
+
+You can also configure the theme using JavaScript by creating a `frontile.js` file in your project root:
+
+```js
+const { frontile } = require('@frontile/theme/plugin');
+
+module.exports = frontile({
+  defaultTheme: 'dark',
+  themes: {
+    light: {
+      colors: {
+        // Customize semantic colors
+        brand: {
+          subtle: '#eff6ff',
+          soft: '#93c5fd',
+          medium: '#3b82f6',
+          strong: '#1e40af'
+        }
+      },
+      layout: {
+        // Customize layout values
+        opacity: {
+          hover: .85,
+          disabled: .4
+        },
+        radius: {
+          DEFAULT: '0.75rem',
+          pill: '2rem'
+        }
+      }
+    },
+    dark: {
+      colors: {
+        brand: {
+          subtle: '#1e3a8a',
+          soft: '#3b82f6',
+          medium: '#60a5fa',
+          strong: '#dbeafe'
+        }
+      }
+    }
+  }
+});
+```
+
+Then reference it in your CSS:
+
+```css
+@import 'tailwindcss' source('../../');
+@plugin "./../../frontile.js";
+@import "@frontile/theme";
 ```
 
 ## Best Practices

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./declarations/index.d.ts",
+      "style": "./src/index.css",
       "default": "./dist/index.js"
     },
     "./*": {
@@ -35,7 +36,8 @@
     "addon-main.js",
     "declarations",
     "dist",
-    "tailwind"
+    "tailwind",
+    "src/index.css"
   ],
   "scripts": {
     "build": "rollup --config",

--- a/packages/theme/src/index.css
+++ b/packages/theme/src/index.css
@@ -1,0 +1,69 @@
+@source './';
+
+/* Theme variants */
+@custom-variant dark (&:is(.dark *, .light .theme-inverse *):not(.dark .theme-inverse *));
+@custom-variant light (&:is(.light *, .dark .theme-inverse *):not(.light .theme-inverse *));
+@custom-variant focus-visible (&[data-focus-visible-added]);
+
+/* Data state variants */
+@custom-variant data-is-active (&[data-active=true]);
+@custom-variant group-data-is-active (:merge(.group)[data-active="true"] &);
+
+/* ARIA variants */
+@custom-variant aria-invalid (&[aria-invalid="true"]);
+
+/* Animations */
+@keyframes loading {
+  from {
+    transform: translateX(-100%) scaleX(0);
+  }
+  to {
+    transform: translateX(200%) scaleX(3);
+  }
+}
+
+@keyframes swing {
+  0%, 100% {
+    width: 50%;
+    transform: translateX(-25%);
+  }
+  50% {
+    transform: translateX(125%);
+  }
+}
+
+/* Default theme values - can be overridden via CSS or JS config */
+:root {
+  /* Drawer Sizes */
+  --drawer-xs: 20rem;
+  --drawer-sm: 24rem;
+  --drawer-md: 28rem;
+  --drawer-lg: 32rem;
+  --drawer-xl: 36rem;
+  --drawer-full: 100%;
+
+  /* Modal Sizes */
+  --modal-xs: 20rem;
+  --modal-sm: 24rem;
+  --modal-md: 28rem;
+  --modal-lg: 32rem;
+  --modal-xl: 36rem;
+  --modal-full: 100%;
+}
+
+/* Tailwind theme - auto-generates utilities */
+@theme {
+  /* Border Radius */
+  --radius-xs: 0.125rem;  /* 2px */
+  --radius-sm: 0.25rem;   /* 4px */
+  --radius-md: 0.375rem;  /* 6px */
+  --radius: 0.5rem;       /* 8px - DEFAULT */
+  --radius-lg: 0.75rem;   /* 12px */
+  --radius-xl: 0.75rem;   /* 12px */
+  --radius-2xl: 1rem;     /* 16px */
+  --radius-pill: 9999px;
+
+  /* Opacity */
+  --opacity-hover: .8;
+  --opacity-disabled: .5;
+}

--- a/packages/theme/src/plugin.ts
+++ b/packages/theme/src/plugin.ts
@@ -13,7 +13,7 @@ export { safelist } from './plugin/safelist';
 
 function frontile(config: PluginConfig = {}): ReturnType<typeof plugin> {
   const c = resolveConfig(config);
-  const resolved = resolveThemes(c.themes, c.defaultTheme, c.prefix);
+  const resolved = resolveThemes(c.themes, c.defaultTheme);
 
   return plugin(
     ({ addComponents, theme, addVariant, addBase, addUtilities }) => {
@@ -29,12 +29,6 @@ function frontile(config: PluginConfig = {}): ReturnType<typeof plugin> {
         addVariant(variant.name, variant.definition);
       });
 
-      addVariant('data-is-active', '&[data-active=true]');
-      addVariant(
-        'group-data-is-active',
-        ':merge(.group)[data-active="true"] &'
-      );
-
       addTransitions(
         addComponents,
         '.notification-transition',
@@ -43,31 +37,9 @@ function frontile(config: PluginConfig = {}): ReturnType<typeof plugin> {
 
       addTransitions(addComponents, '.overlay-transition', overlayTransitions);
 
-      // drawer sizes
-      drawerSizes(
-        addComponents,
-        {
-          xs: '20rem',
-          sm: '24rem',
-          md: '28rem',
-          lg: '32rem',
-          xl: '36rem',
-          full: '100%'
-        },
-        theme('spacing.8')
-      );
-      modalSizes(
-        addComponents,
-        {
-          xs: '20rem',
-          sm: '24rem',
-          md: '28rem',
-          lg: '32rem',
-          xl: '36rem',
-          full: '100%'
-        },
-        theme('spacing.8')
-      );
+      // drawer and modal sizes (using CSS variables)
+      drawerSizes(addComponents, theme('spacing.8'));
+      modalSizes(addComponents, theme('spacing.8'));
 
       addComponents({
         '.checked-bg-checkbox:checked': {
@@ -81,43 +53,13 @@ function frontile(config: PluginConfig = {}): ReturnType<typeof plugin> {
         }
       });
 
-      registerPowerSelectComponents(addComponents, c.prefix);
+      registerPowerSelectComponents(addComponents);
     },
     {
       theme: {
         extend: {
           colors: {
             ...(resolved?.colors as Record<string, never>)
-          },
-          opacity: {
-            hover: `var(--${c.prefix}-hover-opacity)`,
-            disabled: `var(--${c.prefix}-disabled-opacity)`
-          },
-          aria: {
-            invalid: 'invalid="true"'
-          },
-          animation: {
-            loading: 'loading 1.5s linear infinite',
-            swing: 'swing 2s ease-in-out infinite'
-          },
-          keyframes: {
-            loading: {
-              from: {
-                transform: 'translateX(-100%) scaleX(0)'
-              },
-              to: {
-                transform: 'translateX(200%) scaleX(3)'
-              }
-            },
-            swing: {
-              '0%, 100%': {
-                width: '50%',
-                transform: 'translateX(-25%)'
-              },
-              '50%': {
-                transform: 'translateX(125%)'
-              }
-            }
           }
         }
       }

--- a/packages/theme/src/plugin/default-config.ts
+++ b/packages/theme/src/plugin/default-config.ts
@@ -1,21 +1,20 @@
 import { semanticColors } from '../colors/config';
 import type { LayoutTheme } from '../types';
 
-const baseLayout: LayoutTheme = {
-  disabledOpacity: '.5'
-};
+// No default layout values - defaults are in index.css
+// Users can override via CSS or configure via JS
+const baseLayout: LayoutTheme = {};
 
 const defaultConfig = {
   defaultTheme: 'light',
-  prefix: 'frontile',
   themes: {
     light: {
       colors: semanticColors.light,
-      layout: { ...baseLayout, hoverOpacity: '.8' }
+      layout: baseLayout
     },
     dark: {
       colors: semanticColors.dark,
-      layout: { ...baseLayout, hoverOpacity: '.7' }
+      layout: baseLayout
     }
   }
 };

--- a/packages/theme/src/plugin/overlays.ts
+++ b/packages/theme/src/plugin/overlays.ts
@@ -2,19 +2,20 @@ import type { CSSRuleObject, PluginAPI } from 'tailwindcss/types/config';
 
 function drawerSizes(
   addComponents: PluginAPI['addComponents'],
-  sizes: { [key: string]: string },
   margin: string
 ): void {
-  Object.keys(sizes).forEach((key) => {
-    const size = sizes[key] as string;
+  const sizes = ['xs', 'sm', 'md', 'lg', 'xl', 'full'];
+
+  sizes.forEach((key) => {
+    const sizeVar = `var(--drawer-${key})`;
     let rules: CSSRuleObject = {
-      maxHeight: size
+      maxHeight: sizeVar
     };
 
     if (key !== 'full') {
       rules = {
         ...rules,
-        [`@media(max-height: calc(${size} + ${margin}))`]: {
+        [`@media(max-height: calc(${sizeVar} + ${margin}))`]: {
           maxHeight: `calc(100vh - ${margin})`
         }
       };
@@ -22,13 +23,13 @@ function drawerSizes(
 
     addComponents({ [`.drawer--vertical-${key}`]: rules });
     rules = {
-      maxWidth: size
+      maxWidth: sizeVar
     };
 
     if (key !== 'full') {
       rules = {
         ...rules,
-        [`@media(max-width: calc(${size} + ${margin}))`]: {
+        [`@media(max-width: calc(${sizeVar} + ${margin}))`]: {
           maxWidth: `calc(100vw - ${margin})`
         }
       };
@@ -40,25 +41,26 @@ function drawerSizes(
 
 function modalSizes(
   addComponents: PluginAPI['addComponents'],
-  sizes: { [key: string]: string },
   margin: string
 ): void {
-  Object.keys(sizes).forEach((key) => {
-    const size = sizes[key] as string;
+  const sizes = ['xs', 'sm', 'md', 'lg', 'xl', 'full'];
+
+  sizes.forEach((key) => {
+    const sizeVar = `var(--modal-${key})`;
     let rules: CSSRuleObject = {};
 
     if (key === 'full') {
       rules = {
-        width: size,
-        height: size,
+        width: sizeVar,
+        height: sizeVar,
         marginTop: 'auto',
         marginBottom: 'auto',
         borderRadius: '0'
       };
     } else {
       rules = {
-        maxWidth: size,
-        [`@media(max-width: ${size})`]: {
+        maxWidth: sizeVar,
+        [`@media(max-width: ${sizeVar})`]: {
           maxWidth: `calc(100vw - ${margin})`
         }
       };

--- a/packages/theme/src/plugin/power-select.ts
+++ b/packages/theme/src/plugin/power-select.ts
@@ -2,8 +2,7 @@ import powerSelectPlugin from 'tailwindcss-ember-power-select';
 import type { PluginAPI } from 'tailwindcss/types/config';
 
 function registerPowerSelectComponents(
-  addComponents: PluginAPI['addComponents'],
-  prefix: string
+  addComponents: PluginAPI['addComponents']
 ): void {
   addComponents({
     '.ember-power-select-trigger, .ember-power-select-dropdown, .ember-power-select-search-input':
@@ -15,10 +14,10 @@ function registerPowerSelectComponents(
       },
     '.dark .ember-power-select-search-input, .dark .ember-power-select-trigger':
       {
-        backgroundColor: `hsl(var(--${prefix}-default-100) / var(--${prefix}-default-100-opacity, var(--tw-bg-opacity)))`
+        backgroundColor: `hsl(var(--default-100) / var(--default-100-opacity, var(--tw-bg-opacity)))`
       },
     '.dark .ember-power-select-dropdown': {
-      backgroundColor: `hsl(var(--${prefix}-default-200) / var(--${prefix}-default-200-opacity, var(--tw-bg-opacity)))`
+      backgroundColor: `hsl(var(--default-200) / var(--default-200-opacity, var(--tw-bg-opacity)))`
     }
   });
   powerSelectPlugin.registerComponents(
@@ -27,15 +26,15 @@ function registerPowerSelectComponents(
     },
     {},
     {
-      textColor: `hsl(var(--${prefix}-default-900) / var(--${prefix}-default-900-opacity, var(--tw-bg-opacity)))`,
-      disabledTextColor: `hsl(var(--${prefix}-default-500) / var(--${prefix}-default-500-opacity, var(--tw-text-opacity)))`,
-      disabledBorderColor: `hsl(var(--${prefix}-default-200) / var(--${prefix}-default-200-opacity, var(--tw-border-opacity)))`,
-      placeholderTextColor: `hsl(var(--${prefix}-default-400) / var(--${prefix}-default-400-opacity, var(--tw-placeholder-opacity)))`,
+      textColor: `hsl(var(--default-900) / var(--default-900-opacity, var(--tw-bg-opacity)))`,
+      disabledTextColor: `hsl(var(--default-500) / var(--default-500-opacity, var(--tw-text-opacity)))`,
+      disabledBorderColor: `hsl(var(--default-200) / var(--default-200-opacity, var(--tw-border-opacity)))`,
+      placeholderTextColor: `hsl(var(--default-400) / var(--default-400-opacity, var(--tw-placeholder-opacity)))`,
       backgroundColor: 'white',
       dropdownBackgroundColor: 'white',
-      borderColor: `hsl(var(--${prefix}-default-400) / var(--${prefix}-default-400-opacity, var(--tw-border-opacity)))`,
-      focusBorderColor: `hsl(var(--${prefix}-primary-400) / var(--${prefix}-primary-400-opacity, var(--tw-border-opacity)))`,
-      invalidBorderColor: `hsl(var(--${prefix}-danger-400) / var(--${prefix}-danger-400-opacity, var(--tw-border-opacity)))`
+      borderColor: `hsl(var(--default-400) / var(--default-400-opacity, var(--tw-border-opacity)))`,
+      focusBorderColor: `hsl(var(--primary-400) / var(--primary-400-opacity, var(--tw-border-opacity)))`,
+      invalidBorderColor: `hsl(var(--danger-400) / var(--danger-400-opacity, var(--tw-border-opacity)))`
       //   triggerFocusBoxShadow: config.focusBoxShadow,
       //   triggerFocusBoxShadowInvalid: config.focusBoxShadowInvalid,
       //   searchInputFocusBoxShadow: config.focusBoxShadow

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -2,15 +2,37 @@ import type { ThemeColors } from './colors/types';
 
 export interface LayoutTheme {
   /**
-   * A number between 0 and 1 that is applied as opacity: [value] when the component is hovered.
-   *
-   * format: ".[value]"
-   *
-   * @default .8
+   * Opacity configuration for components.
+   * Supports Tailwind's opacity-* naming convention.
    */
-  hoverOpacity?: string | number;
+  opacity?: {
+    /**
+     * A number between 0 and 1 that is applied as opacity when the component is hovered.
+     * @default .8
+     */
+    hover?: string | number;
+    /**
+     * A number between 0 and 1 that is applied as opacity when the component is disabled.
+     * @default .5
+     */
+    disabled?: string | number;
+  };
 
-  disabledOpacity?: string | number;
+  /**
+   * Border radius configuration for components.
+   * Values can be any valid CSS length unit (px, rem, em, etc.)
+   */
+  radius?: {
+    xs?: string;
+    sm?: string;
+    md?: string;
+    lg?: string;
+    DEFAULT?: string;
+    xl?: string;
+    '2xl'?: string;
+    full?: string;
+    pill?: string;
+  };
 }
 
 export type ConfigTheme = {
@@ -23,11 +45,6 @@ export type ConfigThemes = Record<string, ConfigTheme>;
 export type DefaultThemeType = 'light' | 'dark';
 
 export type PluginConfig = {
-  /**
-   * The prefix for the css variables.
-   * @default "frontile"
-   */
-  prefix?: string;
   themes?: ConfigThemes;
   layout?: LayoutTheme;
   defaultTheme?: DefaultThemeType;

--- a/site/app/styles/app.css
+++ b/site/app/styles/app.css
@@ -1,8 +1,8 @@
 @import "tailwindcss" source("../");
 @plugin "@frontile/theme/plugin/default";
 @plugin "@tailwindcss/typography";
-@source '../../node_modules/@frontile/theme';
 @source '../templates/docs/';
+@import "@frontile/theme";
 
 @font-face Inter {
   src: url(/assets/fonts/inter-var-latin-ext.woff2) format('woff2');
@@ -94,10 +94,6 @@
     @apply text-neutral-soft;
   }
 }
-
-@custom-variant dark (&:is(.dark *, .light .theme-inverse *):not(.dark .theme-inverse *));
-@custom-variant light (&:is(.light *, .dark .theme-inverse *):not(.light .theme-inverse *));
-@custom-variant focus-visible (&[data-focus-visible-added]);
 
 @import './highlight.css';
 @import './docfy-demo.css';

--- a/site/app/templates/index.gts
+++ b/site/app/templates/index.gts
@@ -100,7 +100,6 @@ class IndexPage extends Component {
 
   <template>
     <div class="min-h-screen bg-white dark:bg-black">
-
       {{! Hero Section }}
       <section
         class="relative overflow-hidden bg-gradient-to-b from-blue-50 to-white dark:from-gray-950 dark:to-black pt-20 pb-24 sm:pt-24 sm:pb-32"

--- a/test-app/app/tw.css
+++ b/test-app/app/tw.css
@@ -5,5 +5,4 @@
 @import "tailwindcss" source('./');
 /* @plugin "@frontile/theme/plugin/default"; */
 @plugin "../../../frontile.js";
-@source '../../@frontile';
-@custom-variant dark (&:is(.dark *));
+@import "@frontile/theme";


### PR DESCRIPTION
## Summary

Major refactoring to embrace Tailwind v4's CSS-first configuration approach. This PR moves static theme configuration from JavaScript to CSS, removes CSS variable prefixes, and provides comprehensive documentation for both CSS and JavaScript configuration methods.

## Key Changes

### 🎨 CSS-First Approach
- **New `index.css` file** with `@theme` block for Tailwind utilities (radius, opacity)
- **Custom variants moved to CSS**: `@custom-variant` for dark, light, theme-inverse, data-is-active, aria-invalid
- **Animations in CSS**: loading and swing keyframes
- **Default values in CSS**: opacity, drawer/modal sizes

### 🔧 Theme System Improvements
- **Unprefixed CSS variables**: `--frontile-brand-500` → `--brand-500`
- **Tailwind naming convention**: `--hover-opacity` → `--opacity-hover`
- **Simplified plugin**: Removed borderRadius and opacity theme extensions (now auto-generated by `@theme`)
- **Cleaner overlays**: drawer/modal sizes use CSS variables directly

### 📝 TypeScript Updates
- Updated `LayoutTheme` interface with nested structures:
  - `hoverOpacity`/`disabledOpacity` → `opacity.hover`/`opacity.disabled`
  - Matches Tailwind's naming convention for better DX
- Removed `prefix` option from `PluginConfig`

### 📚 Documentation Overhaul
- **Simplified installation docs**: Removed Tailwind v3 legacy content
- **Comprehensive theme documentation**:
  - CSS-first configuration guide (recommended)
  - JavaScript configuration (alternative)
  - Theme classes explained (`.dark`, `.light`, `.theme-inverse`)
  - Color system with adaptation details
  - Advanced configuration section
- **Theme-inverse selector usage**: Proper multi-selector approach for CSS customization

## Breaking Changes

⚠️ **CSS Variable Names**: All unprefixed (migration needed if using CSS variables directly)
⚠️ **LayoutTheme Interface**: API changed to nested structure
⚠️ **Required Import**: Apps must add `@import "@frontile/theme"` in app.css

## Migration Guide

### Update app.css
```css
@import 'tailwindcss' source('../../');
@plugin "@frontile/theme/plugin/default";
@import "@frontile/theme";  /* ← Add this line */
```

### Update theme config (if using JS config)
```diff
// Before
layout: {
-  hoverOpacity: .9,
-  disabledOpacity: .4
}

// After
layout: {
+  opacity: {
+    hover: .9,
+    disabled: .4
+  }
}
```

## Test Plan

- [x] Build theme package successfully
- [x] Verify CSS imports work
- [x] Test radius utilities generated from `@theme`
- [x] Test opacity utilities generated from `@theme`
- [x] Verify unprefixed CSS variables work
- [x] Test theme switching (light/dark)
- [x] Test theme-inverse functionality
- [x] Documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)