### PR TITLE
fix(site): resolve index page markdown URL for DocfyCopyPage

### DIFF
--- a/site/app/components/docfy/docfy-copy-page.gts
+++ b/site/app/components/docfy/docfy-copy-page.gts
@@ -15,13 +15,37 @@ export interface DocfyCopyPageSignature {
 
 type CopyStatus = 'idle' | 'copying' | 'copied' | 'error';
 
+/**
+ * Map a Docfy page URL to the path of its exported Markdown mirror.
+ *
+ * Docfy gives index pages (`index.md` / `readme.md`) a URL ending in `/` —
+ * e.g. `/docs/get-started/` — even though the router renders it without the
+ * trailing slash. @docfy/ember-vite's static export mirrors those to
+ * `<url>index.md`, so naively appending `.md` would ask for
+ * `/docs/get-started/.md` and 404. This mirrors `markdownFileName` from
+ * @docfy/ember-vite's static-export.
+ */
+export function markdownPathForPageUrl(url: string): string {
+  const normalized = url.startsWith('/') ? url : `/${url}`;
+
+  if (normalized === '/') {
+    return '/index.md';
+  }
+
+  if (normalized.endsWith('/')) {
+    return `${normalized}index.md`;
+  }
+
+  return `${normalized}.md`;
+}
+
 export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
   @tracked status: CopyStatus = 'idle';
 
   resetTimer?: ReturnType<typeof setTimeout>;
 
   get mdUrl(): string {
-    return `${window.location.origin}${this.args.url}.md`;
+    return `${window.location.origin}${markdownPathForPageUrl(this.args.url)}`;
   }
 
   buildPrompt(): string {

--- a/site/tests/integration/components/docfy/docfy-copy-page-test.gts
+++ b/site/tests/integration/components/docfy/docfy-copy-page-test.gts
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
-import DocfyCopyPage from 'site/components/docfy/docfy-copy-page';
+import DocfyCopyPage, {
+  markdownPathForPageUrl,
+} from 'site/components/docfy/docfy-copy-page';
 
 module('Integration | Component | docfy/docfy-copy-page', function (hooks) {
   setupRenderingTest(hooks);
@@ -190,6 +192,70 @@ module('Integration | Component | docfy/docfy-copy-page', function (hooks) {
     assert.strictEqual(
       openedUrls[1],
       `https://claude.ai/new?q=${encodeURIComponent(expectedPrompt)}`
+    );
+  });
+
+  test('markdownPathForPageUrl maps index page URLs to their index.md mirror', function (assert) {
+    assert.strictEqual(
+      markdownPathForPageUrl('/docs/components/buttons/button-group'),
+      '/docs/components/buttons/button-group.md'
+    );
+    assert.strictEqual(
+      markdownPathForPageUrl('/docs/get-started/'),
+      '/docs/get-started/index.md'
+    );
+    assert.strictEqual(markdownPathForPageUrl('/'), '/index.md');
+    assert.strictEqual(
+      markdownPathForPageUrl('docs/get-started/'),
+      '/docs/get-started/index.md'
+    );
+  });
+
+  test('an index page fetches and links to <url>index.md, not <url>.md', async function (assert) {
+    const requestedUrls: string[] = [];
+    const openedUrls: string[] = [];
+
+    window.fetch = ((input: string) => {
+      requestedUrls.push(input);
+      return Promise.resolve(new Response('# Get Started', { status: 200 }));
+    }) as typeof window.fetch;
+
+    window.open = ((url: string) => {
+      openedUrls.push(url);
+      return null;
+    }) as typeof window.open;
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: () => Promise.resolve() },
+    });
+
+    await render(
+      <template>
+        <DocfyCopyPage @url="/docs/get-started/" @title="Get Started" />
+      </template>
+    );
+
+    await click('[data-test-id="copy-page-primary"]');
+
+    assert.deepEqual(requestedUrls, [
+      `${window.location.origin}/docs/get-started/index.md`,
+    ]);
+
+    await click('[data-test-id="copy-page-trigger"]');
+
+    assert
+      .dom('[data-test-id="copy-page-view-markdown"]')
+      .hasAttribute(
+        'href',
+        `${window.location.origin}/docs/get-started/index.md`
+      );
+
+    await click('[data-key="view-as-markdown"]');
+
+    assert.strictEqual(
+      openedUrls[0],
+      `${window.location.origin}/docs/get-started/index.md`
     );
   });
 });


### PR DESCRIPTION
## Problem

On any page whose source is an `index.md`, every action in the "Copy Markdown" control was broken.

Docfy gives index pages (`index.md` / `readme.md`) a URL ending in `/` — e.g. `page.url === "/docs/get-started/"` — even though the Ember router renders it as `/docs/get-started`. `DocfyCopyPage` built its markdown URL as `${origin}${page.url}.md`, which produced `/docs/get-started/.md` and 404s. That broke:

- Copy Markdown (showed "Unavailable")
- View as Markdown (both the `href` and the opened tab)
- Open in ChatGPT / Open in Claude (the prompt pointed at a dead URL)

`@docfy/ember-vite`'s static export mirrors those pages to `<url>index.md` instead — `dist/docs/get-started/index.md`.

## Fix

Map the page URL through a new exported `markdownPathForPageUrl`, mirroring `markdownFileName` from @docfy/ember-vite's static export:

| page URL | markdown path |
| --- | --- |
| `/docs/get-started/` | `/docs/get-started/index.md` |
| `/docs/components/buttons/button-group` | `/docs/components/buttons/button-group.md` |
| `/` | `/index.md` |

`mdUrl` now goes through it, so all four actions get the right URL.

No extra data needs threading through from `docfy-page.gts`: `DocfyOutput @fromCurrentURL` resolves via `docfy.findByUrl`, which strips the trailing slash off the *router* URL for matching but returns the page whose `url` retains it — so `page.url` is already authoritative.

## Verification

- Live on the dev server at `/docs/get-started` (`location.pathname` has no trailing slash): the menu `href` is now `/docs/get-started/index.md` and fetching it returns **200**.
- Two new tests — a unit test of the URL mapping (incl. root and a slash-less input) and a rendering test asserting an index page fetches, links to, and opens `<url>index.md`.
- Full `docfy-copy-page` module: 8 tests / 20 assertions, 0 failed. Prettier clean; no new ESLint errors.

Note: Testem can't launch Chrome in this sandbox, so the suite was run through the vite dev server's `/tests` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)