### PR TITLE
docs: fix contradictory inverse color category note in v0.18 guide

### DIFF
--- a/docs/migrations/v0.18/index.md
+++ b/docs/migrations/v0.18/index.md
@@ -66,7 +66,7 @@ The semantic color system has been completely redesigned with named levels inste
 - Renamed `default-*` to `neutral-*` (the `primary-*` category name is unchanged; only its numbered scale moved to named levels)
 - Replaced numbered scales (50, 100, 200...) with named levels (subtle, soft, medium, strong)
 - Removed legacy `text-foreground` classes
-- Removed `inverse` color category (use `neutral` instead)
+- Added `inverse` color category for elements on inverted surfaces (e.g. `text-inverse-strong`)
 - Replaced `contrast-1`/`contrast-2` with automatic `on-{color}-{level}` classes
 
 **See:** [Semantic Colors Migration Guide](./semantic-colors.md)


### PR DESCRIPTION
## What changed

Fixed a contradictory entry in the v0.18 migration guide. `docs/migrations/v0.18/index.md` listed under "Key Changes":

> Removed `inverse` color category (use `neutral` instead)

This was wrong and directly contradicted `docs/migrations/v0.18/semantic-colors.md`, which documents `inverse` as a **new** category for elements on inverted surfaces.

The entry now reads:

> Added `inverse` color category for elements on inverted surfaces (e.g. `text-inverse-strong`)

## Why

Verified against the theme source — the `inverse` category genuinely exists and was added in v0.18:

- `packages/theme/src/colors/types.ts:78` — `inverse` defined with `subtle`/`soft`/`medium`/`strong` levels
- `packages/theme/src/colors/semantic.ts:149` (and `:325`) — actual OKLCH values for the inverse category

So the index was the documentation bug; semantic-colors.md was already correct.

## Notes for reviewer

- Docs-only change, one line. No code touched.
- Unrelated to the brand→primary rename; this was a pre-existing inaccuracy in the migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
