### PR TITLE
Round form inputs and strengthen label contrast

### DIFF
--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -4,7 +4,7 @@ import { focusVisibleRing, focusVisibleWithinRing } from '../shared';
 const label = tv({
   slots: {
     // label text role (Open Sans semibold, tight leading)
-    base: 'text-neutral-strong inline-block font-label text-label-sm pb-1',
+    base: 'text-neutral-bolder inline-block font-label text-label-sm pb-2',
     asterisk: 'text-danger'
   },
   variants: {
@@ -77,7 +77,7 @@ const input = tv({
       'font-body text-base text-left',
       'border',
       'border-neutral-soft',
-      'rounded-sm',
+      'rounded-xl',
       'leading-tight',
       'focus:ring-3',
       'focus:ring-focus',


### PR DESCRIPTION
Small visual pass on form fields to match the Beacon account-form spec (light mode reference).

## Changes (`packages/theme/src/components/forms/forms.ts`)
- **Input radius** `rounded-sm` (2px) → `rounded-xl` (12px). Applies to **Input, Textarea, and Select** via the shared `input` slot.
- **Label color** `text-neutral-strong` → `text-neutral-bolder` for higher contrast against the light surface.
- **Label → input gap** `pb-1` (4px) → `pb-2` (8px).

Label weight is unchanged — the `label` role is already semibold (600), matching the Beacon typography spec.

## Verification
Rendered in the docs site (light mode) and measured the computed values:
- input `border-radius: 12px`
- label `color: oklch(0.326…)` (neutral-bolder, darker than the previous 0.432)
- label `padding-bottom: 8px`, `font-weight: 600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)