### PR TITLE
fix(forms): clear the input element when the value is owned elsewhere

### DIFF
--- a/packages/frontile/src/components/forms/input.gts
+++ b/packages/frontile/src/components/forms/input.gts
@@ -73,6 +73,14 @@ function or(arg1: unknown, arg2: unknown): boolean {
 class Input extends Component<InputSignature> {
   @tracked uncontrolledValue: string = this.args.value || '';
 
+  /**
+   * What the element itself currently holds. A controlled parent does not
+   * always feed the value back through `@value` — `<Form>`, for one, reads it
+   * off the DOM instead — so the argument alone cannot tell us whether there
+   * is anything to clear.
+   */
+  @tracked elementValue: string = this.args.value || '';
+
   inputRef = ref<HTMLInputElement>();
 
   get isControlled() {
@@ -86,6 +94,20 @@ class Input extends Component<InputSignature> {
     return this.isControlled ? this.args.value : this.uncontrolledValue;
   }
 
+  /**
+   * The value in the field regardless of who owns it: the argument when the
+   * parent feeds one back, the element's own value otherwise.
+   */
+  get currentValue(): string | undefined {
+    if (!this.isControlled) {
+      return this.uncontrolledValue;
+    }
+
+    return typeof this.args.value === 'undefined'
+      ? this.elementValue
+      : this.args.value;
+  }
+
   get type(): string {
     if (typeof this.args.type === 'string') {
       return this.args.type;
@@ -95,6 +117,7 @@ class Input extends Component<InputSignature> {
 
   @action handleOnInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
+    this.elementValue = value;
 
     if (this.isControlled) {
       this.args.onInput?.(value, event as InputEvent);
@@ -105,6 +128,7 @@ class Input extends Component<InputSignature> {
 
   @action handleOnChange(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
+    this.elementValue = value;
 
     if (this.isControlled) {
       this.args.onChange?.(value, event as InputEvent);
@@ -118,6 +142,14 @@ class Input extends Component<InputSignature> {
   }
 
   @action clearValue(): void {
+    // Clear the element first: a parent that owns the value may derive it from
+    // the DOM (as `<Form>` does via FormData), in which case notifying it
+    // before the element is empty would just hand back the stale value.
+    if (this.inputRef.current) {
+      this.inputRef.current.value = '';
+    }
+    this.elementValue = '';
+
     if (this.isControlled) {
       this.args.onChange?.('');
       this.args.onInput?.('');
@@ -132,8 +164,8 @@ class Input extends Component<InputSignature> {
   get isClearable(): boolean {
     if (
       this.args.isClearable === true &&
-      this.value !== '' &&
-      typeof this.value !== 'undefined'
+      this.currentValue !== '' &&
+      typeof this.currentValue !== 'undefined'
     ) {
       return true;
     }

--- a/test-app/tests/integration/components/forms/input-test.gts
+++ b/test-app/tests/integration/components/forms/input-test.gts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, find, settled, click } from '@ember/test-helpers';
 
-import { Input } from 'frontile';
+import { Form, Input } from 'frontile';
 import { cell } from 'ember-resources';
 
 module('Integration | Component | @frontile/forms/Input', function (hooks) {
@@ -243,6 +243,58 @@ module('Integration | Component | @frontile/forms/Input', function (hooks) {
 
     await click('[data-test-id="input-clear-button"]');
     assert.equal(value.current, '');
+  });
+
+  test('clear button clears the element when the value is owned elsewhere', async function (assert) {
+    // A parent that observes changes without feeding a new @value back in —
+    // what `<Form>` does, since it reads the values off the DOM.
+    const observed: string[] = [];
+    const onChange = (val: string) => {
+      observed.push(val);
+    };
+
+    await render(
+      <template>
+        <Input data-test-input @onChange={{onChange}} @isClearable={{true}} />
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="input-clear-button"]')
+      .doesNotExist('nothing to clear yet');
+
+    await fillIn('[data-test-input]', 'Josemar');
+    assert
+      .dom('[data-test-id="input-clear-button"]')
+      .exists('the field has a value, so it can be cleared');
+
+    await click('[data-test-id="input-clear-button"]');
+
+    assert.dom('[data-test-input]').hasValue('');
+    assert.deepEqual(observed, ['Josemar', ''], 'onChange is still notified');
+    assert
+      .dom('[data-test-id="input-clear-button"]')
+      .doesNotExist('the button goes away once the field is empty');
+  });
+
+  test('clear button clears a Form-owned field', async function (assert) {
+    const onSubmit = () => {};
+
+    await render(
+      <template>
+        <Form @onSubmit={{onSubmit}} as |form|>
+          <form.Field @name="email" as |field|>
+            <field.Input @isClearable={{true}} data-test-input />
+          </form.Field>
+        </Form>
+      </template>
+    );
+
+    await fillIn('[data-test-input]', 'josemar@example.com');
+    assert.dom('[data-test-input]').hasValue('josemar@example.com');
+
+    await click('[data-test-id="input-clear-button"]');
+    assert.dom('[data-test-input]').hasValue('');
   });
 
   test('uncontrolled input behavior', async function (assert) {


### PR DESCRIPTION
Fixes #433.

`<Input @isClearable>` didn't work when the value lives outside the component — most visibly inside `<Form>`, which reads its values off the DOM via `FormData` while `<Field>` binds an `onChange` that only runs validation.

Two defects, both fixed here:

1. **`clearValue` never cleared the element.** It notified `onChange`/`onInput` and dispatched an input event, so `<Form>` re-read the untouched input and handed back the stale value. It now clears the element before notifying.
2. **The clear button never appeared.** `isClearable` keyed off `@value`, which is `undefined` for a Form-owned field no matter what the user types. `<Input>` now also tracks what the element itself holds (`elementValue`) and derives `currentValue` from whichever source actually owns the value.

Controlled usage is unchanged: when a parent does feed `@value` back, the argument still wins.

## Tests

Two regression tests in `test-app/tests/integration/components/forms/input-test.gts`:

- a parent that observes changes without feeding `@value` back
- a real `<Form>` + `<form.Field>` field

Both fail on `main` (the first never renders the button; the second leaves the typed text in place) and pass here.

Full test-app suite: 806 tests, 803 pass, 3 skip, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)