### PR TITLE
feat: add accent intent to Spinner, ProgressBar, Listbox, and FormFeedback

### DIFF
--- a/packages/frontile/src/components/buttons/chip.md
+++ b/packages/frontile/src/components/buttons/chip.md
@@ -79,6 +79,7 @@ import { Chip } from 'frontile';
   <div>
     <Chip @appearance="outlined" @intent='default' @withDot={{true}}>Chip</Chip>
     <Chip @appearance="outlined" @intent='primary' @withDot={{true}}>Primary</Chip>
+    <Chip @appearance="outlined" @intent='accent' @withDot={{true}}>Accent</Chip>
     <Chip @appearance="outlined" @intent='success' @withDot={{true}}>Success</Chip>
     <Chip @appearance="outlined" @intent='warning' @withDot={{true}}>Warning</Chip>
     <Chip @appearance="outlined" @intent='danger' @withDot={{true}}>Danger</Chip>
@@ -103,6 +104,7 @@ export default class DemoComponent extends Component {
   <template>
     <Chip @appearance="faded" @onClose={{this.onClose}}>My Chip</Chip>
     <Chip @appearance="faded" @intent="primary" @onClose={{this.onClose}}>My Chip</Chip>
+    <Chip @appearance="faded" @intent="accent" @onClose={{this.onClose}}>My Chip</Chip>
     <Chip @appearance="faded" @intent="success" @onClose={{this.onClose}}>My Chip</Chip>
     <Chip @appearance="faded" @intent="warning" @onClose={{this.onClose}}>My Chip</Chip>
     <Chip @appearance="faded" @intent="danger" @onClose={{this.onClose}}>My Chip</Chip>
@@ -133,6 +135,7 @@ import { Chip } from 'frontile';
   <div>
     <Chip @intent='default' @isDisabled={{true}}>Chip</Chip>
     <Chip @intent='primary' @isDisabled={{true}}>Primary</Chip>
+    <Chip @intent='accent' @isDisabled={{true}}>Accent</Chip>
     <Chip @intent='success' @isDisabled={{true}}>Success</Chip>
     <Chip @intent='warning' @isDisabled={{true}}>Warning</Chip>
     <Chip @intent='danger' @isDisabled={{true}}>Danger</Chip>

--- a/packages/frontile/src/components/buttons/toggle-button.md
+++ b/packages/frontile/src/components/buttons/toggle-button.md
@@ -58,6 +58,7 @@ export default class Example extends Component {
   isSelected = {
     default: false,
     primary: false,
+    accent: false,
     success: false,
     warning: false,
     danger: false
@@ -108,6 +109,7 @@ import { ToggleButton } from 'frontile';
   <div>
     <ToggleButton @intent='default' disabled="true">ToggleButton</ToggleButton>
     <ToggleButton @intent='primary' disabled="true">Primary</ToggleButton>
+    <ToggleButton @intent='accent' disabled="true">Accent</ToggleButton>
     <ToggleButton @intent='success' disabled="true">Success</ToggleButton>
     <ToggleButton @intent='warning' disabled="true">Warning</ToggleButton>
     <ToggleButton @intent='danger' disabled="true">Danger</ToggleButton>

--- a/packages/frontile/src/components/collections/dropdown.md
+++ b/packages/frontile/src/components/collections/dropdown.md
@@ -243,6 +243,14 @@ export default class TriggerStyles extends Component {
       </Dropdown>
 
       <Dropdown as |d|>
+        <d.Trigger @intent='accent' @size='sm'>Accent</d.Trigger>
+        <d.Menu @onAction={{this.onAction}} as |Item|>
+          <Item @key='option1'>Option 1</Item>
+          <Item @key='option2'>Option 2</Item>
+        </d.Menu>
+      </Dropdown>
+
+      <Dropdown as |d|>
         <d.Trigger @intent='success' @size='sm'>Success</d.Trigger>
         <d.Menu @onAction={{this.onAction}} as |Item|>
           <Item @key='option1'>Option 1</Item>

--- a/packages/frontile/src/components/collections/listbox.md
+++ b/packages/frontile/src/components/collections/listbox.md
@@ -321,6 +321,7 @@ export default class IntentColors extends Component {
       <Listbox @isKeyboardEventsEnabled={{true}} @appearance='faded' as |l|>
         <l.Item @key='default'>Default Color</l.Item>
         <l.Item @key='primary' @intent='primary'>Primary Color</l.Item>
+        <l.Item @key='accent' @intent='accent'>Accent Color</l.Item>
         <l.Item @key='success' @intent='success'>Success Color</l.Item>
         <l.Item @key='warning' @intent='warning'>Warning Color</l.Item>
         <l.Item @key='danger' @intent='danger'>Danger Color</l.Item>

--- a/packages/frontile/src/components/collections/listbox/item.gts
+++ b/packages/frontile/src/components/collections/listbox/item.gts
@@ -30,7 +30,13 @@ export interface ListboxItemSignature {
     /**
      * The intent of each item
      */
-    intent?: 'default' | 'primary' | 'success' | 'warning' | 'danger';
+    intent?:
+      | 'default'
+      | 'primary'
+      | 'accent'
+      | 'success'
+      | 'warning'
+      | 'danger';
 
     type?: 'menu' | 'listbox';
   };

--- a/packages/frontile/src/components/collections/listbox/listbox.gts
+++ b/packages/frontile/src/components/collections/listbox/listbox.gts
@@ -54,7 +54,13 @@ interface ListboxSignature<T> {
     /**
      * The intent of each item
      */
-    intent?: 'default' | 'primary' | 'success' | 'warning' | 'danger';
+    intent?:
+      | 'default'
+      | 'primary'
+      | 'accent'
+      | 'success'
+      | 'warning'
+      | 'danger';
   };
   Element: HTMLUListElement;
   Blocks: {

--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -1783,6 +1783,31 @@ When you call `form.reset()`:
 **With no initial data**:
 - Simply calls the native form reset, clearing all fields to empty values
 
+## Feedback Messages
+
+When a field fails validation, `Form`/`Field` automatically render a `FormFeedback`
+element with the `danger` intent and the appropriate `aria-live` announcement — you don't
+need to wire this up yourself (see the [Form Validation](#form-validation-integration)
+examples above).
+
+For feedback outside of validation errors — hints, confirmations, or warnings — render the
+standalone `FormFeedback` component and choose an `@intent`. Available intents are
+`primary`, `accent`, `success`, `warning`, and `danger`.
+
+```gts preview
+import { FormFeedback } from 'frontile';
+
+<template>
+  <div class='flex flex-col gap-2'>
+    <FormFeedback @intent='primary' @messages='Your changes are being saved.' />
+    <FormFeedback @intent='accent' @messages='This field supports Markdown.' />
+    <FormFeedback @intent='success' @messages='Looks good!' />
+    <FormFeedback @intent='warning' @messages='This username is close to the limit.' />
+    <FormFeedback @intent='danger' @messages='This field is required.' />
+  </div>
+</template>
+```
+
 ## Accessibility
 
 The Form component maintains all standard HTML form accessibility features:

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -35,6 +35,29 @@ const options = ['Option 1', 'Option 2', 'Option 3'];
 
 > **Modern Usage:** For forms with data binding and validation, use the Form and Field components as shown in the examples below. Form/Field provides automatic state management, validation, and error handling without manual `@onChange` handlers.
 
+### Intent Colors
+
+Use `@intent` to color the highlighted and selected options in the dropdown. Open each
+Select to see how the active option adopts the intent color. Available intents are
+`default`, `primary`, `accent`, `success`, `warning`, and `danger`.
+
+```gts preview
+import { Select } from 'frontile';
+
+const options = ['Option 1', 'Option 2', 'Option 3'];
+
+<template>
+  <div class='grid grid-cols-2 gap-4'>
+    <Select @intent='default' @placeholder='Default' @items={{options}} />
+    <Select @intent='primary' @placeholder='Primary' @items={{options}} />
+    <Select @intent='accent' @placeholder='Accent' @items={{options}} />
+    <Select @intent='success' @placeholder='Success' @items={{options}} />
+    <Select @intent='warning' @placeholder='Warning' @items={{options}} />
+    <Select @intent='danger' @placeholder='Danger' @items={{options}} />
+  </div>
+</template>
+```
+
 ### Data Binding with Form/Field
 
 When working with forms, the Form component automatically manages the selected value and provides data binding:

--- a/packages/frontile/src/components/forms/switch.md
+++ b/packages/frontile/src/components/forms/switch.md
@@ -247,6 +247,7 @@ import { hash } from '@ember/helper';
       <div class='flex gap-4'>
         <Switch @intent='default' @label='Default' @defaultSelected={{true}} />
         <Switch @intent='primary' @label='Primary' @defaultSelected={{true}} />
+        <Switch @intent='accent' @label='Accent' @defaultSelected={{true}} />
         <Switch @intent='success' @label='Success' @defaultSelected={{true}} />
         <Switch @intent='warning' @label='Warning' @defaultSelected={{true}} />
         <Switch @intent='danger' @label='Danger' @defaultSelected={{true}} />

--- a/packages/frontile/src/components/status/progress-bar.gts
+++ b/packages/frontile/src/components/status/progress-bar.gts
@@ -9,7 +9,13 @@ interface ProgressBarSignature {
     /**
      * The intent of the progress bar
      */
-    intent?: 'default' | 'primary' | 'success' | 'warning' | 'danger';
+    intent?:
+      | 'default'
+      | 'primary'
+      | 'accent'
+      | 'success'
+      | 'warning'
+      | 'danger';
 
     /**
      * The size of the progress bar

--- a/packages/frontile/src/components/status/progress-bar.md
+++ b/packages/frontile/src/components/status/progress-bar.md
@@ -28,12 +28,18 @@ import { ProgressBar } from 'frontile';
 import { ProgressBar } from 'frontile';
 
 <template>
-  <div class='grid grid-cols-5 gap-4'>
+  <div class='grid grid-cols-6 gap-4'>
     <ProgressBar @progress={{50}} @label='Default' @showValueLabel={{false}} />
     <ProgressBar
       @progress={{50}}
       @label='Primary'
       @intent='primary'
+      @showValueLabel={{false}}
+    />
+    <ProgressBar
+      @progress={{50}}
+      @label='Accent'
+      @intent='accent'
       @showValueLabel={{false}}
     />
     <ProgressBar

--- a/packages/frontile/src/components/utilities/spinner.md
+++ b/packages/frontile/src/components/utilities/spinner.md
@@ -54,6 +54,7 @@ import { Spinner } from 'frontile';
   <div class="flex items-center space-x-2">
     <Spinner @intent="default" />
     <Spinner @intent="primary" />
+    <Spinner @intent="accent" />
     <Spinner @intent="success" />
     <Spinner @intent="warning" />
     <Spinner @intent="danger" />

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -41,6 +41,7 @@ const formFeedback = tv({
   variants: {
     intent: {
       primary: 'text-primary',
+      accent: 'text-accent',
       success: 'text-success',
       danger: 'text-danger',
       warning: 'text-warning'

--- a/packages/theme/src/components/listbox.ts
+++ b/packages/theme/src/components/listbox.ts
@@ -61,6 +61,7 @@ const listboxItem = tv({
       default: {},
       primary: {},
       secondary: {},
+      accent: {},
       success: {},
       warning: {},
       danger: {}
@@ -112,6 +113,16 @@ const listboxItem = tv({
     },
     {
       appearance: 'default',
+      intent: 'accent',
+      class: {
+        base: [
+          'data-is-active:bg-accent-soft',
+          'data-is-active:text-on-accent-soft'
+        ]
+      }
+    },
+    {
+      appearance: 'default',
       intent: 'success',
       class: {
         base: [
@@ -158,6 +169,14 @@ const listboxItem = tv({
     },
     {
       appearance: 'default',
+      intent: 'accent',
+      isActive: true,
+      class: {
+        shortcut: ['text-on-accent-soft', 'border-on-accent-soft/20']
+      }
+    },
+    {
+      appearance: 'default',
       intent: 'success',
       isActive: true,
       class: {
@@ -199,6 +218,16 @@ const listboxItem = tv({
         base: [
           'data-is-active:border-primary-medium',
           'data-is-active:text-primary-strong'
+        ]
+      }
+    },
+    {
+      appearance: 'outlined',
+      intent: 'accent',
+      class: {
+        base: [
+          'data-is-active:border-accent-medium',
+          'data-is-active:text-accent-strong'
         ]
       }
     },
@@ -253,6 +282,17 @@ const listboxItem = tv({
           'data-is-active:bg-primary-soft/20',
           'data-is-active:border-primary-medium',
           'data-is-active:text-primary-strong'
+        ]
+      }
+    },
+    {
+      appearance: 'faded',
+      intent: 'accent',
+      class: {
+        base: [
+          'data-is-active:bg-accent-soft/20',
+          'data-is-active:border-accent-medium',
+          'data-is-active:text-accent-strong'
         ]
       }
     },

--- a/packages/theme/src/components/progress-bar.ts
+++ b/packages/theme/src/components/progress-bar.ts
@@ -20,6 +20,9 @@ const progressBar = tv({
       primary: {
         progress: 'bg-primary-soft'
       },
+      accent: {
+        progress: 'bg-accent-soft'
+      },
       success: {
         progress: 'bg-success-soft'
       },

--- a/packages/theme/src/components/spinner.ts
+++ b/packages/theme/src/components/spinner.ts
@@ -12,6 +12,7 @@ const spinner = tv({
     intent: {
       default: 'fill-neutral-strong',
       primary: 'fill-primary',
+      accent: 'fill-accent',
       success: 'fill-success',
       warning: 'fill-warning',
       danger: 'fill-danger'

--- a/test-app/tests/integration/components/collections/listbox-test.gts
+++ b/test-app/tests/integration/components/collections/listbox-test.gts
@@ -479,6 +479,7 @@ module(
                 default: { base: 'intent-default' },
                 primary: { base: 'intent-primary' },
                 secondary: { base: 'intent-secondary' },
+                accent: { base: 'intent-accent' },
                 success: { base: 'intent-success' },
                 warning: { base: 'intent-warning' },
                 danger: { base: 'intent-danger' }
@@ -528,6 +529,7 @@ module(
               <l.Item @key="item-4" @withDivider={{true}}>Item 4</l.Item>
               <l.Item @key="item-5">Item 5</l.Item>
               <l.Item @key="item-6">Item 6</l.Item>
+              <l.Item @key="item-7" @intent="accent">Item 7</l.Item>
             </Listbox>
           </template>
         );
@@ -548,6 +550,9 @@ module(
 
         // intent overwritten at item
         assert.dom('[data-key="item-3"]').hasClass('intent-danger');
+
+        // accent intent overwritten at item
+        assert.dom('[data-key="item-7"]').hasClass('intent-accent');
 
         // Divider
         assert.dom('[data-key="item-4"]').hasClass('with-divider');

--- a/test-app/tests/integration/components/forms/from-feedback-test.gts
+++ b/test-app/tests/integration/components/forms/from-feedback-test.gts
@@ -1,9 +1,34 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
+import { registerCustomStyles } from '@frontile/theme';
+import { tv } from 'tailwind-variants';
 
 import { FormFeedback, type FormFeedbackSignature } from 'frontile';
 import { cell } from 'ember-resources';
+
+registerCustomStyles({
+  formFeedback: tv({
+    base: 'form-field-feedback' as never,
+    variants: {
+      intent: {
+        primary: 'intent-primary',
+        accent: 'intent-accent',
+        success: 'intent-success',
+        warning: 'intent-warning',
+        danger: 'form-field-feedback--error'
+      },
+      size: {
+        sm: 'form-field-feedback--sm',
+        md: '',
+        lg: 'form-field-feedback--lg'
+      }
+    },
+    defaultVariants: {
+      size: 'sm'
+    }
+  }) as never
+});
 
 module(
   'Integration | Component | @frontile/forms/FormFeedback',
@@ -43,6 +68,14 @@ module(
       assert
         .dom('[data-component="form-feedback"]')
         .hasAttribute('id', 'feedback');
+    });
+
+    test('it adds the class for the accent intent', async function (assert) {
+      messages.current = 'My message';
+      intent.current = 'accent';
+      await settled();
+
+      assert.dom('[data-component="form-feedback"]').hasClass('intent-accent');
     });
 
     test('it renders aria-live', async function (assert) {

--- a/test-app/tests/integration/components/status/progress-bar-test.gts
+++ b/test-app/tests/integration/components/status/progress-bar-test.gts
@@ -23,6 +23,7 @@ registerCustomStyles({
       intent: {
         default: 'intent-default',
         primary: 'intent-primary',
+        accent: 'intent-accent',
         success: 'intent-success',
         warning: 'intent-warning',
         danger: 'intent-danger'
@@ -73,6 +74,18 @@ module(
           assert
             .dom('[data-test-id="progress-bar"] > div.pb-base')
             .hasClass('intent-primary');
+        });
+
+        test('it adds class for the accent intent', async function (assert) {
+          await render(
+            <template>
+              <ProgressBar @intent="accent" data-test-id="progress-bar" />
+            </template>
+          );
+
+          assert
+            .dom('[data-test-id="progress-bar"] > div.pb-base')
+            .hasClass('intent-accent');
         });
 
         test('it adds class for the default intent', async function (assert) {

--- a/test-app/tests/integration/components/utilities/spinner-test.gts
+++ b/test-app/tests/integration/components/utilities/spinner-test.gts
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { Spinner } from 'frontile';
+
+module(
+  'Integration | Component | Spinner | @frontile/utilities',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      await render(<template><Spinner data-test-id="spinner" /></template>);
+      assert.dom('[data-test-id="spinner"]').exists();
+    });
+
+    test('it adds the class for the accent intent', async function (assert) {
+      await render(
+        <template><Spinner @intent="accent" data-test-id="spinner" /></template>
+      );
+
+      assert.dom('[data-test-id="spinner"]').hasClass('fill-accent');
+    });
+  }
+);


### PR DESCRIPTION
## Summary

The `accent` semantic color category was added, but several components that accept an `intent` argument were missing it — in their theme variants, their TypeScript unions, or both — and many docs omitted `accent` examples. This brings `accent` to full parity with the other intents (`primary`, `success`, `warning`, `danger`) everywhere `intent` is accepted.

### Theme (`@frontile/theme`)
- **spinner** → `fill-accent`
- **progress-bar** → `bg-accent-soft`
- **listbox** → `accent` variant + compound variants for `default` / `outlined` / `faded` appearances and the active-shortcut state
- **form-feedback** → `text-accent`

### Component types
- Widened the hardcoded `intent` unions in `progress-bar.gts`, `listbox.gts`, and listbox `item.gts`.
- `Spinner`, `Switch`, and `FormFeedback` derive their `intent` type from the theme variants, so they widened automatically.
- `Select` and `Dropdown` menu items inherit from `Listbox`; the `Dropdown` trigger and `ToggleButton`/`ButtonGroup` already supported `accent` via `ButtonArgs`.

### Tests (TDD — RED then GREEN)
- New `spinner-test.gts`; added `accent` coverage to `progress-bar`, `listbox`, and `form-feedback` integration tests.

### Docs
- Added `accent` examples to **chip** (completed 3 partial sections), **toggle-button**, **switch**, **spinner**, **progress-bar**, **listbox**, and **dropdown**.
- Added a new **Intent Colors** section to **select** and a **Feedback Messages** section to **form** (documents the standalone `FormFeedback` intents, since Form/Field hardcode validation feedback to the `danger` intent).

## Verification
- Full test suite: **721 pass, 3 skip, 0 fail**
- `frontile` and `@frontile/theme` type-check clean; test-app type-error count unchanged from `main`
- Changed files lint-clean (`lint:js`, `lint:hbs`)
- `site build` succeeds — all new `gts preview` demos compile and render

## Note
While writing the listbox test I caught a real issue: mutating a shared tracked `intent` cell *after* render triggered an `isActive` backtracking error that aborted the entire test run in the full suite (while passing in isolation). Rewrote that assertion to use a render-time `@intent="accent"` item instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)