### PR TITLE
Match button sizes to the Facet 2.0 spec

### DIFF
--- a/docs/theming/design-tokens/colors.md
+++ b/docs/theming/design-tokens/colors.md
@@ -84,7 +84,9 @@ Background colors with automatic text colors:
 <template>
   <div class='flex gap-4 flex-col'>
     {{! Filled Button }}
-    <button class='bg-primary text-on-primary hover:bg-primary-soft px-4 py-2 rounded'>
+    <button
+      class='bg-primary text-on-primary hover:bg-primary-soft px-4 py-2 rounded'
+    >
       Filled Button
     </button>
 
@@ -96,12 +98,16 @@ Background colors with automatic text colors:
     </button>
 
     {{! Tonal Button }}
-    <button class='bg-primary-subtle text-primary-strong hover:bg-primary-soft/20 px-4 py-2 rounded'>
+    <button
+      class='bg-primary-subtle text-primary-strong hover:bg-primary-soft/20 px-4 py-2 rounded'
+    >
       Tonal Button
     </button>
 
     {{! Text Button }}
-    <button class='text-primary hover:bg-primary-subtle bg-transparent px-4 py-2 rounded'>
+    <button
+      class='text-primary hover:bg-primary-subtle bg-transparent px-4 py-2 rounded'
+    >
       Text Button
     </button>
   </div>
@@ -116,13 +122,15 @@ Banners:
     {{! Filled Banner }}
     <div class='bg-primary text-on-primary p-4 rounded'>
       <div class='font-semibold'>Filled Banner</div>
-      <div class='text-sm opacity-90'>High emphasis notification with brand colors</div>
+      <div class='text-sm opacity-90'>High emphasis notification with brand
+        colors</div>
     </div>
 
     {{! Tonal Banner }}
     <div class='bg-primary-subtle border border-primary-soft p-4 rounded'>
       <div class='text-primary-strong font-semibold'>Tonal Banner</div>
-      <div class='text-primary-strong text-sm'>Subtle notification with brand colors</div>
+      <div class='text-primary-strong text-sm'>Subtle notification with brand
+        colors</div>
     </div>
   </div>
 </template>
@@ -146,7 +154,9 @@ Banners:
     </div>
 
     {{! Accent Button }}
-    <button class='bg-accent text-on-accent hover:bg-accent-soft px-4 py-2 rounded'>
+    <button
+      class='bg-accent text-on-accent hover:bg-accent-soft px-4 py-2 rounded'
+    >
       Explore Features
     </button>
   </div>
@@ -171,7 +181,9 @@ Banners:
     </div>
 
     {{! Success Button }}
-    <button class='bg-success text-on-success hover:bg-success-soft px-4 py-2 rounded'>
+    <button
+      class='bg-success text-on-success hover:bg-success-soft px-4 py-2 rounded'
+    >
       Confirm Action
     </button>
   </div>
@@ -196,7 +208,9 @@ Banners:
     </div>
 
     {{! Destructive Button }}
-    <button class='bg-danger text-on-danger hover:bg-danger-soft px-4 py-2 rounded'>
+    <button
+      class='bg-danger text-on-danger hover:bg-danger-soft px-4 py-2 rounded'
+    >
       Delete Item
     </button>
   </div>
@@ -221,9 +235,7 @@ Banners:
     </div>
 
     {{! Warning Button }}
-    <button
-      class='bg-warning text-on-warning hover:bg-warning-soft rounded'
-    >
+    <button class='bg-warning text-on-warning hover:bg-warning-soft rounded'>
       Proceed with Caution
     </button>
   </div>
@@ -264,8 +276,10 @@ Frontile automatically generates optimal contrasting text colors for every backg
 ```html
 <!-- Automatically generates optimal text color (black or white) -->
 <button class="bg-primary text-on-primary">
-<div class="bg-success-soft text-on-success-soft">
-<div class="bg-neutral-strong text-on-neutral-strong">
+  <div class="bg-success-soft text-on-success-soft">
+    <div class="bg-neutral-strong text-on-neutral-strong"></div>
+  </div>
+</button>
 ```
 
 **How it works:**
@@ -301,8 +315,8 @@ module.exports = frontile({
         },
         // Override specific on-colors
         'on-primary': {
-          DEFAULT: '#ffffff',  // Force white text on the bare primary fill
-          strong: '#e0f2fe'    // Use light blue instead of auto-generated white
+          DEFAULT: '#ffffff', // Force white text on the bare primary fill
+          strong: '#e0f2fe' // Use light blue instead of auto-generated white
         }
         // on-primary-subtle and on-primary-soft are still auto-generated
       }

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -27,7 +27,7 @@ export interface ButtonArgs {
   /**
    * The size of the button
    */
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
   /**
    * Disable rendering the button element. It yields an object with classNames instead.

--- a/packages/frontile/src/components/buttons/button.md
+++ b/packages/frontile/src/components/buttons/button.md
@@ -104,7 +104,6 @@ import { Button } from 'frontile';
   <Button @size='lg'>Button lg</Button>
   <Button @size='xl'>Button xl</Button>
   <Button @size='2xl'>Button 2xl</Button>
-  <Button @size='3xl'>Button 3xl</Button>
 </template>
 ```
 

--- a/packages/theme/src/colors/semantic.ts
+++ b/packages/theme/src/colors/semantic.ts
@@ -145,9 +145,9 @@ const themeColorsDark: ThemeColors = {
     },
     app: absolute.black,
     canvas: palette.gray['950'],
-    card: palette.gray['800'],
+    card: palette.gray['900'],
     input: absolute.black,
-    modal: palette.gray['700']
+    modal: absolute.black
   }
 };
 

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -3,11 +3,11 @@ import { focusVisibleRing } from './shared.ts';
 
 const baseButton = tv({
   base: [
-    // label text role (Open Sans semibold); buttons stay single-line so keep tight leading
-    'leading-none',
+    // strong text role (Open Sans bold); size variants set text-strong-* which
+    // carries the label size, weight, tracking, and line-height per the Facet spec
     'inline-flex items-center justify-center',
     '[&_svg]:size-[1em]',
-    'font-label',
+    'font-header',
     'border',
     'border-transparent',
     'disabled:cursor-not-allowed',
@@ -29,14 +29,12 @@ const baseButton = tv({
       danger: 'focus-visible:ring-danger-soft'
     },
     size: {
-      xs: 'text-label-xs px-4 py-1 gap-1 rounded-full',
-      sm: 'text-label-sm px-5 py-1.5 gap-1.5 rounded-full',
-      md: 'text-label-md px-6 py-2 gap-1.5 rounded-full',
-      lg: 'text-label-xl px-8 py-2.5 gap-2 rounded-full',
-      xl: 'text-label-2xl px-10 py-3 gap-2.5 rounded-full',
-      '2xl': 'text-label-3xl px-12 py-3.5 gap-3 rounded-full',
-      // exceeds the label text scale (max 3xl); keep raw size with the label font
-      '3xl': 'text-5xl px-12 py-4 gap-3 rounded-full'
+      xs: 'text-strong-sm px-4 py-1 gap-1 rounded-full',
+      sm: 'text-strong-md px-5 py-1.5 gap-1 rounded-full',
+      md: 'text-strong-lg px-6 py-2 gap-1.5 rounded-full',
+      lg: 'text-strong-xl px-8 py-2.5 gap-1.5 rounded-full',
+      xl: 'text-strong-2xl px-10 py-3 gap-2 rounded-full',
+      '2xl': 'text-strong-3xl px-12 py-3.5 gap-2.5 rounded-full'
     },
     isInGroup: {
       true: [


### PR DESCRIPTION
Aligns the button size scale with the Facet 2.0 design system (read from Figma), plus a small dark-surface tuning.

## Button sizes → Facet (`packages/theme/src/components/button.ts`)
From the Facet button component: the label uses the **`strong` text style** (Open Sans Bold 700), and the six sizes **xs–2xl** map to the strong sizes sm–3xl with role-specific padding. Our `strong` role tokens already match Facet's strong styles exactly (typescale, weight, tracking, line-height).

- `base`: `font-label` → `font-header`; dropped `leading-none` so `text-strong-*` carries the label size, weight (700), tracking, and line-height.
- Size scale (font / px / py / gap), producing Facet heights **30 / 38 / 43 / 50 / 63 / 68**:

  | size | label | px | py | gap |
  |---|---|---|---|---|
  | xs | strong-sm 16 | px-4 | py-1 | gap-1 |
  | sm | strong-md 18 | px-5 | py-1.5 | gap-1 |
  | md | strong-lg 22 | px-6 | py-2 | gap-1.5 |
  | lg | strong-xl 25 | px-8 | py-2.5 | gap-1.5 |
  | xl | strong-2xl 33 | px-10 | py-3 | gap-2 |
  | 2xl | strong-3xl 40 | px-12 | py-3.5 | gap-2.5 |

- **Dropped the `3xl` size** to match Facet's six-size scale (updates the `Button` size type and the size demo).

## Dark-mode surfaces (`packages/theme/src/colors/semantic.ts`)
- `surface.card` gray-800 → gray-900, `surface.modal` gray-700 → black (deeper dark stack). Color-docs demo markup reflowed (formatting only).

## Verification
Verified at the source and in a clean rebuilt theme dist (button tops out at `2xl` = `text-strong-3xl`; no leftover `3xl`/`strong-4xl`). Height math checks against the Facet spec (e.g. md 22.13×1.2 + 16 ≈ 43, xl ≈ 63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)