### PR TITLE
feat(table): yield rendered columns and cell components to body blocks

### DIFF
--- a/packages/frontile/src/components/collections/simple-table/body.gts
+++ b/packages/frontile/src/components/collections/simple-table/body.gts
@@ -4,6 +4,7 @@ import { useStyles, twMerge } from '@frontile/theme';
 import { SimpleTableRow } from './row';
 import { SimpleTableCell } from './cell';
 import type { SlotsToClasses, TableSlots } from '../table/types';
+import type { WithBoundArgs } from '@glint/template';
 
 interface SimpleTableBodySignature {
   Args: {
@@ -24,8 +25,8 @@ interface SimpleTableBodySignature {
   Blocks: {
     default: [
       {
-        Row: typeof SimpleTableRow;
-        Cell: typeof SimpleTableCell;
+        Row: WithBoundArgs<typeof SimpleTableRow, 'styleFns' | 'classes'>;
+        Cell: WithBoundArgs<typeof SimpleTableCell, 'styleFns' | 'classes'>;
       }
     ];
   };
@@ -48,7 +49,12 @@ class SimpleTableBody extends Component<SimpleTableBodySignature> {
       data-component="table-body"
       ...attributes
     >
-      {{yield (hash Row=SimpleTableRow Cell=SimpleTableCell)}}
+      {{yield
+        (hash
+          Row=(component SimpleTableRow styleFns=this.styles classes=@classes)
+          Cell=(component SimpleTableCell styleFns=this.styles classes=@classes)
+        )
+      }}
     </tbody>
   </template>
 }

--- a/packages/frontile/src/components/collections/simple-table/row.gts
+++ b/packages/frontile/src/components/collections/simple-table/row.gts
@@ -3,6 +3,7 @@ import { hash } from '@ember/helper';
 import { useStyles, twMerge } from '@frontile/theme';
 import { SimpleTableCell } from './cell';
 import type { SlotsToClasses, TableSlots } from '../table/types';
+import type { WithBoundArgs } from '@glint/template';
 
 interface SimpleTableRowSignature {
   Args: {
@@ -27,7 +28,7 @@ interface SimpleTableRowSignature {
   Blocks: {
     default: [
       {
-        Cell: typeof SimpleTableCell;
+        Cell: WithBoundArgs<typeof SimpleTableCell, 'styleFns' | 'classes'>;
       }
     ];
   };
@@ -56,7 +57,11 @@ class SimpleTableRow extends Component<SimpleTableRowSignature> {
       data-component="table-row"
       ...attributes
     >
-      {{yield (hash Cell=SimpleTableCell)}}
+      {{yield
+        (hash
+          Cell=(component SimpleTableCell styleFns=this.styles classes=@classes)
+        )
+      }}
     </tr>
   </template>
 }

--- a/packages/frontile/src/components/collections/table.md
+++ b/packages/frontile/src/components/collections/table.md
@@ -682,6 +682,62 @@ export default class DemoComponent extends Component {
 }
 ```
 
+### Column-aligned rows in `bodyTop` / `bodyBottom`
+
+`bodyTop` and `bodyBottom` yield the columns the table is actually rendering,
+along with style-bound `Row` and `Cell` components. Use these instead of
+hand-written `<tr>`/`<td>` so your rows stay aligned when a column is hidden
+via `ColumnVisibility` and when `@selectionMode="multiple"` adds its checkbox
+column.
+
+```gts preview
+import { array } from '@ember/helper';
+import { Table } from 'frontile';
+
+const columns = [
+  { key: 'name', name: 'Name' },
+  { key: 'email', name: 'Email' }
+];
+
+<template>
+  <Table @columns={{columns}} @items={{(array)}}>
+    <:bodyTop as |b|>
+      <b.Row>
+        {{#each b.columns as |column|}}
+          <b.Cell data-column={{column.key}}>
+            <div class='h-4 w-full rounded bg-surface-overlay-medium' />
+          </b.Cell>
+        {{/each}}
+      </b.Row>
+    </:bodyTop>
+  </Table>
+</template>
+```
+
+`b.columns` is the rendered column list, not the `@columns` argument you passed
+in. Treat `b.columns` as read-only. It is the table's live column list, not a
+copy — mutating it in place (`sort`, `push`, `splice`) will corrupt the header
+and the rendered rows. Copy it first if you need a different order. `b.Row`
+and `b.Cell` carry the table's resolved `@size` padding, sticky handling, and
+`@classes` overrides.
+
+The `loading` block yields `{ columns }` only — it renders inside a single
+spanning cell, so `Row` and `Cell` would not be valid there. Use it for an
+overlay or spinner over a table that already has content; use `bodyTop` for
+rows that stand in for content that has not arrived yet.
+
+### Data attributes
+
+These are a supported contract, stable across minor versions:
+
+| Attribute     | Element | Value                                    |
+| ------------- | ------- | ---------------------------------------- |
+| `data-key`    | `<th>`  | the column's `key`                       |
+| `data-column` | `<td>`  | the column's `key`                       |
+| `data-key`    | `<tr>`  | the row's key, from `@getKey`            |
+
+Use them for column-targeted styling and test selectors.
+
 ## Column Visibility
 
 Enable users to show/hide columns with the toolbar:

--- a/packages/frontile/src/components/collections/table/table.gts
+++ b/packages/frontile/src/components/collections/table/table.gts
@@ -38,6 +38,8 @@ import type {
 import type { ColumnConfig as UniversalColumnConfig } from '@universal-ember/table';
 import type { ContentValue, WithBoundArgs } from '@glint/template';
 import type Owner from '@ember/owner';
+import type { SimpleTableRow } from '../simple-table/row';
+import type { SimpleTableCell } from '../simple-table/cell';
 
 interface TableSignature<
   T,
@@ -127,9 +129,25 @@ interface TableSignature<
         onSort: () => void;
       }
     ];
-    loading: [];
-    bodyTop: [];
-    bodyBottom: [];
+    loading: [
+      {
+        columns: Column<T>[];
+      }
+    ];
+    bodyTop: [
+      {
+        columns: Column<T>[];
+        Row: WithBoundArgs<typeof SimpleTableRow, 'styleFns' | 'classes'>;
+        Cell: WithBoundArgs<typeof SimpleTableCell, 'styleFns' | 'classes'>;
+      }
+    ];
+    bodyBottom: [
+      {
+        columns: Column<T>[];
+        Row: WithBoundArgs<typeof SimpleTableRow, 'styleFns' | 'classes'>;
+        Cell: WithBoundArgs<typeof SimpleTableCell, 'styleFns' | 'classes'>;
+      }
+    ];
   };
 }
 
@@ -701,7 +719,10 @@ class Table<
 
         <t.Body>
           {{#if (has-block "bodyTop")}}
-            {{yield to="bodyTop"}}
+            {{yield
+              (hash columns=this.headlessColumns Row=t.Row Cell=t.Cell)
+              to="bodyTop"
+            }}
           {{/if}}
 
           {{#each this.headlessRows as |row|}}
@@ -795,13 +816,16 @@ class Table<
                 colspan={{this.headlessColumns.length}}
                 data-test-id="table-loading-cell"
               >
-                {{yield to="loading"}}
+                {{yield (hash columns=this.headlessColumns) to="loading"}}
               </t.Cell>
             </t.Row>
           {{/if}}
 
           {{#if (has-block "bodyBottom")}}
-            {{yield to="bodyBottom"}}
+            {{yield
+              (hash columns=this.headlessColumns Row=t.Row Cell=t.Cell)
+              to="bodyBottom"
+            }}
           {{/if}}
         </t.Body>
 

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -111,6 +111,10 @@ const table = tv({
         ]
       }
     },
+    // Declared empty on purpose: these variants exist only so `isLoading` can
+    // pair with them in `compoundVariants` below, where the actual
+    // `thead: after:bg-*` colour is applied. A colour set here would paint the
+    // hairline even when the table is not loading.
     loadingColor: {
       default: {},
       primary: {},

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -77,7 +77,6 @@ const table = tv({
     columnVisibilityButton: ['flex'],
     columnVisibilityIcon: ['size-6'],
     td: [
-      'p-4',
       'align-middle',
       'text-neutral-strong',
       '[&:has([role=checkbox])]:pr-0'

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -18734,6 +18734,41 @@ const data: ComponentDoc[] = [
   },
   {
     package: 'unknown',
+    module: 'skeleton',
+    name: 'Skeleton',
+    fileName:
+      'packages/frontile/declarations/components/utilities/skeleton.d.ts',
+    Args: [
+      {
+        identifier: 'animation',
+        type: { type: 'SkeletonVariants' },
+        isRequired: false,
+        isInternal: false,
+        description: 'Animation style for the placeholder.',
+        tags: { defaultValue: { name: 'defaultValue', value: "'shimmer'" } },
+        defaultValue: '<span class="hljs-string">\'shimmer\'</span>',
+      },
+      {
+        identifier: 'class',
+        type: { type: '<span class="hljs-built_in">string</span>' },
+        isRequired: false,
+        isInternal: false,
+        description: '',
+        tags: {},
+      },
+    ],
+    Blocks: [],
+    Element: {
+      identifier: 'Element',
+      type: { type: 'HTMLDivElement' },
+      description: '',
+      url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement',
+    },
+    description: '',
+    tags: {},
+  },
+  {
+    package: 'unknown',
     module: 'spinner',
     name: 'Spinner',
     fileName:
@@ -21217,7 +21252,7 @@ const data: ComponentDoc[] = [
         identifier: 'default',
         type: {
           type: '<span class="hljs-built_in">Array</span>',
-          raw: '[{ <span class="hljs-attr">Row</span>: <span class="hljs-keyword">typeof</span> SimpleTableRow; Cell: <span class="hljs-keyword">typeof</span> SimpleTableCell; }]',
+          raw: '[{ <span class="hljs-attr">Row</span>: <span class="hljs-built_in">never</span>; Cell: <span class="hljs-built_in">never</span>; }]',
           items: [
             {
               identifier: '0',
@@ -21226,9 +21261,7 @@ const data: ComponentDoc[] = [
                 items: [
                   {
                     identifier: 'Row',
-                    type: {
-                      type: '<span class="hljs-keyword">typeof</span> SimpleTableRow',
-                    },
+                    type: { type: '<span class="hljs-built_in">never</span>' },
                     isRequired: true,
                     isInternal: false,
                     description: '',
@@ -21236,9 +21269,7 @@ const data: ComponentDoc[] = [
                   },
                   {
                     identifier: 'Cell',
-                    type: {
-                      type: '<span class="hljs-keyword">typeof</span> SimpleTableCell',
-                    },
+                    type: { type: '<span class="hljs-built_in">never</span>' },
                     isRequired: true,
                     isInternal: false,
                     description: '',
@@ -21944,7 +21975,7 @@ const data: ComponentDoc[] = [
         identifier: 'default',
         type: {
           type: '<span class="hljs-built_in">Array</span>',
-          raw: '[{ <span class="hljs-attr">Cell</span>: <span class="hljs-keyword">typeof</span> SimpleTableCell; }]',
+          raw: '[{ <span class="hljs-attr">Cell</span>: <span class="hljs-built_in">never</span>; }]',
           items: [
             {
               identifier: '0',
@@ -21953,9 +21984,7 @@ const data: ComponentDoc[] = [
                 items: [
                   {
                     identifier: 'Cell',
-                    type: {
-                      type: '<span class="hljs-keyword">typeof</span> SimpleTableCell',
-                    },
+                    type: { type: '<span class="hljs-built_in">never</span>' },
                     isRequired: true,
                     isInternal: false,
                     description: '',
@@ -22845,8 +22874,32 @@ const data: ComponentDoc[] = [
         identifier: 'loading',
         type: {
           type: '<span class="hljs-built_in">Array</span>',
-          raw: '[]',
-          items: [],
+          raw: '[{ <span class="hljs-attr">columns</span>: Column&#x3C;T>[]; }]',
+          items: [
+            {
+              identifier: '0',
+              type: {
+                type: '<span class="hljs-built_in">Object</span>',
+                items: [
+                  {
+                    identifier: 'columns',
+                    type: {
+                      type: '<span class="hljs-built_in">Array</span>',
+                      raw: 'Column&#x3C;T>[]',
+                    },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                ],
+              },
+              isRequired: true,
+              isInternal: false,
+              description: '',
+              tags: {},
+            },
+          ],
         },
         isRequired: true,
         isInternal: false,
@@ -22857,8 +22910,48 @@ const data: ComponentDoc[] = [
         identifier: 'bodyTop',
         type: {
           type: '<span class="hljs-built_in">Array</span>',
-          raw: '[]',
-          items: [],
+          raw: '[{ <span class="hljs-attr">columns</span>: Column&#x3C;T>[]; Row: <span class="hljs-built_in">never</span>; Cell: <span class="hljs-built_in">never</span>; }]',
+          items: [
+            {
+              identifier: '0',
+              type: {
+                type: '<span class="hljs-built_in">Object</span>',
+                items: [
+                  {
+                    identifier: 'columns',
+                    type: {
+                      type: '<span class="hljs-built_in">Array</span>',
+                      raw: 'Column&#x3C;T>[]',
+                    },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'Row',
+                    type: { type: '<span class="hljs-built_in">never</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'Cell',
+                    type: { type: '<span class="hljs-built_in">never</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                ],
+              },
+              isRequired: true,
+              isInternal: false,
+              description: '',
+              tags: {},
+            },
+          ],
         },
         isRequired: true,
         isInternal: false,
@@ -22869,8 +22962,48 @@ const data: ComponentDoc[] = [
         identifier: 'bodyBottom',
         type: {
           type: '<span class="hljs-built_in">Array</span>',
-          raw: '[]',
-          items: [],
+          raw: '[{ <span class="hljs-attr">columns</span>: Column&#x3C;T>[]; Row: <span class="hljs-built_in">never</span>; Cell: <span class="hljs-built_in">never</span>; }]',
+          items: [
+            {
+              identifier: '0',
+              type: {
+                type: '<span class="hljs-built_in">Object</span>',
+                items: [
+                  {
+                    identifier: 'columns',
+                    type: {
+                      type: '<span class="hljs-built_in">Array</span>',
+                      raw: 'Column&#x3C;T>[]',
+                    },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'Row',
+                    type: { type: '<span class="hljs-built_in">never</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'Cell',
+                    type: { type: '<span class="hljs-built_in">never</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                ],
+              },
+              isRequired: true,
+              isInternal: false,
+              description: '',
+              tags: {},
+            },
+          ],
         },
         isRequired: true,
         isInternal: false,

--- a/test-app/tests/integration/components/collections/simple-table-test.gts
+++ b/test-app/tests/integration/components/collections/simple-table-test.gts
@@ -319,5 +319,76 @@ module(
 
       assert.dom('[data-test-id="nested-cell"]').hasClass('custom-td-class');
     });
+
+    test('a Row yielded from Body respects the table size', async function (assert) {
+      await render(
+        <template>
+          <SimpleTable @size="sm" as |t|>
+            <t.Body as |b|>
+              <b.Row as |r|>
+                <r.Cell data-test-id="nested-cell">Nested</r.Cell>
+              </b.Row>
+            </t.Body>
+          </SimpleTable>
+        </template>
+      );
+
+      // The `sm` size variant sets `px-3 py-2 text-body-micro` on td; the md
+      // default sets `text-body-2xs`. `text-body-micro` comes only from the
+      // `sm` variant (no shorthand/longhand ambiguity like `p-4` vs `px`/`py`).
+      assert.dom('[data-test-id="nested-cell"]').hasClass('px-3');
+      assert.dom('[data-test-id="nested-cell"]').hasClass('py-2');
+      assert.dom('[data-test-id="nested-cell"]').hasClass('text-body-micro');
+    });
+
+    test('a Row yielded from Body respects table classes.td', async function (assert) {
+      await render(
+        <template>
+          <SimpleTable @classes={{hash td="custom-td-class"}} as |t|>
+            <t.Body as |b|>
+              <b.Row as |r|>
+                <r.Cell data-test-id="nested-cell">Nested</r.Cell>
+              </b.Row>
+            </t.Body>
+          </SimpleTable>
+        </template>
+      );
+
+      assert.dom('[data-test-id="nested-cell"]').hasClass('custom-td-class');
+    });
+
+    test('a Cell yielded from Body respects the table size', async function (assert) {
+      await render(
+        <template>
+          <SimpleTable @size="sm" as |t|>
+            <t.Body as |b|>
+              <tr>
+                <b.Cell data-test-id="nested-cell">Nested</b.Cell>
+              </tr>
+            </t.Body>
+          </SimpleTable>
+        </template>
+      );
+
+      assert.dom('[data-test-id="nested-cell"]').hasClass('px-3');
+      assert.dom('[data-test-id="nested-cell"]').hasClass('py-2');
+      assert.dom('[data-test-id="nested-cell"]').hasClass('text-body-micro');
+    });
+
+    test('a Cell yielded from Body respects table classes.td', async function (assert) {
+      await render(
+        <template>
+          <SimpleTable @classes={{hash td="custom-td-class"}} as |t|>
+            <t.Body as |b|>
+              <tr>
+                <b.Cell data-test-id="nested-cell">Nested</b.Cell>
+              </tr>
+            </t.Body>
+          </SimpleTable>
+        </template>
+      );
+
+      assert.dom('[data-test-id="nested-cell"]').hasClass('custom-td-class');
+    });
   }
 );

--- a/test-app/tests/integration/components/collections/simple-table-test.gts
+++ b/test-app/tests/integration/components/collections/simple-table-test.gts
@@ -282,5 +282,42 @@ module(
           .containsText(`Content for ${color}`);
       }
     });
+
+    test('a Cell yielded from Row respects the table size', async function (assert) {
+      await render(
+        <template>
+          <SimpleTable @size="sm" as |t|>
+            <t.Body>
+              <t.Row as |r|>
+                <r.Cell data-test-id="nested-cell">Nested</r.Cell>
+              </t.Row>
+            </t.Body>
+          </SimpleTable>
+        </template>
+      );
+
+      // The `sm` size variant sets `px-3 py-2 text-body-micro` on td; the md
+      // default sets `text-body-2xs`. `text-body-micro` comes only from the
+      // `sm` variant (no shorthand/longhand ambiguity like `p-4` vs `px`/`py`).
+      assert.dom('[data-test-id="nested-cell"]').hasClass('px-3');
+      assert.dom('[data-test-id="nested-cell"]').hasClass('py-2');
+      assert.dom('[data-test-id="nested-cell"]').hasClass('text-body-micro');
+    });
+
+    test('a Cell yielded from Row respects table classes.td', async function (assert) {
+      await render(
+        <template>
+          <SimpleTable @classes={{hash td="custom-td-class"}} as |t|>
+            <t.Body>
+              <t.Row as |r|>
+                <r.Cell data-test-id="nested-cell">Nested</r.Cell>
+              </t.Row>
+            </t.Body>
+          </SimpleTable>
+        </template>
+      );
+
+      assert.dom('[data-test-id="nested-cell"]').hasClass('custom-td-class');
+    });
   }
 );

--- a/test-app/tests/integration/components/collections/table-test.gts
+++ b/test-app/tests/integration/components/collections/table-test.gts
@@ -3400,5 +3400,208 @@ module(
           .hasText('28');
       });
     });
+
+    module('Body Block Yielded Columns', function () {
+      test('bodyTop yields the rendered columns', async function (assert) {
+        const columns = [
+          { key: 'id', name: 'ID' },
+          { key: 'name', name: 'Name' }
+        ] as const satisfies ColumnConfig<TestItem>[];
+        const items: TestItem[] = [];
+
+        await render(
+          <template>
+            <Table @columns={{columns}} @items={{items}}>
+              <:bodyTop as |b|>
+                <b.Row data-test-id="yielded-row">
+                  {{#each b.columns as |column|}}
+                    <b.Cell data-column={{column.key}}>{{column.key}}</b.Cell>
+                  {{/each}}
+                </b.Row>
+              </:bodyTop>
+            </Table>
+          </template>
+        );
+
+        assert.dom('[data-test-id="yielded-row"]').exists();
+        assert
+          .dom('[data-test-id="yielded-row"] [data-column="id"]')
+          .exists('renders a cell for the id column');
+        assert
+          .dom('[data-test-id="yielded-row"] [data-column="name"]')
+          .exists('renders a cell for the name column');
+        assert.dom('[data-test-id="yielded-row"] td').exists({ count: 2 });
+      });
+
+      test('bodyTop yielded columns include the selection column', async function (assert) {
+        const columns = [
+          { key: 'name', name: 'Name' }
+        ] as const satisfies ColumnConfig<TestItem>[];
+        const items: TestItem[] = [
+          {
+            id: '1',
+            name: 'John Doe',
+            email: 'john@example.com',
+            role: 'admin'
+          }
+        ];
+
+        await render(
+          <template>
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @selectionMode="multiple"
+            >
+              <:bodyTop as |b|>
+                <b.Row data-test-id="yielded-row">
+                  {{#each b.columns as |column|}}
+                    <b.Cell data-column={{column.key}} />
+                  {{/each}}
+                </b.Row>
+              </:bodyTop>
+            </Table>
+          </template>
+        );
+
+        assert
+          .dom('[data-test-id="yielded-row"] [data-column="__selection__"]')
+          .exists('includes the synthetic selection column');
+        assert.dom('[data-test-id="yielded-row"] td').exists({ count: 2 });
+      });
+
+      test('bodyTop yielded columns match the rendered header', async function (assert) {
+        const columns = [
+          { key: 'id', name: 'ID' },
+          { key: 'name', name: 'Name' },
+          { key: 'email', name: 'Email', isVisible: false }
+        ] as const satisfies ColumnConfig<TestItem>[];
+        const items: TestItem[] = [];
+
+        await render(
+          <template>
+            <Table @columns={{columns}} @items={{items}}>
+              <:bodyTop as |b|>
+                <b.Row data-test-id="yielded-row">
+                  {{#each b.columns as |column|}}
+                    <b.Cell data-column={{column.key}} />
+                  {{/each}}
+                </b.Row>
+              </:bodyTop>
+            </Table>
+          </template>
+        );
+
+        const headerKeys = Array.from(
+          this.element.querySelectorAll('thead th[data-key]'),
+          (th) => th.getAttribute('data-key')
+        );
+        const cellKeys = Array.from(
+          this.element.querySelectorAll(
+            '[data-test-id="yielded-row"] td[data-column]'
+          ),
+          (td) => td.getAttribute('data-column')
+        );
+
+        assert.deepEqual(
+          cellKeys,
+          headerKeys,
+          'yielded columns match the rendered header exactly'
+        );
+        assert.notOk(
+          headerKeys.includes('email'),
+          'the hidden column is absent from both'
+        );
+      });
+
+      test('a Cell yielded to bodyTop respects the table size', async function (assert) {
+        const columns = [
+          { key: 'name', name: 'Name' }
+        ] as const satisfies ColumnConfig<TestItem>[];
+        const items: TestItem[] = [];
+
+        await render(
+          <template>
+            <Table @columns={{columns}} @items={{items}} @size="sm">
+              <:bodyTop as |b|>
+                <b.Row>
+                  <b.Cell data-test-id="sized-cell">Cell</b.Cell>
+                </b.Row>
+              </:bodyTop>
+            </Table>
+          </template>
+        );
+
+        assert.dom('[data-test-id="sized-cell"]').hasClass('px-3');
+        assert.dom('[data-test-id="sized-cell"]').doesNotHaveClass('p-4');
+      });
+
+      test('bodyBottom yields the rendered columns', async function (assert) {
+        const columns = [
+          { key: 'id', name: 'ID' },
+          { key: 'name', name: 'Name' }
+        ] as const satisfies ColumnConfig<TestItem>[];
+        const items: TestItem[] = [];
+
+        await render(
+          <template>
+            <Table @columns={{columns}} @items={{items}}>
+              <:bodyBottom as |b|>
+                <b.Row data-test-id="yielded-bottom-row">
+                  {{#each b.columns as |column|}}
+                    <b.Cell data-column={{column.key}} />
+                  {{/each}}
+                </b.Row>
+              </:bodyBottom>
+            </Table>
+          </template>
+        );
+
+        assert
+          .dom('[data-test-id="yielded-bottom-row"] td')
+          .exists({ count: 2 });
+      });
+
+      test('loading yields the rendered columns', async function (assert) {
+        const columns = [
+          { key: 'id', name: 'ID' },
+          { key: 'name', name: 'Name' }
+        ] as const satisfies ColumnConfig<TestItem>[];
+        const items: TestItem[] = [];
+
+        await render(
+          <template>
+            <Table @columns={{columns}} @items={{items}} @isLoading={{true}}>
+              <:loading as |l|>
+                <span data-test-id="loading-count">{{l.columns.length}}</span>
+              </:loading>
+            </Table>
+          </template>
+        );
+
+        assert.dom('[data-test-id="loading-count"]').hasText('2');
+      });
+
+      test('existing blocks that take no block param still render', async function (assert) {
+        const columns = [
+          { key: 'name', name: 'Name' }
+        ] as const satisfies ColumnConfig<TestItem>[];
+        const items: TestItem[] = [];
+
+        await render(
+          <template>
+            <Table @columns={{columns}} @items={{items}}>
+              <:bodyTop>
+                <tr data-test-id="legacy-row">
+                  <td colspan="1">Legacy</td>
+                </tr>
+              </:bodyTop>
+            </Table>
+          </template>
+        );
+
+        assert.dom('[data-test-id="legacy-row"]').exists();
+      });
+    });
   }
 );


### PR DESCRIPTION
Responds to feedback from a team that added skeleton loading states to 28 tables and had to work around gaps in `Table`. First of three stacked PRs.

`Table` knows exactly which columns it renders and never tells anyone. `headlessColumns` is the visibility-filtered, `__selection__`-augmented list the header and every data row iterate, but `bodyTop`, `bodyBottom`, and `loading` were yielded nothing at all. Consumers rendering row-shaped content had to reconstruct the list from the `@columns` argument they passed in — which is not what the table renders. It lacks the synthetic selection column, and it does not reflect columns hidden through the `ColumnVisibility` plugin, since that state lives in the plugin. The workaround downstream was a DOM modifier reading `thead th[data-key]` to hide mismatched cells.

## What changed

`bodyTop` and `bodyBottom` now yield `{ columns, Row, Cell }`; `loading` yields `{ columns }` only, since it renders inside a `<td colspan>` where `Row`/`Cell` would produce invalid nested-table markup. `Row` and `Cell` come from `SimpleTable` already bound with the resolved `styleFns`, so consumers stop hardcoding `p-4 align-middle` and stop drifting when the table sets `@size`.

```hbs
<:bodyTop as |b|>
  <b.Row>
    {{#each b.columns as |column|}}
      <b.Cell data-column={{column.key}}>…</b.Cell>
    {{/each}}
  </b.Row>
</:bodyTop>
```

Also in this PR:

- **`SimpleTableRow` and `SimpleTableBody` yielded their nested `Cell`/`Row` unbound**, so `<r.Cell>` and `<b.Row>` silently ignored the table's `@size` and `@classes`. Both now bind `styleFns`/`classes`, matching what `SimpleTable` already does for its own default block.
- **Removed a redundant base `p-4` from the theme's `td` slot.** tailwind-merge does not treat the `p` shorthand as conflicting with `px`/`py`, so `sm` cells carried `p-4 px-3 py-2`. Verified behavior-preserving: all three size variants fully specify their own padding and `defaultVariants.size` is `md`, so a bare `table()` is unchanged. Only `sm` changes, dropping a class the cascade already overrode.
- Documented `data-key` / `data-column` as a supported contract, and commented why the theme's `loadingColor` variants are declared empty (the colour resolves through `compoundVariants` paired with `isLoading`).

## Behaviour change worth labelling

Binding `classes` on the yielded `Cell` is a fix, not an addition: an existing `<t.Row as |r|><r.Cell>` with `@size="sm"` now renders `px-3 py-2` instead of `p-4`. That is the intended correction, but it should surface in release notes as a fix rather than hide under a feature headline.

Everything else is strictly additive — adding block params is backwards-compatible, and there is a test pinning that blocks which ignore the new param still render.

## Testing

`Table` 115/115, `SimpleTable` 16/16. New coverage: yielded columns omit a `ColumnVisibility`-hidden column, include `__selection__` under `selectionMode="multiple"`, match the rendered `thead th[data-key]` set exactly, and carry the correct `@size` padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
