### PR TITLE
fix(theme): make @font-face URLs relative so bundlers fingerprint them

### DIFF
--- a/packages/theme/src/styles/font-faces.css
+++ b/packages/theme/src/styles/font-faces.css
@@ -1,4 +1,17 @@
 /**
+ * Font URLs below are relative to this file, which lets the consuming
+ * bundler resolve them: it fingerprints each font and rewrites the URL
+ * through the app's asset base.
+ *
+ * They used to be root-absolute (`/@frontile/theme/fonts/...`), matching the
+ * `ember-addon.public-assets` entries in package.json. Vite leaves a
+ * root-absolute url() untouched — no content hash, and no base prefix — so an
+ * app served from a CDN whose URL carries a path resolved the font against the
+ * CDN root and 404'd. The public-assets entries are kept for build pipelines
+ * that rely on them.
+ */
+
+/**
  * Domine (Variable Font)
  * Used for: marquee text styles (text-marquee-*)
  * Primary weight: 600 (SemiBold) - used by all marquee styles
@@ -10,7 +23,8 @@
 /* Variable Font - Normal */
 @font-face {
   font-family: 'Domine';
-  src: url('/@frontile/theme/fonts/domine-variable.woff2') format('woff2-variations');
+  src: url('../../public/fonts/domine-variable.woff2')
+    format('woff2-variations');
   font-weight: 400 700;
   font-style: normal;
   font-display: swap;
@@ -28,7 +42,8 @@
 /* Variable Font - Normal */
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@frontile/theme/fonts/open-sans-variable.woff2') format('woff2-variations');
+  src: url('../../public/fonts/open-sans-variable.woff2')
+    format('woff2-variations');
   font-weight: 300 800;
   font-style: normal;
   font-display: swap;
@@ -37,7 +52,8 @@
 /* Variable Font - Italic */
 @font-face {
   font-family: 'Open Sans';
-  src: url('/@frontile/theme/fonts/open-sans-italic-variable.woff2') format('woff2-variations');
+  src: url('../../public/fonts/open-sans-italic-variable.woff2')
+    format('woff2-variations');
   font-weight: 300 800;
   font-style: italic;
   font-display: swap;
@@ -54,7 +70,8 @@
 /* Variable Font - Normal */
 @font-face {
   font-family: 'Source Code Pro';
-  src: url('/@frontile/theme/fonts/source-code-pro-variable.woff2') format('woff2-variations');
+  src: url('../../public/fonts/source-code-pro-variable.woff2')
+    format('woff2-variations');
   font-weight: 200 900;
   font-style: normal;
   font-display: swap;
@@ -63,7 +80,8 @@
 /* Variable Font - Italic */
 @font-face {
   font-family: 'Source Code Pro';
-  src: url('/@frontile/theme/fonts/source-code-pro-italic-variable.woff2') format('woff2-variations');
+  src: url('../../public/fonts/source-code-pro-italic-variable.woff2')
+    format('woff2-variations');
   font-weight: 200 900;
   font-style: italic;
   font-display: swap;


### PR DESCRIPTION
## The problem

`@frontile/theme`'s `@font-face` rules point at the fonts with root-absolute URLs matching the `ember-addon.public-assets` entries:

```css
src: url('/@frontile/theme/fonts/open-sans-variable.woff2') format('woff2-variations');
```

Vite leaves a root-absolute `url()` untouched — it gets neither a content hash nor the app's `base` prefix, and the build warns:

```
/@frontile/theme/fonts/open-sans-variable.woff2 referenced in ... didn't resolve
at build time, it will remain unchanged to be resolved at runtime
```

At `rootURL` that happens to work, which is why this went unnoticed — including in this repo's own site, whose current build ships the fonts unhashed. An app deployed behind a CDN whose URL carries a path does notice: the browser resolves `/@frontile/theme/fonts/...` against the CDN **root**, skipping the path, and every font 404s.

## The fix

Make the URLs relative to `font-faces.css`. That hands the fonts to the consuming bundler as ordinary assets, so they are fingerprinted and their URLs are rewritten through `base`.

```diff
- src: url('/@frontile/theme/fonts/open-sans-variable.woff2') format('woff2-variations');
+ src: url('../../public/fonts/open-sans-variable.woff2') format('woff2-variations');
```

Five faces: Domine, Open Sans (normal + italic), Source Code Pro (normal + italic). `files` already publishes `public`, so the relative target exists in the tarball.

Content hashes are a second win independent of the CDN bug — the fonts can now be cached immutably.

## `public-assets` is deliberately left alone

The `ember-addon.public-assets` entries in `package.json` are unchanged, so build pipelines that rely on them keep working and keep receiving the unhashed copies at `/@frontile/theme/fonts/`. Nothing in the CSS references those copies anymore, but removing them would be a separate, breaking-ish decision.

## Verified

Built this repo's site, which consumes the theme through `@import "@frontile/theme"` exactly as a consuming app does:

| | before | after |
|---|---|---|
| default base | `url(/@frontile/theme/fonts/open-sans-variable.woff2)` | `url(/assets/open-sans-variable-B73aTk82.woff2)` |
| `--base=https://cdn.example.test/prefix/` | unchanged — the bug | `url(https://cdn.example.test/prefix/assets/open-sans-variable-B73aTk82.woff2)` |
| dev server | served | `200`, `font/woff2`, 279760 bytes |

All five faces are emitted to `dist/assets/` with hashes, the "didn't resolve at build time" warnings are gone, and `dist/@frontile/theme/fonts/` still receives its copies from `public-assets`.

One thing worth checking before merge: whether Tailwind's `@import` rebasing, which is what makes the relative path resolve from a consumer's `app.css`, holds for every supported consumer setup. I confirmed it for Tailwind 4 + Vite (both this site and a standalone fixture reproducing the package layout), and since `@import "@frontile/theme"` is a bare specifier there is always a bundler in the pipeline — but a second pair of eyes on any non-Vite consumer would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)