### PR TITLE
Fix button/chip color mapping and hover contrast bugs

### DIFF
--- a/packages/theme/src/colors/semantic.ts
+++ b/packages/theme/src/colors/semantic.ts
@@ -22,58 +22,58 @@ const themeColorsLight: ThemeColors = {
     boldest: absolute.black
   },
   primary: {
-    subtle: `${palette.teal['700']}12`, // palette.teal['700'] @ 7%
-    muted: `${palette.teal['300']}80`, // palette.teal['300'] @ 50%
-    soft: palette.teal['500'],
-    medium: palette.teal['700'],
-    DEFAULT: palette.teal['700'],
-    firm: palette.teal['800'],
-    strong: palette.teal['800'],
-    bolder: palette.teal['900'],
+    subtle: `${palette.teal['600']}1a`, // palette.teal['600'] @ 10% — bg-tonal
+    muted: `${palette.teal['600']}33`, // palette.teal['600'] @ 20%
+    soft: palette.teal['400'], // bg-hover (lightens)
+    medium: palette.teal['600'], // bg-rest / text
+    DEFAULT: palette.teal['600'],
+    firm: palette.teal['900'], // bg-pressed (darkens)
+    strong: palette.teal['600'], // text (= bg-rest for primary)
+    bolder: palette.teal['900'], // text-strong (= bg-pressed for primary)
     boldest: palette.teal['900']
   },
   accent: {
-    subtle: `${palette.violet['200']}66`, // palette.violet['200'] @ 40%
-    muted: `${palette.violet['300']}80`, // palette.violet['300'] @ 50%
-    soft: palette.violet['500'],
-    medium: palette.violet['700'],
-    DEFAULT: palette.violet['700'],
-    firm: palette.violet['800'],
-    strong: palette.violet['800'],
-    bolder: palette.violet['900'],
+    subtle: `${palette.violet['600']}1a`, // palette.violet['600'] @ 10%
+    muted: `${palette.violet['600']}33`, // palette.violet['600'] @ 20%
+    soft: palette.violet['500'], // bg-hover
+    medium: palette.violet['600'], // bg-rest
+    DEFAULT: palette.violet['600'],
+    firm: palette.violet['800'], // bg-pressed
+    strong: palette.violet['700'], // text
+    bolder: palette.violet['900'], // text-strong
     boldest: palette.violet['900']
   },
   success: {
-    subtle: `${palette.green['200']}66`, // palette.green['200'] @ 40%
-    muted: `${palette.green['300']}80`, // palette.green['300'] @ 50%
-    soft: palette.green['500'],
-    medium: palette.green['700'],
-    DEFAULT: palette.green['700'],
-    firm: palette.green['800'],
-    strong: palette.green['800'],
-    bolder: palette.green['900'],
+    subtle: `${palette.green['400']}1a`, // palette.green['400'] @ 10%
+    muted: `${palette.green['400']}33`, // palette.green['400'] @ 20%
+    soft: palette.green['300'], // bg-hover
+    medium: palette.green['400'], // bg-rest — brand-locked lime
+    DEFAULT: palette.green['400'],
+    firm: palette.green['500'], // bg-pressed
+    strong: palette.green['800'], // text (darker than bg-rest for legibility)
+    bolder: palette.green['900'], // text-strong
     boldest: palette.green['900']
   },
   warning: {
-    subtle: `${palette.orange['200']}66`, // palette.orange['200'] @ 40%
-    muted: `${palette.orange['300']}80`, // palette.orange['300'] @ 50%
-    soft: palette.orange['500'],
-    medium: palette.orange['500'],
-    DEFAULT: palette.orange['500'],
-    firm: palette.orange['600'],
-    strong: palette.orange['700'],
-    bolder: palette.orange['700'],
-    boldest: palette.orange['800']
+    subtle: `${palette.orange['300']}1a`, // palette.orange['300'] @ 10%
+    muted: `${palette.orange['300']}33`, // palette.orange['300'] @ 20%
+    soft: palette.orange['200'], // bg-hover
+    medium: palette.orange['300'], // bg-rest — light solid, black label
+    DEFAULT: palette.orange['300'],
+    firm: palette.orange['400'], // bg-pressed
+    strong: palette.orange['600'], // text (darker than bg-rest for legibility)
+    bolder: palette.orange['900'], // text-strong
+    boldest: palette.orange['900']
   },
   danger: {
-    subtle: `${palette.red['200']}26`, // palette.red['200'] @ 15%
-    muted: `${palette.red['300']}80`, // palette.red['300'] @ 50%
-    soft: palette.red['500'],
-    medium: palette.red['700'],
-    DEFAULT: palette.red['700'],
-    firm: palette.red['800'],
-    strong: palette.red['800'],
-    bolder: palette.red['900'],
+    subtle: `${palette.red['600']}1a`, // palette.red['600'] @ 10%
+    muted: `${palette.red['600']}33`, // palette.red['600'] @ 20%
+    soft: palette.red['500'], // bg-hover (lightens too)
+    medium: palette.red['600'], // bg-rest / text
+    DEFAULT: palette.red['600'],
+    firm: palette.red['700'], // bg-pressed
+    strong: palette.red['600'], // text (= bg-rest for danger)
+    bolder: palette.red['900'], // text-strong
     boldest: palette.red['900']
   },
   surface: {
@@ -105,59 +105,59 @@ const themeColorsDark: ThemeColors = {
     boldest: absolute.white
   },
   primary: {
-    subtle: `${palette.teal['700']}12`, // palette.teal['700'] @ 7%
-    muted: `${palette.teal['600']}66`, // palette.teal['600'] @ 40%
-    soft: palette.teal['700'],
-    medium: palette.teal['600'],
-    DEFAULT: palette.teal['600'],
-    firm: palette.teal['500'],
-    strong: palette.teal['500'],
-    bolder: palette.teal['400'],
-    boldest: palette.teal['300']
+    subtle: `${palette.teal['300']}29`, // palette.teal['300'] @ 16% — bg-tonal
+    muted: `${palette.teal['300']}59`, // palette.teal['300'] @ 35%
+    soft: palette.teal['500'], // bg-hover (darkens)
+    medium: palette.teal['300'], // bg-rest / text
+    DEFAULT: palette.teal['300'],
+    firm: palette.teal['100'], // bg-pressed (flashes light)
+    strong: palette.teal['300'], // text (= bg-rest for primary)
+    bolder: palette.teal['100'], // text-strong (= bg-pressed for primary)
+    boldest: palette.teal['100']
   },
   accent: {
-    subtle: `${palette.violet['800']}59`, // palette.violet['800'] @ 35%
-    muted: `${palette.violet['600']}66`, // palette.violet['600'] @ 40%
-    soft: palette.violet['700'],
-    medium: palette.violet['600'],
-    DEFAULT: palette.violet['600'],
-    firm: palette.violet['500'],
-    strong: palette.violet['500'],
-    bolder: palette.violet['400'],
-    boldest: palette.violet['300']
+    subtle: `${palette.violet['300']}29`, // palette.violet['300'] @ 16%
+    muted: `${palette.violet['300']}59`, // palette.violet['300'] @ 35%
+    soft: palette.violet['500'], // bg-hover
+    medium: palette.violet['300'], // bg-rest
+    DEFAULT: palette.violet['300'],
+    firm: palette.violet['800'], // bg-pressed (presses deep, unlike primary's flash)
+    strong: palette.violet['300'], // text
+    bolder: palette.violet['100'], // text-strong
+    boldest: palette.violet['100']
   },
   success: {
-    subtle: `${palette.green['800']}40`, // palette.green['800'] @ 25%
-    muted: `${palette.green['600']}66`, // palette.green['600'] @ 40%
-    soft: palette.green['700'],
-    medium: palette.green['600'],
-    DEFAULT: palette.green['600'],
-    firm: palette.green['500'],
-    strong: palette.green['500'],
-    bolder: palette.green['400'],
-    boldest: palette.green['300']
+    subtle: `${palette.green['400']}29`, // palette.green['400'] @ 16%
+    muted: `${palette.green['400']}59`, // palette.green['400'] @ 35%
+    soft: palette.green['700'], // bg-hover (darkens)
+    medium: palette.green['400'], // bg-rest — lime holds in both schemes
+    DEFAULT: palette.green['400'],
+    firm: palette.green['900'], // bg-pressed
+    strong: palette.green['300'], // text
+    bolder: palette.green['100'], // text-strong
+    boldest: palette.green['100']
   },
   warning: {
-    subtle: `${palette.orange['600']}7a`, // palette.orange['600'] @ 48%
-    muted: `${palette.orange['500']}66`, // palette.orange['500'] @ 40%
-    soft: palette.orange['700'],
-    medium: palette.orange['600'],
-    DEFAULT: palette.orange['600'],
-    firm: palette.orange['500'],
-    strong: palette.orange['500'],
-    bolder: palette.orange['400'],
-    boldest: palette.orange['300']
+    subtle: `${palette.orange['300']}29`, // palette.orange['300'] @ 16%
+    muted: `${palette.orange['300']}59`, // palette.orange['300'] @ 35%
+    soft: palette.orange['500'], // bg-hover (darkens)
+    medium: palette.orange['300'], // bg-rest — holds
+    DEFAULT: palette.orange['300'],
+    firm: palette.orange['700'], // bg-pressed
+    strong: palette.orange['300'], // text (= bg-rest)
+    bolder: palette.orange['100'], // text-strong
+    boldest: palette.orange['100']
   },
   danger: {
-    subtle: `${palette.red['700']}26`, // palette.red['700'] @ 15%
-    muted: `${palette.red['600']}66`, // palette.red['600'] @ 40%
-    soft: palette.red['700'],
-    medium: palette.red['600'],
-    DEFAULT: palette.red['600'],
-    firm: palette.red['500'],
-    strong: palette.red['500'],
-    bolder: palette.red['400'],
-    boldest: palette.red['300']
+    subtle: `${palette.red['400']}29`, // palette.red['400'] @ 16%
+    muted: `${palette.red['400']}59`, // palette.red['400'] @ 35%
+    soft: palette.red['500'], // bg-hover
+    medium: palette.red['400'], // bg-rest — lifts from light's 600
+    DEFAULT: palette.red['400'],
+    firm: palette.red['700'], // bg-pressed
+    strong: palette.red['300'], // text
+    bolder: palette.red['100'], // text-strong
+    boldest: palette.red['100']
   },
   surface: {
     overlay: {

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -50,37 +50,37 @@ const baseButton = tv({
       appearance: 'outlined',
       intent: 'default',
       class:
-        'text-neutral-strong border-neutral-medium hover:bg-neutral-subtle hover:border-neutral-firm active:bg-neutral-muted active:text-neutral-bolder'
+        'text-neutral-boldest border-neutral-boldest hover:bg-neutral-subtle hover:border-neutral-bolder hover:text-neutral-bolder active:bg-neutral-muted active:border-neutral-strong active:text-neutral-strong'
     },
     {
       appearance: 'outlined',
       intent: 'primary',
       class:
-        'text-primary-strong border-primary-medium hover:bg-primary-subtle hover:border-primary-firm active:bg-primary-muted active:text-primary-bolder'
+        'text-primary-strong border-primary-medium hover:bg-primary-subtle hover:border-primary-soft hover:text-primary-bolder active:bg-primary-muted active:border-primary-firm active:text-primary-bolder'
     },
     {
       appearance: 'outlined',
       intent: 'accent',
       class:
-        'text-accent-strong border-accent-medium hover:bg-accent-subtle hover:border-accent-firm active:bg-accent-muted active:text-accent-bolder'
+        'text-accent-strong border-accent-medium hover:bg-accent-subtle hover:border-accent-soft hover:text-accent-bolder active:bg-accent-muted active:border-accent-firm active:text-accent-bolder'
     },
     {
       appearance: 'outlined',
       intent: 'success',
       class:
-        'text-success-strong border-success-medium hover:bg-success-subtle hover:border-success-firm active:bg-success-muted active:text-success-bolder'
+        'text-success-strong border-success-medium hover:bg-success-subtle hover:border-success-soft hover:text-success-bolder active:bg-success-muted active:border-success-firm active:text-success-bolder'
     },
     {
       appearance: 'outlined',
       intent: 'warning',
       class:
-        'text-warning-strong border-warning-medium hover:bg-warning-subtle hover:border-warning-firm active:bg-warning-muted active:text-warning-bolder'
+        'text-warning-strong border-warning-medium hover:bg-warning-subtle hover:border-warning-soft hover:text-warning-bolder active:bg-warning-muted active:border-warning-firm active:text-warning-bolder'
     },
     {
       appearance: 'outlined',
       intent: 'danger',
       class:
-        'text-danger-strong border-danger-medium hover:bg-danger-subtle hover:border-danger-firm active:bg-danger-muted active:text-danger-bolder'
+        'text-danger-strong border-danger-medium hover:bg-danger-subtle hover:border-danger-soft hover:text-danger-bolder active:bg-danger-muted active:border-danger-firm active:text-danger-bolder'
     }
   ],
   defaultVariants: {
@@ -104,41 +104,46 @@ const button = tv({
   },
   compoundVariants: [
     // APPEARANCE: default (filled)
+    // Text color is fixed to the rest on-color for all states — only the
+    // background walks the interaction trio. Switching the on-color per
+    // state causes the label to flip white/black mid-interaction whenever
+    // a state's background crosses the contrast threshold (e.g. primary's
+    // hover step is lighter than its rest step in light mode).
     {
       appearance: 'default',
       intent: 'default',
       class:
-        'bg-neutral-boldest text-on-neutral-boldest hover:bg-neutral-bolder hover:text-on-neutral-bolder active:bg-neutral-strong active:text-on-neutral-strong'
+        'bg-neutral-boldest text-on-neutral-boldest hover:bg-neutral-bolder active:bg-neutral-strong'
     },
     {
       appearance: 'default',
       intent: 'primary',
       class:
-        'bg-primary-soft text-on-primary-soft hover:bg-primary-medium hover:text-on-primary-medium active:bg-primary-firm active:text-on-primary-firm'
+        'bg-primary-medium text-on-primary-medium hover:bg-primary-soft active:bg-primary-firm'
     },
     {
       appearance: 'default',
       intent: 'accent',
       class:
-        'bg-accent-soft text-on-accent-soft hover:bg-accent-medium hover:text-on-accent-medium active:bg-accent-firm active:text-on-accent-firm'
+        'bg-accent-medium text-on-accent-medium hover:bg-accent-soft active:bg-accent-firm'
     },
     {
       appearance: 'default',
       intent: 'success',
       class:
-        'bg-success-soft text-on-success-soft hover:bg-success-medium hover:text-on-success-medium active:bg-success-firm active:text-on-success-firm'
+        'bg-success-medium text-on-success-medium hover:bg-success-soft active:bg-success-firm'
     },
     {
       appearance: 'default',
       intent: 'warning',
       class:
-        'bg-warning-soft text-on-warning-soft hover:bg-warning-medium hover:text-on-warning-medium active:bg-warning-firm active:text-on-warning-firm'
+        'bg-warning-medium text-on-warning-medium hover:bg-warning-soft active:bg-warning-firm'
     },
     {
       appearance: 'default',
       intent: 'danger',
       class:
-        'bg-danger-soft text-on-danger-soft hover:bg-danger-medium hover:text-on-danger-medium active:bg-danger-firm active:text-on-danger-firm'
+        'bg-danger-medium text-on-danger-medium hover:bg-danger-soft active:bg-danger-firm'
     },
 
     // APPEARANCE: soft (tint fill + colored stroke)
@@ -146,37 +151,37 @@ const button = tv({
       appearance: 'soft',
       intent: 'default',
       class:
-        'bg-neutral-subtle border-neutral-medium text-neutral-strong hover:bg-neutral-muted hover:border-neutral-firm active:bg-neutral-soft active:border-neutral-strong active:text-on-neutral-soft'
+        'bg-neutral-subtle border-neutral-boldest text-neutral-boldest hover:bg-neutral-muted hover:border-neutral-bolder hover:text-neutral-bolder active:bg-neutral-soft active:border-neutral-strong active:text-neutral-strong'
     },
     {
       appearance: 'soft',
       intent: 'primary',
       class:
-        'bg-primary-subtle border-primary-medium text-primary-strong hover:bg-primary-muted hover:border-primary-firm active:bg-primary-soft active:border-primary-strong active:text-on-primary-soft'
+        'bg-primary-subtle border-primary-medium text-primary-strong hover:bg-primary-muted hover:border-primary-soft hover:text-primary-bolder active:bg-primary-soft active:border-primary-firm active:text-primary-bolder'
     },
     {
       appearance: 'soft',
       intent: 'accent',
       class:
-        'bg-accent-subtle border-accent-medium text-accent-strong hover:bg-accent-muted hover:border-accent-firm active:bg-accent-soft active:border-accent-strong active:text-on-accent-soft'
+        'bg-accent-subtle border-accent-medium text-accent-strong hover:bg-accent-muted hover:border-accent-soft hover:text-accent-bolder active:bg-accent-soft active:border-accent-firm active:text-accent-bolder'
     },
     {
       appearance: 'soft',
       intent: 'success',
       class:
-        'bg-success-subtle border-success-medium text-success-strong hover:bg-success-muted hover:border-success-firm active:bg-success-soft active:border-success-strong active:text-on-success-soft'
+        'bg-success-subtle border-success-medium text-success-strong hover:bg-success-muted hover:border-success-soft hover:text-success-bolder active:bg-success-soft active:border-success-firm active:text-success-bolder'
     },
     {
       appearance: 'soft',
       intent: 'warning',
       class:
-        'bg-warning-subtle border-warning-medium text-warning-strong hover:bg-warning-muted hover:border-warning-firm active:bg-warning-soft active:border-warning-strong active:text-on-warning-soft'
+        'bg-warning-subtle border-warning-medium text-warning-strong hover:bg-warning-muted hover:border-warning-soft hover:text-warning-bolder active:bg-warning-soft active:border-warning-firm active:text-warning-bolder'
     },
     {
       appearance: 'soft',
       intent: 'danger',
       class:
-        'bg-danger-subtle border-danger-medium text-danger-strong hover:bg-danger-muted hover:border-danger-firm active:bg-danger-soft active:border-danger-strong active:text-on-danger-soft'
+        'bg-danger-subtle border-danger-medium text-danger-strong hover:bg-danger-muted hover:border-danger-soft hover:text-danger-bolder active:bg-danger-soft active:border-danger-firm active:text-danger-bolder'
     },
 
     // APPEARANCE: minimal (ghost)
@@ -184,75 +189,76 @@ const button = tv({
       appearance: 'minimal',
       intent: 'default',
       class:
-        'text-neutral-strong hover:bg-neutral-subtle active:bg-neutral-muted active:text-neutral-bolder'
+        'text-neutral-boldest hover:bg-neutral-subtle hover:text-neutral-bolder active:bg-neutral-muted active:text-neutral-strong'
     },
     {
       appearance: 'minimal',
       intent: 'primary',
       class:
-        'text-primary-strong hover:bg-primary-subtle active:bg-primary-muted active:text-primary-bolder'
+        'text-primary-strong hover:bg-primary-subtle hover:text-primary-bolder active:bg-primary-muted active:text-primary-bolder'
     },
     {
       appearance: 'minimal',
       intent: 'accent',
       class:
-        'text-accent-strong hover:bg-accent-subtle active:bg-accent-muted active:text-accent-bolder'
+        'text-accent-strong hover:bg-accent-subtle hover:text-accent-bolder active:bg-accent-muted active:text-accent-bolder'
     },
     {
       appearance: 'minimal',
       intent: 'success',
       class:
-        'text-success-strong hover:bg-success-subtle active:bg-success-muted active:text-success-bolder'
+        'text-success-strong hover:bg-success-subtle hover:text-success-bolder active:bg-success-muted active:text-success-bolder'
     },
     {
       appearance: 'minimal',
       intent: 'warning',
       class:
-        'text-warning-strong hover:bg-warning-subtle active:bg-warning-muted active:text-warning-bolder'
+        'text-warning-strong hover:bg-warning-subtle hover:text-warning-bolder active:bg-warning-muted active:text-warning-bolder'
     },
     {
       appearance: 'minimal',
       intent: 'danger',
       class:
-        'text-danger-strong hover:bg-danger-subtle active:bg-danger-muted active:text-danger-bolder'
+        'text-danger-strong hover:bg-danger-subtle hover:text-danger-bolder active:bg-danger-muted active:text-danger-bolder'
     },
 
-    // APPEARANCE: tonal
+    // APPEARANCE: tonal — text stays fixed (on-tonal); only the tint
+    // background walks tonal → tint-hover → tint-pressed.
     {
       appearance: 'tonal',
       intent: 'default',
       class:
-        'bg-neutral-subtle text-neutral-strong hover:bg-neutral-muted active:bg-neutral-soft active:text-on-neutral-soft'
+        'bg-neutral-subtle text-neutral-boldest hover:bg-neutral-muted active:bg-neutral-soft'
     },
     {
       appearance: 'tonal',
       intent: 'primary',
       class:
-        'bg-primary-subtle text-primary-strong hover:bg-primary-muted active:bg-primary-soft active:text-on-primary-soft'
+        'bg-primary-subtle text-primary-strong hover:bg-primary-muted active:bg-primary-soft'
     },
     {
       appearance: 'tonal',
       intent: 'accent',
       class:
-        'bg-accent-subtle text-accent-strong hover:bg-accent-muted active:bg-accent-soft active:text-on-accent-soft'
+        'bg-accent-subtle text-accent-strong hover:bg-accent-muted active:bg-accent-soft'
     },
     {
       appearance: 'tonal',
       intent: 'success',
       class:
-        'bg-success-subtle text-success-strong hover:bg-success-muted active:bg-success-soft active:text-on-success-soft'
+        'bg-success-subtle text-success-strong hover:bg-success-muted active:bg-success-soft'
     },
     {
       appearance: 'tonal',
       intent: 'warning',
       class:
-        'bg-warning-subtle text-warning-strong hover:bg-warning-muted active:bg-warning-soft active:text-on-warning-soft'
+        'bg-warning-subtle text-warning-strong hover:bg-warning-muted active:bg-warning-soft'
     },
     {
       appearance: 'tonal',
       intent: 'danger',
       class:
-        'bg-danger-subtle text-danger-strong hover:bg-danger-muted active:bg-danger-soft active:text-on-danger-soft'
+        'bg-danger-subtle text-danger-strong hover:bg-danger-muted active:bg-danger-soft'
     },
 
     // APPEARANCE: custom
@@ -307,42 +313,37 @@ const toggleButton = tv({
       intent: 'default',
       isSelected: true,
       class:
-        'bg-neutral-firm text-on-neutral-firm hover:bg-neutral-strong hover:text-on-neutral-strong'
+        'bg-neutral-boldest text-on-neutral-boldest hover:bg-neutral-bolder'
     },
     {
       appearance: 'outlined',
       intent: 'primary',
       isSelected: true,
-      class:
-        'bg-primary-soft text-on-primary-soft hover:bg-primary-medium hover:text-on-primary-medium'
+      class: 'bg-primary-medium text-on-primary-medium hover:bg-primary-soft'
     },
     {
       appearance: 'outlined',
       intent: 'accent',
       isSelected: true,
-      class:
-        'bg-accent-soft text-on-accent-soft hover:bg-accent-medium hover:text-on-accent-medium'
+      class: 'bg-accent-medium text-on-accent-medium hover:bg-accent-soft'
     },
     {
       appearance: 'outlined',
       intent: 'success',
       isSelected: true,
-      class:
-        'bg-success-soft text-on-success-soft hover:bg-success-medium hover:text-on-success-medium'
+      class: 'bg-success-medium text-on-success-medium hover:bg-success-soft'
     },
     {
       appearance: 'outlined',
       intent: 'warning',
       isSelected: true,
-      class:
-        'bg-warning-soft text-on-warning-soft hover:bg-warning-medium hover:text-on-warning-medium'
+      class: 'bg-warning-medium text-on-warning-medium hover:bg-warning-soft'
     },
     {
       appearance: 'outlined',
       intent: 'danger',
       isSelected: true,
-      class:
-        'bg-danger-soft text-on-danger-soft hover:bg-danger-medium hover:text-on-danger-medium'
+      class: 'bg-danger-medium text-on-danger-medium hover:bg-danger-soft'
     }
   ]
 });

--- a/packages/theme/src/components/chip.ts
+++ b/packages/theme/src/components/chip.ts
@@ -32,47 +32,47 @@ const chip = tv({
         ]
       },
       primary: {
-        dot: 'bg-primary-soft',
+        dot: 'bg-primary-medium',
         closeButton: [
           'bg-primary-muted',
-          'text-on-primary-soft',
-          'hover:bg-primary-medium',
+          'text-on-primary-medium',
+          'hover:bg-primary-firm',
           'focus-visible:ring-primary-soft'
         ]
       },
       accent: {
-        dot: 'bg-accent-soft',
+        dot: 'bg-accent-medium',
         closeButton: [
           'bg-accent-muted',
-          'text-on-accent-soft',
-          'hover:bg-accent-medium',
+          'text-on-accent-medium',
+          'hover:bg-accent-firm',
           'focus-visible:ring-accent-soft'
         ]
       },
       success: {
-        dot: 'bg-success-soft',
+        dot: 'bg-success-medium',
         closeButton: [
           'bg-success-muted',
-          'text-on-success-soft',
-          'hover:bg-success-medium',
+          'text-on-success-medium',
+          'hover:bg-success-firm',
           'focus-visible:ring-success-soft'
         ]
       },
       warning: {
-        dot: 'bg-warning-soft',
+        dot: 'bg-warning-medium',
         closeButton: [
           'bg-warning-muted',
-          'text-on-warning-soft',
-          'hover:bg-warning-medium',
+          'text-on-warning-medium',
+          'hover:bg-warning-firm',
           'focus-visible:ring-warning-soft'
         ]
       },
       danger: {
-        dot: 'bg-danger-soft',
+        dot: 'bg-danger-medium',
         closeButton: [
           'bg-danger-muted',
-          'text-on-danger-soft',
-          'hover:bg-danger-medium',
+          'text-on-danger-medium',
+          'hover:bg-danger-firm',
           'focus-visible:ring-danger-soft'
         ]
       }
@@ -114,35 +114,35 @@ const chip = tv({
       appearance: 'default',
       intent: 'primary',
       class: {
-        base: 'bg-primary-soft text-on-primary-soft'
+        base: 'bg-primary-medium text-on-primary-medium'
       }
     },
     {
       appearance: 'default',
       intent: 'accent',
       class: {
-        base: 'bg-accent-soft text-on-accent-soft'
+        base: 'bg-accent-medium text-on-accent-medium'
       }
     },
     {
       appearance: 'default',
       intent: 'success',
       class: {
-        base: 'bg-success-soft text-on-success-soft'
+        base: 'bg-success-medium text-on-success-medium'
       }
     },
     {
       appearance: 'default',
       intent: 'warning',
       class: {
-        base: 'bg-warning-soft text-on-warning-soft'
+        base: 'bg-warning-medium text-on-warning-medium'
       }
     },
     {
       appearance: 'default',
       intent: 'danger',
       class: {
-        base: 'bg-danger-soft text-on-danger-soft'
+        base: 'bg-danger-medium text-on-danger-medium'
       }
     },
 


### PR DESCRIPTION
## Summary
- Remap semantic color levels (medium/soft/firm/strong/bolder) for primary, accent, success, warning, and danger to match Beacon's actual role tokens (bg-rest/bg-hover/bg-pressed/text/text-strong), surfacing success's brand-locked lime and warning's pastel orange that were previously using the wrong palette steps.
- Fix Button's filled/soft/outlined/minimal/tonal/toggle-selected ladders, which were built on the wrong rung (e.g. filled used `soft` for rest instead of `medium`).
- Stop switching the on-color per interaction state on filled and tonal buttons — this caused labels to visibly flip white/black mid-hover whenever a state's background crossed the WCAG contrast threshold (worst case: primary/accent in light mode flipped white→black→white across rest→hover→active).
- Fix illegible hover/active text on default/neutral buttons (was using light gray tint steps as text) and on success/warning outlined/soft/minimal buttons (was using very light neon/pastel steps as hover text) by decoupling text color — always the legible `strong`/`bolder` tier — from the border/background interaction trio (`medium`/`soft`/`firm`).
- Apply the same `medium`-based color fix to Chip's filled appearance and intent dot/close-button colors, matching Button.

## Test plan
- [x] `pnpm --filter @frontile/theme build` / `lint:types` / `lint:js`
- [x] `pnpm --filter frontile build`
- [x] Manually verified in browser (light + dark) via Playwright: exact OKLCH values for medium/soft/firm confirmed against Beacon's token source; confirmed no hover text-color flip remains in the compiled classes; confirmed hover/active text on neutral and success/warning outlined/soft/minimal buttons is now dark and legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)