### PR TITLE
feat: update checkbox and radio styles for better visibility

### DIFF
--- a/packages/forms/src/components/checkbox.md
+++ b/packages/forms/src/components/checkbox.md
@@ -229,6 +229,78 @@ export default class DisabledCheckbox extends Component {
 }
 ```
 
+### Indeterminate State
+
+The indeterminate state represents a "partially checked" state, commonly used for "select all" checkboxes when only some child items are selected. Since HTML doesn't support setting indeterminate via an attribute, you need to use a modifier to set it via JavaScript.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+import { Checkbox } from 'frontile';
+
+export default class IndeterminateCheckbox extends Component {
+  @tracked items = [
+    { label: 'Email notifications', checked: true },
+    { label: 'SMS notifications', checked: false },
+    { label: 'Push notifications', checked: true }
+  ];
+
+  get allChecked() {
+    return this.items.every((item) => item.checked);
+  }
+
+  get noneChecked() {
+    return this.items.every((item) => !item.checked);
+  }
+
+  get isIndeterminate() {
+    return !this.allChecked && !this.noneChecked;
+  }
+
+  setIndeterminate = modifier(
+    (element: HTMLInputElement, [indeterminate]: [boolean]) => {
+      element.indeterminate = indeterminate;
+    }
+  );
+
+  toggleAll = (checked: boolean) => {
+    this.items = this.items.map((item) => ({ ...item, checked }));
+  };
+
+  toggleItem = (index: number) => (checked: boolean) => {
+    this.items = this.items.map((item, i) =>
+      i === index ? { ...item, checked } : item
+    );
+  };
+
+  <template>
+    <div class='flex flex-col gap-2'>
+      <Checkbox
+        @name='select-all'
+        @label='Select All'
+        @checked={{this.allChecked}}
+        @onChange={{this.toggleAll}}
+        {{this.setIndeterminate this.isIndeterminate}}
+      />
+
+      <div class='ml-6 flex flex-col gap-2'>
+        {{#each this.items as |item index|}}
+          <Checkbox
+            @name='item-{{index}}'
+            @label={{item.label}}
+            @checked={{item.checked}}
+            @onChange={{this.toggleItem index}}
+          />
+        {{/each}}
+      </div>
+    </div>
+  </template>
+}
+```
+
+> **Note:** The `indeterminate` property can only be set via JavaScript — there is no HTML attribute for it. Use the `ember-modifier` package to create a modifier that sets `element.indeterminate` on the checkbox input.
+
 ### Checkbox with Description
 
 Add helpful description text that appears below the checkbox label.

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -132,12 +132,12 @@ const checkboxRadioBase = tv({
       'align-middle',
       'select-none',
       'shrink-0',
-      'h-[1em] w-[1em]',
       'text-base',
-      'text-brand',
-      'border border-neutral-soft',
+      'border-2 border-neutral-medium',
       'bg-surface-solid-0',
-      'checked:bg-origin-border checked:border-transparent dark:checked:bg-current checked:bg-current checked:bg-center checked:bg-no-repeat checked:disabled:bg-neutral-soft',
+      'transition-colors',
+      'checked:bg-origin-border checked:bg-center checked:bg-no-repeat',
+      'checked:disabled:bg-neutral-soft checked:disabled:border-neutral-soft',
       ...focusVisibleRing
     ],
     labelContainer: ['flex flex-col ml-2'],
@@ -145,9 +145,9 @@ const checkboxRadioBase = tv({
   },
   variants: {
     size: {
-      sm: { input: '' },
-      md: { input: '' },
-      lg: { input: '' }
+      sm: { input: 'h-4 w-4' },
+      md: { input: 'h-5 w-5' },
+      lg: { input: 'h-6 w-6' }
     }
   },
   defaultVariants: {
@@ -178,21 +178,21 @@ const checkbox = tv({
     input: [
       'checked-bg-checkbox',
       'indeterminate-bg-checkbox',
-      'rounded-xs',
+      'rounded-sm',
+      'checked:bg-brand-medium checked:border-brand-medium',
       // Indeterminate state styles - show minus/dash icon
-      'indeterminate:bg-brand',
+      'indeterminate:bg-brand-medium',
       'indeterminate:border-brand-medium',
       'indeterminate:bg-origin-border',
       'indeterminate:bg-center',
-      'indeterminate:bg-no-repeat',
-      'dark:indeterminate:bg-current'
+      'indeterminate:bg-no-repeat'
     ]
   },
   variants: {
     size: {
-      sm: { input: '' },
-      md: { input: '' },
-      lg: { input: '' }
+      sm: {},
+      md: {},
+      lg: {}
     }
   },
   defaultVariants: {
@@ -203,13 +203,17 @@ const checkbox = tv({
 const radio = tv({
   extend: checkboxRadioBase,
   slots: {
-    input: ['checked-bg-radio', 'rounded-full']
+    input: [
+      'checked-bg-radio',
+      'rounded-full',
+      'checked:bg-brand-medium checked:border-brand-medium'
+    ]
   },
   variants: {
     size: {
-      sm: { input: '' },
-      md: { input: '' },
-      lg: { input: '' }
+      sm: {},
+      md: {},
+      lg: {}
     }
   },
   defaultVariants: {

--- a/packages/theme/src/plugin.ts
+++ b/packages/theme/src/plugin.ts
@@ -49,7 +49,10 @@ function frontile(config: PluginConfig = {}): ReturnType<typeof plugin> {
           backgroundImage: `url("${svgToDataUri(checkboxIndeterminateIcon)}")`
         },
         '.checked-bg-radio:checked': {
-          backgroundImage: `url("${svgToDataUri(radioIcon)}")`
+          backgroundImage: `url("${svgToDataUri(radioIconLight)}")`
+        },
+        '.dark .checked-bg-radio:checked': {
+          backgroundImage: `url("${svgToDataUri(radioIconDark)}")`
         }
       });
 
@@ -69,6 +72,7 @@ function frontile(config: PluginConfig = {}): ReturnType<typeof plugin> {
 
 const checkboxIcon = `<svg viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg"><path d="M5.125 7.666a1.304 1.304 0 00-.882-.328 1.3 1.3 0 00-.876.343c-.232.216-.364.51-.367.816-.003.307.124.602.352.822l2.508 2.339c.235.219.554.342.886.342.333 0 .651-.123.887-.342l5.015-4.677c.228-.22.355-.516.352-.822a1.132 1.132 0 00-.367-.817A1.301 1.301 0 0011.757 5a1.304 1.304 0 00-.882.328l-4.129 3.85-1.621-1.512z"/></svg>`;
 const checkboxIndeterminateIcon = `<svg viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg"><path d="M3 7.5C3 7.22386 3.22386 7 3.5 7H12.5C12.7761 7 13 7.22386 13 7.5V8.5C13 8.77614 12.7761 9 12.5 9H3.5C3.22386 9 3 8.77614 3 8.5V7.5Z" fill="white"/></svg>`;
-const radioIcon = `<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="6" stroke="white" stroke-width="3" fill="none" /></svg>`;
+const radioIconLight = `<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="4" fill="white"/></svg>`;
+const radioIconDark = `<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="4" fill="#0c0c15"/></svg>`;
 
 export { frontile };


### PR DESCRIPTION
## Summary

- Increase checkbox/radio sizes with explicit size variants (sm: 16px, md: 20px, lg: 24px) instead of relative `h-[1em] w-[1em]`
- Use thicker borders (`border-2 border-neutral-medium`) for better visibility in both light and dark modes
- Use `brand-medium` fill for checked checkbox, radio, and indeterminate states
- Add `rounded-sm` to checkbox for more visible rounding per design
- Replace radio SVG icon with a filled inner dot, with separate light/dark mode variants
- Fix indeterminate checkbox rendering as a white box in dark mode by removing broken `dark:indeterminate:bg-current`
- Add indeterminate state documentation with an interactive "Select All" example

## Test plan

- [x] `pnpm --filter theme build` and `pnpm --filter forms build` succeed
- [x] `pnpm --filter theme lint:types` passes
- [x] Checkbox tests pass: `cd test-app && pnpm ember test --filter="Checkbox"` (51/51)
- [x] Radio tests pass: `cd test-app && pnpm ember test --filter="Radio"` (51/51)
- [x] Visual check: checkbox unchecked/checked/indeterminate in light and dark mode
- [x] Visual check: radio unselected/selected in light and dark mode
- [x] Visual check: size variants (sm/md/lg) render with distinct sizes
- [x] Visual check: disabled states render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)