### PR TITLE
feat(site): add "Copy Markdown URL" action to DocfyCopyPage

### DIFF
--- a/site/app/components/docfy/docfy-copy-page.gts
+++ b/site/app/components/docfy/docfy-copy-page.gts
@@ -13,7 +13,7 @@ export interface DocfyCopyPageSignature {
   Element: HTMLDivElement;
 }
 
-type CopyStatus = 'idle' | 'copying' | 'copied' | 'error';
+type CopyStatus = 'idle' | 'copying' | 'copied' | 'copied-url' | 'error';
 
 /**
  * Map a Docfy page URL to the path of its exported Markdown mirror.
@@ -61,7 +61,7 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
   }
 
   get isCopied(): boolean {
-    return this.status === 'copied';
+    return this.status === 'copied' || this.status === 'copied-url';
   }
 
   get primaryLabel(): string {
@@ -70,6 +70,8 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
         return 'Copying…';
       case 'copied':
         return 'Copied!';
+      case 'copied-url':
+        return 'URL copied!';
       case 'error':
         return 'Unavailable';
       default:
@@ -85,7 +87,7 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
       if (this.isDestroying || this.isDestroyed) {
         return;
       }
-      if (this.status === 'copied' || this.status === 'error') {
+      if (this.status !== 'copying') {
         this.status = 'idle';
       }
     }, 2000);
@@ -110,6 +112,20 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
       const text = await response.text();
       await navigator.clipboard.writeText(text);
       this.status = 'copied';
+    } catch {
+      this.status = 'error';
+    } finally {
+      this.resetAfterDelay();
+    }
+  }
+
+  // Copies the `.md` URL itself, rather than the page contents — handy for
+  // pasting into an agent that will do its own fetching.
+  @action
+  async copyMarkdownUrl(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(this.mdUrl);
+      this.status = 'copied-url';
     } catch {
       this.status = 'error';
     } finally {
@@ -160,7 +176,9 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
 
   @action
   handleMenuAction(key: string): void {
-    if (key === 'view-as-markdown') {
+    if (key === 'copy-markdown-url') {
+      void this.copyMarkdownUrl();
+    } else if (key === 'view-as-markdown') {
       this.viewAsMarkdown();
     } else if (key === 'open-chatgpt') {
       this.openInChatGpt();
@@ -210,6 +228,7 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
             @disableTransitions={{true}}
             as |Item|
           >
+            <Item @key="copy-markdown-url">Copy Markdown URL</Item>
             <Item @key="view-as-markdown">
               <a
                 href={{this.mdUrl}}

--- a/site/tests/integration/components/docfy/docfy-copy-page-test.gts
+++ b/site/tests/integration/components/docfy/docfy-copy-page-test.gts
@@ -103,7 +103,7 @@ module('Integration | Component | docfy/docfy-copy-page', function (hooks) {
     assert.dom('[data-test-id="copy-page-primary"]').hasText('Unavailable');
   });
 
-  test('the dropdown lists the remaining three actions', async function (assert) {
+  test('the dropdown lists the remaining actions', async function (assert) {
     await render(
       <template>
         <DocfyCopyPage
@@ -115,9 +115,99 @@ module('Integration | Component | docfy/docfy-copy-page', function (hooks) {
 
     await click('[data-test-id="copy-page-trigger"]');
 
+    assert.dom('[data-key="copy-markdown-url"]').hasText('Copy Markdown URL');
     assert.dom('[data-key="view-as-markdown"]').hasText('View as Markdown');
     assert.dom('[data-key="open-chatgpt"]').hasText('Open in ChatGPT');
     assert.dom('[data-key="open-claude"]').hasText('Open in Claude');
+  });
+
+  test('"Copy Markdown URL" copies the .md URL itself, not the page contents', async function (assert) {
+    const copied: string[] = [];
+
+    window.fetch = (() => {
+      assert.step('fetch should not be called');
+      return Promise.reject(new Error('unexpected fetch'));
+    }) as typeof window.fetch;
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          copied.push(text);
+          return Promise.resolve();
+        },
+      },
+    });
+
+    await render(
+      <template>
+        <DocfyCopyPage
+          @url="/docs/components/buttons/button-group"
+          @title="ButtonGroup"
+        />
+      </template>
+    );
+
+    await click('[data-test-id="copy-page-trigger"]');
+    await click('[data-key="copy-markdown-url"]');
+
+    assert.deepEqual(copied, [
+      `${window.location.origin}/docs/components/buttons/button-group.md`,
+    ]);
+    assert.verifySteps([]);
+    assert
+      .dom('[data-test-id="copy-page-primary"]')
+      .hasText('URL copied!', 'the primary button reports what was copied');
+  });
+
+  test('"Copy Markdown URL" copies the index.md URL on an index page', async function (assert) {
+    const copied: string[] = [];
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          copied.push(text);
+          return Promise.resolve();
+        },
+      },
+    });
+
+    await render(
+      <template>
+        <DocfyCopyPage @url="/docs/get-started/" @title="Get Started" />
+      </template>
+    );
+
+    await click('[data-test-id="copy-page-trigger"]');
+    await click('[data-key="copy-markdown-url"]');
+
+    assert.deepEqual(copied, [
+      `${window.location.origin}/docs/get-started/index.md`,
+    ]);
+  });
+
+  test('"Copy Markdown URL" surfaces a failure when the clipboard rejects', async function (assert) {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: () => Promise.reject(new Error('denied')),
+      },
+    });
+
+    await render(
+      <template>
+        <DocfyCopyPage
+          @url="/docs/components/buttons/button-group"
+          @title="ButtonGroup"
+        />
+      </template>
+    );
+
+    await click('[data-test-id="copy-page-trigger"]');
+    await click('[data-key="copy-markdown-url"]');
+
+    assert.dom('[data-test-id="copy-page-primary"]').hasText('Unavailable');
   });
 
   test('"View as markdown" carries the .md URL as a real href, and also opens via keyboard/click through the menu action', async function (assert) {


### PR DESCRIPTION
Adds a fourth item to the docs page's "Copy Markdown" dropdown:

| | action |
| --- | --- |
| **Copy Markdown URL** | **new** — copies the page's `.md` URL to the clipboard |
| View as Markdown | opens the `.md` in a new tab |
| Open in ChatGPT | |
| Open in Claude | |

Copying the URL (rather than the contents) is the handier option when pasting into an agent that will do its own fetching.

## Implementation

- New `copyMarkdownUrl` action writes `this.mdUrl` to the clipboard — no fetch. It goes through the existing `markdownPathForPageUrl`, so index pages copy `<url>index.md` (e.g. `/docs/get-started/index.md`), not `<url>.md`.
- The dropdown closes on action, so the primary button is the only place feedback is visible: a new `copied-url` status renders **"URL copied!"** with the check icon, resetting after the usual 2s. A rejected clipboard write falls into the existing `error` → "Unavailable" state.
- `resetAfterDelay` now resets from any non-`copying` status instead of enumerating them, so the new status can't get stuck.

## Verification

- Four new/updated tests: the menu lists all four items; the action copies the `.md` URL and never fetches (asserted with `assert.step` / `verifySteps`); an index page copies `<url>index.md`; a rejecting clipboard shows "Unavailable".
- Full `docfy-copy-page` module: **11 tests / 26 assertions, 0 failed.**
- Live on `/docs/get-started`: clicking the item copied `http://localhost:4732/docs/get-started/index.md`, the button read "URL copied!", then reverted to "Copy Markdown" after 2s.

Note: Testem can't launch Chrome in my sandbox, so the suite was run through the vite dev server's `/tests` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)