### PR TITLE
Add button soft appearance, pill shape, and fix focus ring background

### DIFF
--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -17,7 +17,7 @@ export interface ButtonArgs {
    *
    * @defaultValue 'default'
    */
-  appearance?: 'default' | 'outlined' | 'minimal' | 'tonal' | 'custom';
+  appearance?: 'default' | 'soft' | 'outlined' | 'minimal' | 'tonal' | 'custom';
 
   /**
    * The intent of the button
@@ -27,7 +27,7 @@ export interface ButtonArgs {
   /**
    * The size of the button
    */
-  size?: 'xs' | 'sm' | 'lg' | 'xl';
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 
   /**
    * Disable rendering the button element. It yields an object with classNames instead.

--- a/packages/frontile/src/components/buttons/button.md
+++ b/packages/frontile/src/components/buttons/button.md
@@ -31,6 +31,7 @@ import { Button } from 'frontile';
 <template>
   <div>
     <Button>Default</Button>
+    <Button @appearance='soft'>Soft</Button>
     <Button @appearance='outlined'>Outlined</Button>
     <Button @appearance='tonal'>Tonal</Button>
     <Button @appearance='minimal'>Minimal</Button>
@@ -55,6 +56,14 @@ import { Button } from 'frontile';
     <Button @intent='success'>Success</Button>
     <Button @intent='warning'>Warning</Button>
     <Button @intent='danger'>Danger</Button>
+  </div>
+  <div class='mt-4'>
+    <Button @appearance='soft' @intent='default'>Default</Button>
+    <Button @appearance='soft' @intent='primary'>Primary</Button>
+    <Button @appearance='soft' @intent='accent'>Accent</Button>
+    <Button @appearance='soft' @intent='success'>Success</Button>
+    <Button @appearance='soft' @intent='warning'>Warning</Button>
+    <Button @appearance='soft' @intent='danger'>Danger</Button>
   </div>
   <div class='mt-4'>
     <Button @appearance='outlined' @intent='default'>Default</Button>
@@ -94,6 +103,8 @@ import { Button } from 'frontile';
   <Button>Button md</Button>
   <Button @size='lg'>Button lg</Button>
   <Button @size='xl'>Button xl</Button>
+  <Button @size='2xl'>Button 2xl</Button>
+  <Button @size='3xl'>Button 3xl</Button>
 </template>
 ```
 

--- a/packages/theme/src/colors/config.ts
+++ b/packages/theme/src/colors/config.ts
@@ -6,10 +6,12 @@ import tokens from './semantic';
 
 const base: SemanticBaseColors = {
   light: {
+    background: 'var(--color-surface-app)',
     focus: 'var(--color-primary-muted)',
     divider: 'rgba(17, 17, 17, 0.15)'
   },
   dark: {
+    background: 'var(--color-surface-app)',
     focus: 'var(--color-primary-muted)',
     divider: 'rgba(255, 255, 255, 0.15)'
   }

--- a/packages/theme/src/colors/types.ts
+++ b/packages/theme/src/colors/types.ts
@@ -16,6 +16,7 @@ export type ColorScale =
   | string;
 
 export type BaseColors = {
+  background: ColorScale;
   divider: ColorScale;
   focus: ColorScale;
 };

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -28,15 +28,17 @@ const baseButton = tv({
       danger: 'focus-visible:ring-danger-soft'
     },
     size: {
-      xs: 'text-xs leading-none px-2.5 py-0.5 gap-1 rounded',
-      sm: 'text-sm leading-none px-3 py-1 gap-1.5 rounded-lg',
-      md: 'text-lg leading-none px-4 py-2 gap-1.5 rounded-xl',
-      lg: 'text-xl leading-none px-6 py-3 gap-1.5 rounded-xl',
-      xl: 'text-3xl leading-none px-8 py-4 gap-2.5 rounded-2xl'
+      xs: 'text-sm leading-none px-4 py-1 gap-1 rounded-full',
+      sm: 'text-base leading-none px-5 py-1.5 gap-1.5 rounded-full',
+      md: 'text-lg leading-none px-6 py-2 gap-1.5 rounded-full',
+      lg: 'text-2xl leading-none px-8 py-2.5 gap-2 rounded-full',
+      xl: 'text-3xl leading-none px-10 py-3 gap-2.5 rounded-full',
+      '2xl': 'text-4xl leading-none px-12 py-3.5 gap-3 rounded-full',
+      '3xl': 'text-5xl leading-none px-12 py-4 gap-3 rounded-full'
     },
     isInGroup: {
       true: [
-        'rounded-none first:rounded-l last:rounded-r',
+        'rounded-none first:rounded-s-full last:rounded-e-full',
         '[&:not(:first-child):not(:last-child)]:rounded-none',
         'not-last-of-type:-me-px'
       ]
@@ -93,6 +95,7 @@ const button = tv({
   variants: {
     appearance: {
       default: 'shadow-elevation-2',
+      soft: '',
       outlined: '',
       minimal: '',
       tonal: 'shadow-elevation-2',
@@ -105,7 +108,7 @@ const button = tv({
       appearance: 'default',
       intent: 'default',
       class:
-        'bg-neutral-firm text-on-neutral-firm hover:bg-neutral-strong hover:text-on-neutral-strong active:bg-neutral-bolder active:text-on-neutral-bolder'
+        'bg-neutral-boldest text-on-neutral-boldest hover:bg-neutral-bolder hover:text-on-neutral-bolder active:bg-neutral-strong active:text-on-neutral-strong'
     },
     {
       appearance: 'default',
@@ -136,6 +139,44 @@ const button = tv({
       intent: 'danger',
       class:
         'bg-danger-soft text-on-danger-soft hover:bg-danger-medium hover:text-on-danger-medium active:bg-danger-firm active:text-on-danger-firm'
+    },
+
+    // APPEARANCE: soft (tint fill + colored stroke)
+    {
+      appearance: 'soft',
+      intent: 'default',
+      class:
+        'bg-neutral-subtle border-neutral-medium text-neutral-strong hover:bg-neutral-muted hover:border-neutral-firm active:bg-neutral-soft active:border-neutral-strong active:text-on-neutral-soft'
+    },
+    {
+      appearance: 'soft',
+      intent: 'primary',
+      class:
+        'bg-primary-subtle border-primary-medium text-primary-strong hover:bg-primary-muted hover:border-primary-firm active:bg-primary-soft active:border-primary-strong active:text-on-primary-soft'
+    },
+    {
+      appearance: 'soft',
+      intent: 'accent',
+      class:
+        'bg-accent-subtle border-accent-medium text-accent-strong hover:bg-accent-muted hover:border-accent-firm active:bg-accent-soft active:border-accent-strong active:text-on-accent-soft'
+    },
+    {
+      appearance: 'soft',
+      intent: 'success',
+      class:
+        'bg-success-subtle border-success-medium text-success-strong hover:bg-success-muted hover:border-success-firm active:bg-success-soft active:border-success-strong active:text-on-success-soft'
+    },
+    {
+      appearance: 'soft',
+      intent: 'warning',
+      class:
+        'bg-warning-subtle border-warning-medium text-warning-strong hover:bg-warning-muted hover:border-warning-firm active:bg-warning-soft active:border-warning-strong active:text-on-warning-soft'
+    },
+    {
+      appearance: 'soft',
+      intent: 'danger',
+      class:
+        'bg-danger-subtle border-danger-medium text-danger-strong hover:bg-danger-muted hover:border-danger-firm active:bg-danger-soft active:border-danger-strong active:text-on-danger-soft'
     },
 
     // APPEARANCE: minimal (ghost)

--- a/packages/theme/src/components/chip.ts
+++ b/packages/theme/src/components/chip.ts
@@ -107,7 +107,7 @@ const chip = tv({
       appearance: 'default',
       intent: 'default',
       class: {
-        base: 'bg-neutral-firm text-on-neutral-firm'
+        base: 'bg-neutral-boldest text-on-neutral-boldest'
       }
     },
     {


### PR DESCRIPTION
## Summary
- Add a `soft` button appearance (tint background + colored border), filling a gap between `outlined` and `tonal`.
- Switch buttons to pill shape (`rounded-full`) at every size, and extend the size scale with `2xl`/`3xl`.
- Fix the default/neutral filled Button and Chip color to use `neutral-boldest` (true inverted black/white contrast) instead of the muted `neutral-firm`.
- Add a `background` theme color (mapped to `surface-app`) so `ring-offset-background` correctly resolves per-theme instead of defaulting to white — fixes a visible white halo around focus rings in dark mode.

## Test plan
- [x] `pnpm --filter @frontile/theme build` / `lint:types` / `lint:js`
- [x] `pnpm --filter frontile build`
- [x] Manually verified in browser (light + dark): Button appearances/sizes/intents, Chip, and keyboard-triggered focus rings (via Playwright) all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)