### PR TITLE
fix(collections): stop render-time focus events from writing list item state

### DIFF
--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -20,9 +20,59 @@ class ListItem {
   key: string;
   textValue: string;
 
-  @tracked isSelected: boolean;
-  @tracked isDisabled: boolean;
-  @tracked isActive: boolean;
+  // Ember's tracked setter dirties a tag unconditionally — it never compares
+  // against the current value. That makes a redundant write more than wasted
+  // work here: Glimmer reads an attribute and writes it to the DOM inside a
+  // single autotracking frame, and writing `tabindex` onto the focused item
+  // blurs it, so the browser dispatches `focusout` synchronously and this
+  // item's own listeners run *inside* the frame that just consumed `isActive`.
+  // Dirtying a tag that frame already consumed trips a backtracking-rerender
+  // assertion, so every field below only writes on a real change.
+  //
+  // Each comparison reads a plain mirror rather than the tracked field itself.
+  // Reading the tracked field would *consume* its tag, so the write that
+  // followed would dirty a tag the current frame had just consumed — precisely
+  // the failure these guards exist to prevent.
+  @tracked private _isSelected: boolean;
+  @tracked private _isDisabled: boolean;
+  @tracked private _isActive: boolean;
+
+  private selectedValue: boolean;
+  private disabledValue: boolean;
+  private activeValue: boolean;
+
+  get isSelected(): boolean {
+    return this._isSelected;
+  }
+
+  set isSelected(value: boolean) {
+    if (this.selectedValue !== value) {
+      this.selectedValue = value;
+      this._isSelected = value;
+    }
+  }
+
+  get isDisabled(): boolean {
+    return this._isDisabled;
+  }
+
+  set isDisabled(value: boolean) {
+    if (this.disabledValue !== value) {
+      this.disabledValue = value;
+      this._isDisabled = value;
+    }
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  set isActive(value: boolean) {
+    if (this.activeValue !== value) {
+      this.activeValue = value;
+      this._isActive = value;
+    }
+  }
 
   constructor(
     el: HTMLLIElement | HTMLOptionElement,
@@ -31,9 +81,9 @@ class ListItem {
     this.el = el;
     this.key = args.key;
     this.textValue = args.textValue;
-    this.isSelected = args.isSelected;
-    this.isDisabled = args.isDisabled;
-    this.isActive = args.isActive;
+    this._isSelected = this.selectedValue = args.isSelected;
+    this._isDisabled = this.disabledValue = args.isDisabled;
+    this._isActive = this.activeValue = args.isActive;
   }
 }
 
@@ -452,12 +502,31 @@ class ListManager {
         }
       };
 
+      // Glimmer mutates this item's DOM during a render — rewriting `tabindex`
+      // on the focused item, or clearing the block that contains it — and the
+      // browser reacts by blurring the element and dispatching `focusout`
+      // synchronously, inside the same autotracking frame that just consumed
+      // `isActive`. Writing tracked state from there trips a
+      // backtracking-rerender assertion.
+      //
+      // Such a blur has no `relatedTarget`: focus went nowhere rather than to
+      // another element. A user genuinely moving focus away — to a sibling
+      // option, the trigger, or anything else — always names that element, so
+      // reacting only when focus actually lands somewhere keeps deactivation
+      // working while ignoring the render's collateral.
+      const focusOut = (event: Event): void => {
+        if ((event as FocusEvent).relatedTarget === null) {
+          return;
+        }
+        mouseLeave();
+      };
+
       if (!args.disableEvents) {
         el.addEventListener('mouseenter', mouseEnter);
         el.addEventListener('mouseleave', mouseLeave);
 
         el.addEventListener('focusin', mouseEnter);
-        el.addEventListener('focusout', mouseLeave);
+        el.addEventListener('focusout', focusOut);
       }
 
       return (): void => {
@@ -468,7 +537,7 @@ class ListManager {
           el.removeEventListener('mouseleave', mouseLeave);
 
           el.removeEventListener('focusin', mouseEnter);
-          el.removeEventListener('focusout', mouseLeave);
+          el.removeEventListener('focusout', focusOut);
         }
       };
     }

--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -32,22 +32,24 @@ class ListItem {
   // Each comparison reads a plain mirror rather than the tracked field itself.
   // Reading the tracked field would *consume* its tag, so the write that
   // followed would dirty a tag the current frame had just consumed — precisely
-  // the failure these guards exist to prevent.
+  // the failure these guards exist to prevent. For the same reason, code that
+  // reads a field only to decide whether to write it should read the mirror;
+  // `isActiveUntracked` exposes that for the one caller outside this class.
   @tracked private _isSelected: boolean;
   @tracked private _isDisabled: boolean;
   @tracked private _isActive: boolean;
 
-  private selectedValue: boolean;
-  private disabledValue: boolean;
-  private activeValue: boolean;
+  private isSelectedMirror: boolean;
+  private isDisabledMirror: boolean;
+  private isActiveMirror: boolean;
 
   get isSelected(): boolean {
     return this._isSelected;
   }
 
   set isSelected(value: boolean) {
-    if (this.selectedValue !== value) {
-      this.selectedValue = value;
+    if (this.isSelectedMirror !== value) {
+      this.isSelectedMirror = value;
       this._isSelected = value;
     }
   }
@@ -57,8 +59,8 @@ class ListItem {
   }
 
   set isDisabled(value: boolean) {
-    if (this.disabledValue !== value) {
-      this.disabledValue = value;
+    if (this.isDisabledMirror !== value) {
+      this.isDisabledMirror = value;
       this._isDisabled = value;
     }
   }
@@ -68,10 +70,15 @@ class ListItem {
   }
 
   set isActive(value: boolean) {
-    if (this.activeValue !== value) {
-      this.activeValue = value;
+    if (this.isActiveMirror !== value) {
+      this.isActiveMirror = value;
       this._isActive = value;
     }
+  }
+
+  /** `isActive` read without consuming its tag, for write decisions. */
+  get isActiveUntracked(): boolean {
+    return this.isActiveMirror;
   }
 
   constructor(
@@ -81,9 +88,9 @@ class ListItem {
     this.el = el;
     this.key = args.key;
     this.textValue = args.textValue;
-    this._isSelected = this.selectedValue = args.isSelected;
-    this._isDisabled = this.disabledValue = args.isDisabled;
-    this._isActive = this.activeValue = args.isActive;
+    this._isSelected = this.isSelectedMirror = args.isSelected;
+    this._isDisabled = this.isDisabledMirror = args.isDisabled;
+    this._isActive = this.isActiveMirror = args.isActive;
   }
 }
 
@@ -279,7 +286,10 @@ class ListManager {
   }
 
   activateItem(item?: ListItem): void {
-    if (item && !item.isActive) {
+    // `isActiveUntracked`, not `isActive`: this read only decides whether to
+    // write, and consuming the tag here would put the write below in the same
+    // frame as a read of it — the hazard `ListItem` documents.
+    if (item && !item.isActiveUntracked) {
       this.#clearActive();
       item.isActive = true;
       this.args.onActiveItemChange?.(item.key, item);
@@ -431,10 +441,10 @@ class ListManager {
 
   #clearActive(): void {
     for (let i = 0; i < this.#items.length; i++) {
-      const item = this.#items[i] as ListItem;
-      if (item.isActive) {
-        item.isActive = false;
-      }
+      // No `isActive` check: the setter already skips unchanged values, and
+      // reading it here would consume every item's tag on a path that can run
+      // mid-render.
+      (this.#items[i] as ListItem).isActive = false;
     }
   }
 
@@ -505,15 +515,15 @@ class ListManager {
       // Glimmer mutates this item's DOM during a render — rewriting `tabindex`
       // on the focused item, or clearing the block that contains it — and the
       // browser reacts by blurring the element and dispatching `focusout`
-      // synchronously, inside the same autotracking frame that just consumed
-      // `isActive`. Writing tracked state from there trips a
-      // backtracking-rerender assertion.
+      // synchronously, inside the frame that just consumed `isActive` (see
+      // `ListItem` above). Those blurs carry no `relatedTarget`.
       //
-      // Such a blur has no `relatedTarget`: focus went nowhere rather than to
-      // another element. A user genuinely moving focus away — to a sibling
-      // option, the trigger, or anything else — always names that element, so
-      // reacting only when focus actually lands somewhere keeps deactivation
-      // working while ignoring the render's collateral.
+      // Neither do some genuine ones: clicking a non-focusable region,
+      // switching tab or window, or moving focus to browser chrome. Ignoring
+      // every targetless blur therefore trades a possibly-stale highlight for
+      // never writing tracked state mid-render. That is a good trade here —
+      // for a roving-tabindex widget, keeping the active item across a blur is
+      // closer to the ARIA pattern than clearing it.
       const focusOut = (event: Event): void => {
         if ((event as FocusEvent).relatedTarget === null) {
           return;

--- a/test-app/tests/integration/components/collections/list-manager-render-safety-test.gts
+++ b/test-app/tests/integration/components/collections/list-manager-render-safety-test.gts
@@ -5,19 +5,11 @@ import Component from '@glimmer/component';
 import { cell } from 'ember-resources';
 import { ListManager } from 'frontile/utils/listManager';
 
-// Glimmer mutates an item's DOM during a render — rewriting `tabindex` on the
-// focused item, or clearing the block that contains it — and the browser reacts
-// by blurring the element and dispatching `focusout` synchronously, inside the
-// same autotracking frame that just consumed `isActive`. Writing tracked state
-// from there trips:
-//
-//   You attempted to update `isActive` on `ListItem`, but it had already been
-//   used previously in the same computation.
-//
-// In production that frame belongs to Glimmer. These tests reproduce its shape
-// deterministically: the probe's getter consumes `isActive` and then dispatches
-// a real `focusout`, driving the real listener `setupItem` installed, all within
-// one frame.
+// Reproduces the frame that `ListItem` in listManager.ts documents: the getter
+// consumes `isActive` and then dispatches a real `focusout`, driving the real
+// listener `setupItem` installed — all inside one autotracking frame. In
+// production that frame belongs to Glimmer, which blurs the item as a side
+// effect of its own DOM writes.
 interface ProbeArgs {
   manager: ListManager;
   relatedTarget: EventTarget | null;
@@ -25,17 +17,16 @@ interface ProbeArgs {
 
 class Probe extends Component<{ Args: ProbeArgs }> {
   get consumeThenBlur(): string {
-    const el = document.querySelector<HTMLLIElement>('[data-test-probe-item]');
-    const item = el ? this.args.manager.at(el) : undefined;
+    const item = this.args.manager.atKey('a');
 
-    if (!el || !item) {
-      return 'no-item';
+    if (!item) {
+      throw new Error('probe could not find the registered item');
     }
 
     // Consume the tag, exactly as ListboxItem's `tabindex` getter does.
     const wasActive = item.isActive;
 
-    el.dispatchEvent(
+    item.el.dispatchEvent(
       new FocusEvent('focusout', {
         bubbles: true,
         relatedTarget: this.args.relatedTarget
@@ -61,43 +52,35 @@ module('Integration | Utils | ListManager | render safety', function (hooks) {
     const manager = buildManager();
     const showProbe = cell(false);
 
-    // Focus moving to a real element is a genuine blur, so the listener runs
-    // and writes `isActive = false` — a value the item already holds. The write
-    // must not dirty the tag that the same frame just consumed.
-    const elsewhere = document.createElement('button');
-    document.body.appendChild(elsewhere);
+    // Focus landing on a real element is a genuine blur, so the listener runs
+    // and writes `isActive = false` — a value the item already holds. That
+    // write must not dirty the tag the same frame just consumed.
+    const focusLandsHere = document.body;
 
-    try {
-      await render(
-        <template>
-          <ul>
-            <li
-              data-test-probe-item
-              {{manager.setupItem key="a" textValue="a"}}
-            >
-              a
-            </li>
-          </ul>
+    await render(
+      <template>
+        <ul>
+          <li data-test-probe-item {{manager.setupItem key="a" textValue="a"}}>
+            a
+          </li>
+        </ul>
 
-          {{#if showProbe.current}}
-            <Probe @manager={{manager}} @relatedTarget={{elsewhere}} />
-          {{/if}}
-        </template>
-      );
+        {{#if showProbe.current}}
+          <Probe @manager={{manager}} @relatedTarget={{focusLandsHere}} />
+        {{/if}}
+      </template>
+    );
 
-      const item = manager.atKey('a');
-      assert.false(item?.isActive, 'item starts inactive');
+    const item = manager.atKey('a');
+    assert.false(item?.isActive, 'item starts inactive');
 
-      // Render the probe only now, so `setupItem` has installed the real
-      // focusout listener before the getter dispatches to it.
-      showProbe.current = true;
-      await settled();
+    // Render the probe only now, so `setupItem` has installed the real
+    // focusout listener before the getter dispatches to it.
+    showProbe.current = true;
+    await settled();
 
-      assert.dom('[data-test-probe-item]').exists('item still rendered');
-      assert.false(item?.isActive, 'item remained inactive');
-    } finally {
-      elsewhere.remove();
-    }
+    assert.dom('[data-test-probe-item]').exists('item still rendered');
+    assert.false(item?.isActive, 'item remained inactive');
   });
 
   test('a focusout with no relatedTarget does not deactivate the item', async function (assert) {
@@ -123,9 +106,9 @@ module('Integration | Utils | ListManager | render safety', function (hooks) {
     await settled();
     assert.true(item?.isActive, 'item is active before the blur');
 
-    // A blur with no relatedTarget is what Glimmer's own DOM mutation produces.
-    // Deactivating there would be a genuine state change landing mid-render, so
-    // the listener must ignore it entirely.
+    // A targetless blur is what Glimmer's own DOM mutation produces.
+    // Deactivating there would be a genuine state change landing mid-render,
+    // so the listener must ignore it entirely.
     showProbe.current = true;
     await settled();
 

--- a/test-app/tests/integration/components/collections/list-manager-render-safety-test.gts
+++ b/test-app/tests/integration/components/collections/list-manager-render-safety-test.gts
@@ -1,0 +1,135 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import Component from '@glimmer/component';
+import { cell } from 'ember-resources';
+import { ListManager } from 'frontile/utils/listManager';
+
+// Glimmer mutates an item's DOM during a render — rewriting `tabindex` on the
+// focused item, or clearing the block that contains it — and the browser reacts
+// by blurring the element and dispatching `focusout` synchronously, inside the
+// same autotracking frame that just consumed `isActive`. Writing tracked state
+// from there trips:
+//
+//   You attempted to update `isActive` on `ListItem`, but it had already been
+//   used previously in the same computation.
+//
+// In production that frame belongs to Glimmer. These tests reproduce its shape
+// deterministically: the probe's getter consumes `isActive` and then dispatches
+// a real `focusout`, driving the real listener `setupItem` installed, all within
+// one frame.
+interface ProbeArgs {
+  manager: ListManager;
+  relatedTarget: EventTarget | null;
+}
+
+class Probe extends Component<{ Args: ProbeArgs }> {
+  get consumeThenBlur(): string {
+    const el = document.querySelector<HTMLLIElement>('[data-test-probe-item]');
+    const item = el ? this.args.manager.at(el) : undefined;
+
+    if (!el || !item) {
+      return 'no-item';
+    }
+
+    // Consume the tag, exactly as ListboxItem's `tabindex` getter does.
+    const wasActive = item.isActive;
+
+    el.dispatchEvent(
+      new FocusEvent('focusout', {
+        bubbles: true,
+        relatedTarget: this.args.relatedTarget
+      })
+    );
+
+    return String(wasActive);
+  }
+
+  <template>{{this.consumeThenBlur}}</template>
+}
+
+module('Integration | Utils | ListManager | render safety', function (hooks) {
+  setupRenderingTest(hooks);
+
+  const buildManager = () =>
+    new ListManager({
+      selectionMode: 'single',
+      autoActivateMode: 'none'
+    });
+
+  test('a redundant isActive write from focusout does not invalidate a consumed tag', async function (assert) {
+    const manager = buildManager();
+    const showProbe = cell(false);
+
+    // Focus moving to a real element is a genuine blur, so the listener runs
+    // and writes `isActive = false` — a value the item already holds. The write
+    // must not dirty the tag that the same frame just consumed.
+    const elsewhere = document.createElement('button');
+    document.body.appendChild(elsewhere);
+
+    try {
+      await render(
+        <template>
+          <ul>
+            <li
+              data-test-probe-item
+              {{manager.setupItem key="a" textValue="a"}}
+            >
+              a
+            </li>
+          </ul>
+
+          {{#if showProbe.current}}
+            <Probe @manager={{manager}} @relatedTarget={{elsewhere}} />
+          {{/if}}
+        </template>
+      );
+
+      const item = manager.atKey('a');
+      assert.false(item?.isActive, 'item starts inactive');
+
+      // Render the probe only now, so `setupItem` has installed the real
+      // focusout listener before the getter dispatches to it.
+      showProbe.current = true;
+      await settled();
+
+      assert.dom('[data-test-probe-item]').exists('item still rendered');
+      assert.false(item?.isActive, 'item remained inactive');
+    } finally {
+      elsewhere.remove();
+    }
+  });
+
+  test('a focusout with no relatedTarget does not deactivate the item', async function (assert) {
+    const manager = buildManager();
+    const showProbe = cell(false);
+
+    await render(
+      <template>
+        <ul>
+          <li data-test-probe-item {{manager.setupItem key="a" textValue="a"}}>
+            a
+          </li>
+        </ul>
+
+        {{#if showProbe.current}}
+          <Probe @manager={{manager}} @relatedTarget={{null}} />
+        {{/if}}
+      </template>
+    );
+
+    const item = manager.atKey('a');
+    manager.activateItem(item);
+    await settled();
+    assert.true(item?.isActive, 'item is active before the blur');
+
+    // A blur with no relatedTarget is what Glimmer's own DOM mutation produces.
+    // Deactivating there would be a genuine state change landing mid-render, so
+    // the listener must ignore it entirely.
+    showProbe.current = true;
+    await settled();
+
+    assert.dom('[data-test-probe-item]').exists('item still rendered');
+    assert.true(item?.isActive, 'item stayed active through a targetless blur');
+  });
+});


### PR DESCRIPTION
## Problem

An intermittent full-suite failure (~1 in 8 runs):

```
Assertion Failed: You attempted to update `isActive` on `ListItem`, but it had
already been used previously in the same computation.
```

The partial fix in b75c0859 deferred `unregister`'s activation and took the rate from ~1/2 to ~1/6, but did not eliminate it.

## Root cause

**Glimmer's own DOM mutations dispatch `focusout` synchronously, inside the autotracking frame that just consumed `isActive`.** Two distinct triggers reach the same listener in `setupItem`:

| Glimmer trigger | Consumer | Write |
| --- | --- | --- |
| `UpdateDynamicAttributeOpcode` reads `ListboxItem.tabindex` and applies the attribute in one frame | `this.tabindex` | redundant (`prev=false value=false`) |
| `clear()` / `ResettableBlockImpl.reset` removing the block's DOM | Listbox render | genuine change |

Applying the attribute (or removing the node) blurs the focused `<li>`; the browser fires `focusout` synchronously; the listener writes `item.isActive` inside the frame that just read it.

Both captured failures had `connected=true` — no teardown involved — which is why deferring `unregister` could not fix them.

## Fix

1. **`focusout` with no `relatedTarget` is ignored.** Glimmer's collateral blur sends focus nowhere (`document.activeElement` becomes `BODY` in both captures), whereas a user moving focus always names the destination. This covers the genuine-change path, which no equality guard could.
2. **Tracked fields are written only on a real change.** Ember's tracked setter is `dirtyTagFor(self, key), values.set(...)` — unconditional, with no value comparison — so re-writing an identical value still invalidates a consumed tag. `#clearActive` and `updateArgs` both do this routinely.

Each comparison reads a **plain untracked mirror**. Comparing against the tracked field would *consume* its tag, so the following write would dirty a tag the frame had just consumed — that mistake self-trips in `register` and broke 41 tests during development.

## Verification

- **10 consecutive clean full-suite runs** (804 tests each, 0 failures). At the measured ~1-in-8 rate, that is roughly a 1-in-4 outcome by luck alone, so the deterministic tests below carry most of the weight.
- **Two deterministic regression tests** that drive the real `setupItem` listener from inside a tracking frame, so they do not depend on full-suite timing. Negative controls confirm each is load-bearing: removing the `focusout` guard fails one with the exact production assertion, removing the equality guard fails the other.
- `glint` clean; `lint:js` and `lint:hbs` unchanged from the repo's pre-existing baseline.

## Note

b75c0859's `later()` in `unregister` is left in place. It targets a teardown path neither captured failure exercised, so it may now be redundant, but removing it warrants its own verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)