### PR TITLE
fix(collections): derive listbox navigation order from the DOM

### DIFF
--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -65,6 +65,29 @@ class ListManager {
     this.updateArgs(args);
   }
 
+  /**
+   * Registered items that are still in the document, in DOM order.
+   *
+   * The order cannot be maintained eagerly as items register: Glimmer moves
+   * the element of an item that persists across an update instead of
+   * re-creating it (no registration to react to), and it installs the
+   * modifiers of newly rendered items before tearing down the ones they
+   * replace — so a sort at registration time both misses later moves and
+   * compares against detached elements, which `compareDocumentPosition`
+   * orders arbitrarily. Deriving the order from the document when it is
+   * needed keeps navigation in step with what the user sees.
+   */
+  get #orderedItems(): ListItem[] {
+    return this.#items
+      .filter((item) => item.el.isConnected)
+      .sort((a, b) => {
+        const position = a.el.compareDocumentPosition(b.el);
+        if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+        if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+        return 0;
+      });
+  }
+
   register(
     el: HTMLLIElement | HTMLOptionElement,
     args: Required<ListItemArgs>
@@ -72,17 +95,16 @@ class ListManager {
     const newItem = new ListItem(el, args);
     if (
       this.args.autoActivateMode == 'first' &&
-      this.#items.length === 0 &&
+      this.#orderedItems.length === 0 &&
       !args.isDisabled
     ) {
       newItem.isActive = true;
       this.args.onActiveItemChange?.(newItem.key, newItem);
     }
     this.#items.push(newItem);
-    this.#syncItemsOrderWithDOM();
 
     if (typeof this.args.onListItemsChange === 'function') {
-      this.args.onListItemsChange(this.#items, 'add');
+      this.args.onListItemsChange(this.#orderedItems, 'add');
     }
 
     if (this.args.autoActivateMode != 'none' && this.#items.length > 1) {
@@ -99,12 +121,13 @@ class ListManager {
   unregister(el: HTMLLIElement | HTMLOptionElement): void {
     this.#items = this.#items.filter((item) => item.el !== el);
 
-    if (this.args.autoActivateMode == 'first' && this.#items.length >= 1) {
-      this.activateItem(this.#items[0]);
+    const items = this.#orderedItems;
+    if (this.args.autoActivateMode == 'first' && items.length >= 1) {
+      this.activateItem(items[0]);
     }
 
     if (typeof this.args.onListItemsChange === 'function') {
-      this.args.onListItemsChange(this.#items, 'remove');
+      this.args.onListItemsChange(items, 'remove');
     }
   }
 
@@ -188,8 +211,9 @@ class ListManager {
   }
 
   setNextOptionActive(): void {
-    for (let i = this.#indexofActiveItem + 1; i < this.#items.length; i++) {
-      const item = this.#items[i];
+    const items = this.#orderedItems;
+    for (let i = this.#indexOfActiveItem(items) + 1; i < items.length; i++) {
+      const item = items[i];
       if (item && !item.isDisabled && !item.isActive) {
         this.activateItem(item);
         break;
@@ -198,8 +222,9 @@ class ListManager {
   }
 
   setPreviousOptionActive(): void {
-    for (let i = this.#indexofActiveItem - 1; i >= 0; i--) {
-      const item = this.#items[i];
+    const items = this.#orderedItems;
+    for (let i = this.#indexOfActiveItem(items) - 1; i >= 0; i--) {
+      const item = items[i];
       if (item && !item.isDisabled && !item.isActive) {
         this.activateItem(item);
         break;
@@ -208,8 +233,9 @@ class ListManager {
   }
 
   setFirstOptionActive(): void {
-    for (let i = 0; i < this.#items.length; i++) {
-      const item = this.#items[i];
+    const items = this.#orderedItems;
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
       if (item && !item.isDisabled) {
         this.activateItem(item);
         break;
@@ -218,10 +244,11 @@ class ListManager {
   }
 
   setSelectedOptionActive(): void {
+    const items = this.#orderedItems;
     let activated = false;
 
-    for (let i = 0; i < this.#items.length; i++) {
-      const item = this.#items[i];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
       if (item && !item.isDisabled && item.isSelected) {
         this.activateItem(item);
         activated = true;
@@ -235,8 +262,9 @@ class ListManager {
   }
 
   setLastOptionActive(): void {
-    for (let i = this.#items.length - 1; i >= 0; i--) {
-      const item = this.#items[i];
+    const items = this.#orderedItems;
+    for (let i = items.length - 1; i >= 0; i--) {
+      const item = items[i];
       if (item && !item.isDisabled) {
         this.activateItem(item);
         break;
@@ -248,8 +276,9 @@ class ListManager {
     debounce(this, this.#clearSeaerch, 500);
     this.searchKeys += key.toLowerCase();
 
-    for (let i = 0; i < this.#items.length; i++) {
-      const item = this.#items[i] as ListItem;
+    const items = this.#orderedItems;
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i] as ListItem;
 
       if (
         !item.isDisabled &&
@@ -270,42 +299,24 @@ class ListManager {
     return this.args.selectedKeys?.includes(key) || false;
   }
 
-  get #indexofActiveItem(): number {
-    let item = this.#activeItem;
+  #indexOfActiveItem(items: ListItem[]): number {
+    let item = items.find((i) => i.isActive);
 
     if (!item) {
-      for (let i = 0; i < this.#items.length; i++) {
-        const n = this.#items[i] as ListItem;
-        if (n.isSelected) {
-          item = n;
-          break;
-        }
-      }
+      item = items.find((i) => i.isSelected);
     }
     if (!item) {
       return -1;
     }
-    return this.#items.indexOf(item);
-  }
-
-  // Ensure #items is always in sync with DOM order
-  #syncItemsOrderWithDOM(): void {
-    if (!this.#items.length) return;
-
-    // Sort items based on their position in the DOM
-    this.#items.sort((a, b) => {
-      const position = a.el.compareDocumentPosition(b.el);
-      if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
-      if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
-      return 0;
-    });
+    return items.indexOf(item);
   }
 
   #toggleSelectedItem(item: ListItem): string[] {
     let selectedKeys: string[] = [];
 
-    for (let i = 0; i < this.#items.length; i++) {
-      const _item = this.#items[i] as ListItem;
+    const items = this.#orderedItems;
+    for (let i = 0; i < items.length; i++) {
+      const _item = items[i] as ListItem;
       if (_item.isSelected) {
         selectedKeys.push(_item.key);
       }
@@ -330,12 +341,7 @@ class ListManager {
   }
 
   get #activeItem(): ListItem | undefined {
-    for (let i = 0; i < this.#items.length; i++) {
-      const item = this.#items[i] as ListItem;
-      if (item.isActive) {
-        return item;
-      }
-    }
+    return this.#orderedItems.find((item) => item.isActive);
   }
 
   #clearSeaerch(): void {

--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -88,6 +88,31 @@ class ListManager {
       });
   }
 
+  /** Whether any registered item is still in the document. */
+  get #hasVisibleItems(): boolean {
+    return this.#items.some((item) => item.el.isConnected);
+  }
+
+  /**
+   * The registered item that comes first in the document, found in a single
+   * pass so callers that need only one item do not pay to order the whole
+   * list.
+   */
+  get #firstVisibleItem(): ListItem | undefined {
+    let first: ListItem | undefined;
+    for (const item of this.#items) {
+      if (!item.el.isConnected) continue;
+      if (
+        !first ||
+        item.el.compareDocumentPosition(first.el) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ) {
+        first = item;
+      }
+    }
+    return first;
+  }
+
   register(
     el: HTMLLIElement | HTMLOptionElement,
     args: Required<ListItemArgs>
@@ -95,7 +120,7 @@ class ListManager {
     const newItem = new ListItem(el, args);
     if (
       this.args.autoActivateMode == 'first' &&
-      this.#orderedItems.length === 0 &&
+      !this.#hasVisibleItems &&
       !args.isDisabled
     ) {
       newItem.isActive = true;
@@ -121,13 +146,12 @@ class ListManager {
   unregister(el: HTMLLIElement | HTMLOptionElement): void {
     this.#items = this.#items.filter((item) => item.el !== el);
 
-    const items = this.#orderedItems;
-    if (this.args.autoActivateMode == 'first' && items.length >= 1) {
-      this.activateItem(items[0]);
+    if (this.args.autoActivateMode == 'first') {
+      this.activateItem(this.#firstVisibleItem);
     }
 
     if (typeof this.args.onListItemsChange === 'function') {
-      this.args.onListItemsChange(items, 'remove');
+      this.args.onListItemsChange(this.#orderedItems, 'remove');
     }
   }
 

--- a/test-app/tests/integration/components/collections/listbox-test.gts
+++ b/test-app/tests/integration/components/collections/listbox-test.gts
@@ -324,6 +324,118 @@ module(
       assert.dom('[data-key="elephant"]').hasAttribute('data-active', 'false');
     });
 
+    test('keyboard navigation follows DOM order after items are inserted before a persisting item', async function (assert) {
+      // Mimics an async (e.g. address) search: the previous match is still in
+      // the new results, but closer matches are inserted before it. The
+      // persisting item keeps its object identity, so Glimmer moves its
+      // existing element instead of re-creating it.
+      const later = { key: 'later', label: 'Later' };
+      const first = { key: 'first', label: 'First' };
+      const second = { key: 'second', label: 'Second' };
+
+      const items = cell<{ key: string; label: string }[]>([later]);
+
+      await render(
+        <template>
+          <Listbox
+            @isKeyboardEventsEnabled={{true}}
+            @selectionMode="single"
+            @items={{items.current}}
+            @autoActivateMode="none"
+          />
+        </template>
+      );
+
+      assert.dom('[data-key="later"]').exists();
+
+      items.current = [first, second, later];
+      await settled();
+
+      const domOrder = [
+        ...document.querySelectorAll('[data-component="listbox-item"]')
+      ].map((el) => (el as HTMLElement).dataset['key']);
+      assert.deepEqual(
+        domOrder,
+        ['first', 'second', 'later'],
+        'DOM renders the new items before the persisting one'
+      );
+
+      const visited: (string | undefined)[] = [];
+      for (let i = 0; i < 3; i++) {
+        await triggerKeyEvent(
+          '[data-test-id="listbox"]',
+          'keydown',
+          'ArrowDown'
+        );
+        visited.push(
+          (
+            document.querySelector(
+              '[data-component="listbox-item"][data-active="true"]'
+            ) as HTMLElement | null
+          )?.dataset['key']
+        );
+      }
+
+      assert.deepEqual(
+        visited,
+        ['first', 'second', 'later'],
+        'ArrowDown visits items in DOM order'
+      );
+    });
+
+    test('keyboard navigation follows DOM order when results are replaced around a persisting item', async function (assert) {
+      // Same scenario, but the previous results are also dropped — the shape of
+      // a real search where typing narrows the list.
+      const match = { key: 'match', label: 'Match' };
+      const oldA = { key: 'old-a', label: 'Old A' };
+      const oldB = { key: 'old-b', label: 'Old B' };
+      const newA = { key: 'new-a', label: 'New A' };
+      const newB = { key: 'new-b', label: 'New B' };
+
+      const items = cell<{ key: string; label: string }[]>([oldA, oldB, match]);
+
+      await render(
+        <template>
+          <Listbox
+            @isKeyboardEventsEnabled={{true}}
+            @selectionMode="single"
+            @items={{items.current}}
+            @autoActivateMode="none"
+          />
+        </template>
+      );
+
+      items.current = [newA, newB, match];
+      await settled();
+
+      const domOrder = [
+        ...document.querySelectorAll('[data-component="listbox-item"]')
+      ].map((el) => (el as HTMLElement).dataset['key']);
+      assert.deepEqual(domOrder, ['new-a', 'new-b', 'match'], 'DOM order');
+
+      const visited: (string | undefined)[] = [];
+      for (let i = 0; i < 3; i++) {
+        await triggerKeyEvent(
+          '[data-test-id="listbox"]',
+          'keydown',
+          'ArrowDown'
+        );
+        visited.push(
+          (
+            document.querySelector(
+              '[data-component="listbox-item"][data-active="true"]'
+            ) as HTMLElement | null
+          )?.dataset['key']
+        );
+      }
+
+      assert.deepEqual(
+        visited,
+        ['new-a', 'new-b', 'match'],
+        'ArrowDown visits items in DOM order'
+      );
+    });
+
     test('it render item with blocks', async function (assert) {
       const clickedOn: string[] = [];
       const onAction = (key: string) => {

--- a/test-app/tests/integration/components/forms/autocomplete-test.gts
+++ b/test-app/tests/integration/components/forms/autocomplete-test.gts
@@ -267,6 +267,66 @@ module(
       assert.verifySteps(['search:fr']);
     });
 
+    test('keyboard navigation follows DOM order after an async search replaces results', async function (assert) {
+      // Faithful shape of an address search: each response builds fresh
+      // objects, one previously-matching address is still present, and closer
+      // matches are returned before it.
+      const addresses = [
+        '120 Main St',
+        '121 Main St',
+        '122 Main St',
+        '123 Main St',
+        '124 Main St',
+        '125 Main St'
+      ];
+
+      // First response only has the later entry; the second has everything.
+      const onSearch = (query: string) =>
+        (query.length > 3 ? addresses : ['123 Main St']).map((label) => ({
+          key: label,
+          label
+        }));
+
+      await render(
+        <template>
+          <Autocomplete @onSearch={{onSearch}} @searchDebounce={{0}} />
+        </template>
+      );
+
+      await fillIn('[data-test-id="trigger"]', 'Main');
+
+      await fillIn('[data-test-id="trigger"]', 'Main St');
+
+      const domOrder = [
+        ...document.querySelectorAll(
+          '[data-component="listbox"] [data-component="listbox-item"]'
+        )
+      ].map((el) => (el as HTMLElement).dataset['key']);
+      assert.deepEqual(domOrder, addresses, 'DOM order matches the response');
+
+      const visited: (string | undefined)[] = [];
+      for (let i = 0; i < addresses.length - 1; i++) {
+        await triggerKeyEvent(
+          '[data-test-id="trigger"]',
+          'keydown',
+          'ArrowDown'
+        );
+        visited.push(
+          (
+            document.querySelector(
+              '[data-component="listbox"] [data-component="listbox-item"][data-active="true"]'
+            ) as HTMLElement | null
+          )?.dataset['key']
+        );
+      }
+
+      assert.deepEqual(
+        visited,
+        addresses.slice(1),
+        'ArrowDown walks down the list in DOM order'
+      );
+    });
+
     test('onSearch: stale responses are ignored (latest wins)', async function (assert) {
       const resolvers: { query: string; resolve: (i: string[]) => void }[] = [];
       const onSearch = (query: string) =>

--- a/test-app/tests/unit/collections/list-manager-test.ts
+++ b/test-app/tests/unit/collections/list-manager-test.ts
@@ -1,0 +1,126 @@
+import { module, test } from 'qunit';
+import { ListManager } from 'frontile/utils/listManager';
+
+module('Unit | Utils | ListManager', function (hooks) {
+  let container: HTMLUListElement;
+
+  hooks.beforeEach(function () {
+    container = document.createElement('ul');
+    document.body.appendChild(container);
+  });
+
+  hooks.afterEach(function () {
+    container.remove();
+  });
+
+  const buildManager = () =>
+    new ListManager({
+      selectionMode: 'single',
+      autoActivateMode: 'none'
+    });
+
+  const addItem = (manager: ListManager, key: string) => {
+    const el = document.createElement('li');
+    el.dataset['key'] = key;
+    container.appendChild(el);
+    manager.register(el, {
+      key,
+      textValue: key,
+      isActive: false,
+      isDisabled: false,
+      isSelected: false
+    });
+    return el;
+  };
+
+  const domOrder = () =>
+    [...container.children].map((el) => (el as HTMLElement).dataset['key']);
+
+  const walkDown = (manager: ListManager, steps: number) => {
+    const visited: (string | undefined)[] = [];
+    for (let i = 0; i < steps; i++) {
+      manager.setNextOptionActive();
+      visited.push(
+        domOrder().find((key) => key && manager.atKey(key)?.isActive)
+      );
+    }
+    return visited;
+  };
+
+  test('navigation follows DOM order after an element is moved without re-registering', function (assert) {
+    const manager = buildManager();
+    ['a', 'b', 'c'].forEach((key) => addItem(manager, key));
+
+    // Glimmer moves the element of an item that persists across an update
+    // instead of re-creating it, so no registration happens to trigger a
+    // re-sort. Ordering must still come from the DOM.
+    const last = container.lastElementChild as HTMLElement;
+    container.insertBefore(last, container.firstChild);
+
+    assert.deepEqual(domOrder(), ['c', 'a', 'b'], 'DOM was reordered');
+    assert.deepEqual(
+      walkDown(manager, 3),
+      ['c', 'a', 'b'],
+      'ArrowDown walks the list in DOM order'
+    );
+  });
+
+  test('navigation follows DOM order while a previous generation is still registered with detached elements', function (assert) {
+    const manager = buildManager();
+
+    // Generation one.
+    const oldEls = ['old-1', 'old-2', 'old-3'].map((key) =>
+      addItem(manager, key)
+    );
+
+    // An async result replaces the list. Glimmer inserts the new elements and
+    // installs their modifiers (register) before tearing down the old ones, so
+    // for a moment the old, already-detached items are still registered.
+    oldEls.forEach((el) => el.remove());
+    const newKeys = ['new-1', 'new-2', 'new-3', 'new-4', 'new-5', 'new-6'];
+    newKeys.forEach((key) => addItem(manager, key));
+    oldEls.forEach((el) => manager.unregister(el));
+
+    assert.deepEqual(domOrder(), newKeys, 'DOM holds only the new generation');
+    assert.deepEqual(
+      walkDown(manager, newKeys.length),
+      newKeys,
+      'ArrowDown walks the list in DOM order'
+    );
+  });
+
+  test('detached items are skipped by navigation', function (assert) {
+    const manager = buildManager();
+    ['a', 'b', 'c'].forEach((key) => addItem(manager, key));
+
+    // Detached but not yet unregistered.
+    (container.children[1] as HTMLElement).remove();
+
+    assert.deepEqual(
+      walkDown(manager, 2),
+      ['a', 'c'],
+      'navigation visits only items still in the DOM'
+    );
+  });
+
+  test('setLastOptionActive and setPreviousOptionActive use DOM order', function (assert) {
+    const manager = buildManager();
+    ['a', 'b', 'c'].forEach((key) => addItem(manager, key));
+
+    const last = container.lastElementChild as HTMLElement;
+    container.insertBefore(last, container.firstChild);
+    // DOM is now c, a, b
+
+    manager.setLastOptionActive();
+    assert.true(manager.atKey('b')?.isActive, 'last in DOM order is active');
+
+    manager.setPreviousOptionActive();
+    assert.true(
+      manager.atKey('a')?.isActive,
+      'previous in DOM order is active'
+    );
+
+    manager.setFirstOptionActive();
+    assert.true(manager.atKey('c')?.isActive, 'first in DOM order is active');
+  });
+});


### PR DESCRIPTION
## The bug

Arrow-key navigation in `Listbox` (and therefore `Select` / `Autocomplete`) could jump around or land on nothing after an async search returned results that **kept a previously matching item but placed new matches before it** — reported against address autocomplete.

## Root cause

`ListManager` kept its `#items` array eagerly sorted, re-sorting on every registration. That order goes stale in two ways:

1. **Moved elements never trigger a re-sort.** When an item persists across an update, Glimmer *moves* its element rather than re-creating it, so no modifier installs and nothing re-sorts — `#items` keeps the old positions.
2. **The sort runs against detached elements.** Glimmer installs the modifiers of newly rendered items *before* tearing down the ones they replace, so the previous generation is still registered, already detached. `compareDocumentPosition` orders a detached node arbitrarily (`DISCONNECTED | IMPLEMENTATION_SPECIFIC` plus an arbitrary preceding/following bit), making the comparator non-transitive — so `Array#sort` yields a scrambled order that `unregister` never corrects.

Captured from live instrumentation during an async search (6 results replacing 1):

```
before:   [120,121,122,123, 120,121,122,123,124, 124,125,125]
detached: [120,121,122,123,124,125]   ← entire previous generation still registered
dom:      [120,121,122,123,124,125]
after:    [120,121,122,123, 120,121,122,123,124,125, 124,125]   ← not DOM order
```

Navigation then walks that array, so the highlight skips, backtracks, or lands on a detached item (no visible highlight at all).

## The fix

Ordering is now **derived from the document at the point of use** instead of maintained eagerly, and items whose elements have left the document are skipped. Navigation, type-ahead search, first/last/selected activation and the `onListItemsChange` payload all use that order, so they always match what the user sees, and a detached item can no longer be activated into a phantom highlight. The eager `#syncItemsOrderWithDOM` is removed.

Cost is unchanged in practice: the previous implementation also sorted on every registration.

## Tests

New `ListManager` unit tests pin the invariant — 3 of them failed before this change:

| Scenario | Before | After |
| --- | --- | --- |
| Element moved without re-registering | `a,b,c` (stale) | `c,a,b` ✅ |
| Detached item still registered | highlight lands on nothing | skipped ✅ |
| `setLast/Previous/FirstOptionActive` | stale order | DOM order ✅ |

Plus integration tests for `Listbox` (items inserted before a persisting item; results replaced around one) and `Autocomplete` (async search replacing results).

## Test plan
- [x] `pnpm --filter frontile build`, `lint:types`, `lint:js`, `lint:hbs` clean
- [x] Full suite: **757 tests, 754 pass, 3 skipped, 0 fail**
- [x] Verified in a real browser on the docs async demo: navigation follows DOM order in both directions, in 3-item and 10-item result sets, after results are replaced around a persisting item

🤖 Generated with [Claude Code](https://claude.com/claude-code)