### PR TITLE
use `ComponentLike` with `WithBoundArgs`

### DIFF
--- a/packages/buttons/src/components/button-group.gts
+++ b/packages/buttons/src/components/button-group.gts
@@ -1,10 +1,10 @@
 import Component from '@glimmer/component';
 import { hash } from '@ember/helper';
 import { useStyles } from '@frontile/theme';
-import Button from './button';
+import Button, { type ButtonSignature } from './button';
 import type { ButtonArgs } from './button';
-import ToggleButton from './toggle-button';
-import type { WithBoundArgs } from '@glint/template';
+import ToggleButton, { type ToggleButtonSignature } from './toggle-button';
+import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 interface ButtonGroupArgs
   extends Pick<ButtonArgs, 'appearance' | 'intent' | 'size' | 'class'> {}
@@ -14,8 +14,8 @@ interface ButtonGroupSignature {
   Blocks: {
     default: [
       {
-        Button: WithBoundArgs<typeof Button, 'isInGroup'>;
-        ToggleButton: WithBoundArgs<typeof ToggleButton, 'isInGroup'>;
+        Button: WithBoundArgs<ComponentLike<ButtonSignature>, 'isInGroup'>;
+        ToggleButton: WithBoundArgs<ComponentLike<ToggleButtonSignature>, 'isInGroup'>;
       }
     ];
   };

--- a/packages/collections/src/components/simple-table/index.gts
+++ b/packages/collections/src/components/simple-table/index.gts
@@ -1,15 +1,15 @@
 import Component from '@glimmer/component';
 import { hash } from '@ember/helper';
 import { useStyles } from '@frontile/theme';
-import { SimpleTableHeader } from './header';
-import { SimpleTableBody } from './body';
-import { SimpleTableFooter } from './footer';
-import { SimpleTableColumn } from './column';
-import { SimpleTableRow } from './row';
-import { SimpleTableCell } from './cell';
+import { SimpleTableHeader, type SimpleTableHeaderSignature } from './header';
+import { SimpleTableBody, type SimpleTableBodySignature } from './body';
+import { SimpleTableFooter, type SimpleTableFooterSignature } from './footer';
+import { SimpleTableColumn, type SimpleTableColumnSignature } from './column';
+import { SimpleTableRow, type SimpleTableRowSignature } from './row';
+import { SimpleTableCell, type SimpleTableCellSignature } from './cell';
 
 import type { TableVariants, TableSlots, SlotsToClasses } from '../table/types';
-import type { WithBoundArgs } from '@glint/template';
+import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 interface SimpleTableSignature {
   Args: {
@@ -38,12 +38,12 @@ interface SimpleTableSignature {
   Blocks: {
     default: [
       {
-        Header: WithBoundArgs<typeof SimpleTableHeader, 'styleFns' | 'classes'>;
-        Body: WithBoundArgs<typeof SimpleTableBody, 'styleFns' | 'classes'>;
-        Footer: WithBoundArgs<typeof SimpleTableFooter, 'styleFns' | 'classes'>;
-        Column: WithBoundArgs<typeof SimpleTableColumn, 'styleFns'>;
-        Row: WithBoundArgs<typeof SimpleTableRow, 'styleFns' | 'classes'>;
-        Cell: WithBoundArgs<typeof SimpleTableCell, 'styleFns' | 'classes'>;
+        Header: WithBoundArgs<ComponentLike<SimpleTableHeaderSignature>, 'styleFns' | 'classes'>;
+        Body: WithBoundArgs<ComponentLike<SimpleTableBodySignature>, 'styleFns' | 'classes'>;
+        Footer: WithBoundArgs<ComponentLike<SimpleTableFooterSignature>, 'styleFns' | 'classes'>;
+        Column: WithBoundArgs<ComponentLike<SimpleTableColumnSignature>, 'styleFns'>;
+        Row: WithBoundArgs<ComponentLike<SimpleTableRowSignature>, 'styleFns' | 'classes'>;
+        Cell: WithBoundArgs<ComponentLike<SimpleTableCellSignature>, 'styleFns' | 'classes'>;
       }
     ];
   };

--- a/packages/forms/src/components/form-control.gts
+++ b/packages/forms/src/components/form-control.gts
@@ -1,10 +1,10 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { hash } from '@ember/helper';
-import Feedback from './form-feedback';
-import Description from './form-description';
-import Label from './label';
-import type { WithBoundArgs } from '@glint/template';
+import Feedback, { type FormFeedbackSignature } from './form-feedback';
+import Description, { type FormDescriptionSignature } from './form-description';
+import Label, { type LabelSignature } from './label';
+import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 interface FormControlSharedArgs {
   label?: string;
@@ -33,10 +33,10 @@ interface FormControlSignature {
           hasDescription?: string | boolean,
           hasFeedback?: string | boolean
         ) => string | undefined;
-        Label: WithBoundArgs<typeof Label, 'for' | 'size' | 'isRequired'>;
-        Description: WithBoundArgs<typeof Description, 'id' | 'size'>;
+        Label: WithBoundArgs<ComponentLike<LabelSignature>, 'for' | 'size' | 'isRequired'>;
+        Description: WithBoundArgs<ComponentLike<FormDescriptionSignature>, 'id' | 'size'>;
         Feedback: WithBoundArgs<
-          typeof Feedback,
+          ComponentLike<FormFeedbackSignature>,
           'id' | 'size' | 'messages' | 'intent'
         >;
       }

--- a/packages/overlays/src/components/drawer.gts
+++ b/packages/overlays/src/components/drawer.gts
@@ -2,11 +2,11 @@ import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { hash } from '@ember/helper';
 import Overlay, { type OverlaySignature } from './overlay';
-import DrawerBody from './drawer/body';
-import DrawerFooter from './drawer/footer';
-import DrawerHeader from './drawer/header';
-import { CloseButton } from '@frontile/buttons';
-import type { WithBoundArgs } from '@glint/template';
+import DrawerBody, { type DrawerBodySignature } from './drawer/body';
+import DrawerFooter, { type DrawerFooterSignature } from './drawer/footer';
+import DrawerHeader, { type DrawerHeaderSignature } from './drawer/header';
+import { CloseButton, type CloseButtonSignature } from '@frontile/buttons';
+import type { ComponentLike, WithBoundArgs } from '@glint/template';
 import {
   useStyles,
   type SlotsToClasses,
@@ -83,13 +83,22 @@ export interface DrawerSignature {
   Blocks: {
     default: [
       {
-        CloseButton: WithBoundArgs<typeof CloseButton, 'onPress' | 'class'>;
+        CloseButton: WithBoundArgs<
+          ComponentLike<CloseButtonSignature>,
+          'onPress' | 'class'
+        >;
         Header: WithBoundArgs<
-          typeof DrawerHeader,
+          ComponentLike<DrawerHeaderSignature>,
           'labelledById' | 'classFromParent'
         >;
-        Body: WithBoundArgs<typeof DrawerBody, 'classFromParent'>;
-        Footer: WithBoundArgs<typeof DrawerFooter, 'classFromParent'>;
+        Body: WithBoundArgs<
+          ComponentLike<DrawerBodySignature>,
+          'classFromParent'
+        >;
+        Footer: WithBoundArgs<
+          ComponentLike<DrawerFooterSignature>,
+          'classFromParent'
+        >;
         headerId: string;
       }
     ];

--- a/packages/overlays/src/components/modal.gts
+++ b/packages/overlays/src/components/modal.gts
@@ -2,17 +2,17 @@ import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { hash } from '@ember/helper';
 import Overlay, { type OverlaySignature } from './overlay';
-import ModalFooter from './modal/footer';
-import ModalBody from './modal/body';
-import ModalHeader from './modal/header';
-import { CloseButton } from '@frontile/buttons';
+import ModalFooter, { type ModalFooterSignature } from './modal/footer';
+import ModalBody, { type ModalBodySignature } from './modal/body';
+import ModalHeader, { type ModalHeaderSignature } from './modal/header';
+import { CloseButton, type CloseButtonSignature } from '@frontile/buttons';
 import {
   useStyles,
   type SlotsToClasses,
   type ModalSlots,
   type ModalVariants
 } from '@frontile/theme';
-import type { WithBoundArgs } from '@glint/template';
+import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 export interface ModalArgs
   extends Pick<
@@ -82,13 +82,22 @@ export interface ModalSignature {
   Blocks: {
     default: [
       {
-        CloseButton: WithBoundArgs<typeof CloseButton, 'onPress' | 'class'>;
+        CloseButton: WithBoundArgs<
+          ComponentLike<CloseButtonSignature>,
+          'onPress' | 'class'
+        >;
         Header: WithBoundArgs<
-          typeof ModalHeader,
+          ComponentLike<ModalHeaderSignature>,
           'labelledById' | 'classFromParent'
         >;
-        Body: WithBoundArgs<typeof ModalBody, 'classFromParent'>;
-        Footer: WithBoundArgs<typeof ModalFooter, 'classFromParent'>;
+        Body: WithBoundArgs<
+          ComponentLike<ModalBodySignature>,
+          'classFromParent'
+        >;
+        Footer: WithBoundArgs<
+          ComponentLike<ModalFooterSignature>,
+          'classFromParent'
+        >;
         headerId: string;
       }
     ];


### PR DESCRIPTION
Fixes https://github.com/josemarluedke/frontile/issues/397

Glint V2 requires the typing of yielded contextual components to be handled differently:

https://typed-ember.gitbook.io/glint/using-glint/glint-types#withboundargs-and-withboundpositionals

This PR updates how these yielded contextual components are typed and addresses the problem in the linked issue.