### PR TITLE
Add frontile-docs skill for writing component documentation

### DIFF
--- a/.claude/skills/frontile-docs/SKILL.md
+++ b/.claude/skills/frontile-docs/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: frontile-docs
+description: Write, review, and audit Frontile component documentation — the co-located `.md` files next to each `.gts` under `packages/frontile/src/components/`. Use this whenever the user is documenting a new component, editing any component `.md`, adding or changing usage demos, or asking whether the docs are accurate, complete, or consistent. Also use it whenever a change touches a component's public arguments, yielded blocks, or styling, because the docs and the JSDoc that generates the API table have to move with the code — reach for it even when the user only asked for the code change and didn't mention docs at all.
+---
+
+# Frontile component documentation
+
+Frontile's docs are not a description of the library sitting beside it — they *are* the
+library's demo surface. Docfy renders every ` ```gts preview ` fence on frontile.dev as a
+live, running component. A wrong class name is a broken demo, not a typo. An argument you
+invent is a runtime error on a public page. That's the reason this skill leans so hard on
+reading source before writing prose: in this repo, documentation is executable.
+
+## The one thing that surprises people
+
+**You do not hand-write the API table.** `## API` contains a single tag:
+
+```md
+<Signature @component="Button" />
+```
+
+That renders from `site/app/components/signature-data.ts`, which
+`site/lib/generate-signature-data.js` generates by running `glimmer-docgen-typescript`
+over `packages/*/declarations/`. So the description, type, and default of every argument
+come from **JSDoc on the `Args` interface in the `.gts` file**. An argument with no JSDoc
+renders as a blank row on the site.
+
+This means documenting an argument is usually a change to the `.gts`, not the `.md`:
+
+```ts
+export interface ButtonArgs {
+  /**
+   * The button appearance
+   *
+   * @defaultValue 'default'
+   */
+  appearance?: 'default' | 'soft' | 'outlined' | 'minimal' | 'tonal' | 'custom';
+}
+```
+
+Use `@defaultValue` for anything with a default — it becomes its own column. Describe what
+the argument *is for*, not what its type already says ("The button appearance", not "A
+string that can be default, soft, outlined…"). After changing JSDoc, regenerate:
+
+```bash
+pnpm --filter frontile build && pnpm --filter site generate-signature-data
+```
+
+Never restate the full argument list as a prose table in the `.md` — it will drift from the
+generated one, and readers get two conflicting sources. Prose earns its place by covering
+what the type signature *can't* say: when to reach for one appearance over another, which
+arguments interact, what happens on mobile.
+
+## Workflow
+
+### 1. Ground yourself in the source before writing a word
+
+Docs that describe an API the model half-remembers are the main failure mode here, and they
+are expensive because a wrong demo ships to a public site. Read, for the component you're
+documenting:
+
+- **`<name>.gts`** — the `Args` interface (every argument, which are required, which have
+  `@defaultValue`), the `Blocks` type (what it yields, and with what), the `Element` type,
+  and any yielded sub-components (`<Form.Input>`, `<Dropdown.Menu>`) it exposes.
+- **The theme file** in `packages/theme/src/components/` — the real variant names. If the
+  theme has no `size="xl"`, the docs must not either.
+- **`test-app/tests/integration/components/`** — the tests encode the behaviors worth
+  documenting, especially keyboard and ARIA behavior for the Accessibility section.
+- **A sibling `.md` in the same category** — for house voice and section rhythm.
+
+If the source and an existing doc disagree, the source wins and the doc is a bug. Say so
+rather than quietly documenting the old behavior.
+
+### 2. Follow the canonical structure
+
+Full template, frontmatter schema, and the approved heading vocabulary are in
+**`references/structure.md`** — read it before creating a new doc or reordering an existing
+one. The shape in brief:
+
+```
+frontmatter (imports: Signature)
+# ComponentName            ← one-sentence purpose, no marketing adjectives
+## Import
+## Usage                   ← the simplest thing that works, no options
+## <Feature sections>      ← one per axis: appearances, intents, sizes, states…
+## Accessibility           ← required; see step 4
+## API                     ← <Signature @component="X" />
+```
+
+### 3. Write demos that actually run
+
+Every demo is real code executing on the site. The rules that keep them running are in
+**`references/demos.md`** — read it before writing your first fence. The traps that bite
+most often:
+
+- Fence ` ```gts preview `. Plain ` ```gts ` renders as a dead code block; ` ```gjs preview `
+  is the legacy form and should be converted when you touch a file.
+- Every demo is standalone: it must import everything it uses, including `frontile` itself.
+- `eq` does not exist. Import `hash`, `array`, `fn`, `get`, `concat` from `@ember/helper`
+  and `on` from `@ember/modifier`.
+- Only semantic color utilities — `bg-primary`, `text-neutral-strong`, `text-on-primary-firm`.
+  There is no numbered scale; `bg-primary-500` silently renders unstyled.
+- Icons come from `site/components/icons`. Never paste an inline `<svg>` into a doc.
+
+### Demos should be made of Frontile
+
+A demo is an implicit recommendation. When a doc hand-rolls a `<button class='bg-primary
+…'>` while the library ships a `<Button>`, it teaches the reader to rebuild the component —
+and that markup then has to be maintained as the theme evolves. So if Frontile has a
+component for the thing being shown, the demo uses it, and it's styled with our generated
+utilities rather than raw Tailwind palette classes.
+
+The honest exception is documentation whose subject *is* the token. In
+`docs/theming/design-tokens/`, a bare `<div class='bg-surface-card'>` is the better demo:
+putting a `<Button>` around it would obscure the one thing the reader came to see. Roughly
+35 of the 36 component-free demos in the theming docs are legitimate for exactly this
+reason. Raw palette classes (`bg-blue-500`, `bg-gray-300`) are likewise fine — but only as
+explicitly labeled ✗ counter-examples, never as the recommended path.
+
+So the test isn't "does this demo import `frontile`", it's **"would a reader copying this
+end up reimplementing something we already give them?"** If yes, use the component.
+
+### 4. Treat Accessibility as load-bearing
+
+This is the section a type signature can never generate, and it's the largest gap in the
+existing docs. A component library is chosen partly on whether someone can trust its
+keyboard and screen-reader behavior without reading the implementation — so document what
+you verified, not what you assume. Cover, where each applies:
+
+- **Keyboard** — every key that does something, as a two-column table. Read the tests; if a
+  key isn't tested, either try it or don't claim it.
+- **ARIA and roles** — the roles the component sets, and any `aria-*` the consumer is
+  responsible for supplying (a `@label` on an icon-only control, for instance).
+- **Focus management** — where focus moves on open, where it returns on close, what is
+  trapped. Link `docs/accessibility/focus-management.md` rather than restating it.
+- **Screen reader notes** — announcements, live regions, anything visually implied that
+  needs a text equivalent.
+
+For a genuinely presentational component (Divider, Spinner, Skeleton) the honest section is
+short — say what role it takes and what the consumer must label. Don't pad it.
+
+### 5. Verify before you claim it's done
+
+```bash
+node .claude/skills/frontile-docs/scripts/lint-docs.mjs      # all component docs
+node .claude/skills/frontile-docs/scripts/lint-docs.mjs packages/frontile/src/components/forms/input.md
+```
+
+The linter handles the mechanical half — required sections, fence languages, `<Signature>`
+wiring, arguments used in demos that don't exist in the signature, arguments missing the
+JSDoc that populates the API table. It exits non-zero on errors, so it can run in CI. Fix
+what it reports, then re-run rather than assuming.
+
+Then confirm the demos actually render, since the linter can't execute them:
+
+```bash
+cd site && pnpm build
+```
+
+Report honestly: if `pnpm build` didn't run, say the demos are unverified.
+
+## Reviewing and auditing existing docs
+
+You have editorial authority here — cut verbose prose, merge redundant examples, and shorten
+bloated files. Length is itself a defect: `form.md` is 1,903 lines, and nobody reads to the
+end of it. What earns its place is a runnable example or a fact the reader can't get from
+the API table. What doesn't: restated types, marketing adjectives ("powerful", "flexible",
+"modern"), and three examples demonstrating one idea.
+
+Two things to be careful with, because they look like fat and aren't:
+
+- **A demo that looks redundant may cover a distinct state.** Check what's different before
+  merging — controlled vs. uncontrolled, single vs. multiple selection.
+- **Prose explaining a footgun.** The `class` vs. `@class` note in `button.md` is exactly the
+  kind of thing that belongs in prose and would be lost in a cut.
+
+When you delete a substantial example or section, say what you removed and why in your
+summary, so the user can push back on a specific call rather than re-reading the diff.
+
+For a multi-file audit, run the linter across everything first and work from its output —
+it's cheaper and more consistent than reading 31 files, and it won't miss the boring
+mechanical failures while chasing the interesting editorial ones.
+
+## Repo facts worth not re-deriving
+
+- Component source and docs live **only** in `packages/frontile/src/components/<category>/`.
+  The `buttons/`, `forms/`, `collections/`, etc. packages are deprecation wrappers — never
+  add docs there.
+- Everything imports from the single `frontile` package: `import { Button } from 'frontile';`
+- Docfy sources the repo-root `docs/` directory too (theming, migrations, accessibility).
+  Component API changes with migration impact belong in `docs/migrations/` as well.
+- Notifications are the exception to co-location: `NotificationCard` and
+  `NotificationsContainer` are documented together in
+  `packages/frontile/docs/notifications-usage.md`, because they're only ever used as a pair.
+  The linter reports them as missing docs — that's expected, not a gap.
+- New components get `label: New` in frontmatter, which renders a sidebar badge. Remove it
+  once the component has shipped for a release or two.

--- a/.claude/skills/frontile-docs/SKILL.md
+++ b/.claude/skills/frontile-docs/SKILL.md
@@ -40,11 +40,33 @@ export interface ButtonArgs {
 
 Use `@defaultValue` for anything with a default — it becomes its own column. Describe what
 the argument *is for*, not what its type already says ("The button appearance", not "A
-string that can be default, soft, outlined…"). After changing JSDoc, regenerate:
+string that can be default, soft, outlined…"). Verify a default against the theme's
+`defaultVariants` rather than assuming one exists; several components genuinely have none.
+
+After changing JSDoc, regenerate:
 
 ```bash
-pnpm --filter frontile build && pnpm --filter site generate-signature-data
+pnpm build && pnpm --filter site generate-signature-data
 ```
+
+**Build everything first, not just the package you touched.** The generator reads
+`packages/*/declarations/`, and it doesn't fail when those are missing — it writes a file
+covering only what it found, silently dropping thousands of lines of other packages'
+signatures and blanking their API tables. If you regenerate before a full build, recover
+with `git checkout -- site/app/components/signature-data.ts`, build, and regenerate again.
+Check `git diff --stat` on that file afterwards: a diff far larger than your change means
+this happened.
+
+Two related traps worth knowing before you go looking for them:
+
+- **A component with no `.md` is never checked.** The linter only inspects a `.gts` when a
+  sibling doc exists, so components without a page accumulate undocumented arguments
+  invisibly. When you create a page for one, audit its whole `Args` interface for JSDoc
+  first — otherwise you ship a beautiful page whose API table is a column of blank cells.
+- **Utilities hardcoded in a component's `.gts` are never generated.** The site's Tailwind
+  scans `site/` and `packages/theme/src` only. A class written directly into a component
+  template under `packages/frontile` produces no CSS on the docs site. Style through the
+  theme's variants instead.
 
 Never restate the full argument list as a prose table in the `.md` — it will drift from the
 generated one, and readers get two conflicting sources. Prose earns its place by covering
@@ -161,23 +183,63 @@ cd site && pnpm build
 
 Report honestly: if `pnpm build` didn't run, say the demos are unverified.
 
+### Keep the change the size of the request
+
+Reading the source to document a component surfaces adjacent problems — a wrong class in a
+neighbouring doc, a theme variant that looks broken, a missing test. Documenting one
+component is not licence to fix them. Report what you found and leave it, unless your change
+is actually wrong without it; a docs edit that also rewrites the theme package is hard to
+review and hard to revert, and it buries the part the user asked for. When you do have to
+reach outside the doc and its component, say so explicitly and say why it was necessary.
+
 ## Reviewing and auditing existing docs
 
-You have editorial authority here — cut verbose prose, merge redundant examples, and shorten
-bloated files. Length is itself a defect: `form.md` is 1,903 lines, and nobody reads to the
-end of it. What earns its place is a runnable example or a fact the reader can't get from
-the API table. What doesn't: restated types, marketing adjectives ("powerful", "flexible",
-"modern"), and three examples demonstrating one idea.
+You have editorial authority over prose. Length is a real defect — `form.md` is 1,903 lines
+and nobody reads to the end — and most of that weight is text: restated types, marketing
+adjectives ("powerful", "flexible", "modern"), orphaned notes, and paragraphs explaining
+what the demo below already shows. Cut all of it freely.
 
-Two things to be careful with, because they look like fat and aren't:
+**Demos are not prose, and the same authority does not extend to them.** Prose can be
+rewritten from the source at any time; a working demo is executable proof that a particular
+combination of arguments does what the docs claim, it is the thing readers copy, and it is
+the only part of the page the site actually runs. Replacing a demo with a sentence
+describing it converts checked behavior into an unchecked assertion. That trade is almost
+never worth it, and it is invisible in review — the page gets shorter and reads better,
+while coverage quietly drops.
 
-- **A demo that looks redundant may cover a distinct state.** Check what's different before
-  merging — controlled vs. uncontrolled, single vs. multiple selection.
-- **Prose explaining a footgun.** The `class` vs. `@class` note in `button.md` is exactly the
-  kind of thing that belongs in prose and would be lost in a cut.
+So the two edits pull in opposite directions, and the reduction you're after comes from
+prose. Before removing any demo, do this explicitly:
 
-When you delete a substantial example or section, say what you removed and why in your
-summary, so the user can push back on a specific call rather than re-reading the diff.
+1. Name the state it exercises — which arguments, which mode, which interaction.
+2. Find a demo you are **keeping** that exercises that same state.
+3. If you can't name one, the demo stays.
+
+"Both demos are about `@isOpen`" is not step 2. Two demos sharing an argument can still
+exercise different states — controlled vs. uncontrolled, single vs. multiple selection, one
+panel vs. several, nested vs. flat, initially-open vs. opening on interaction. Readers also
+navigate by scenario rather than by argument: someone looking for an accordion doesn't
+recognize their problem in a demo titled "Basic".
+
+When two demos genuinely do exercise the same state, **consolidate rather than delete** —
+fold them into one demo with several instances, or an `{{#each}}` over the varying values.
+That keeps the coverage and still removes the duplication.
+
+The one thing prose should keep is a footgun: the `class` vs. `@class` note in `button.md`
+is exactly the kind of fact a reader can't derive from a demo, and it would be lost in an
+undifferentiated cut.
+
+Then report what you did, because a shorter file is not self-evidently a better one:
+
+- demo count before → after
+- for each demo removed, the retained demo that covers its state
+- what prose you cut, in one line
+
+If that list is uncomfortable to write, that's the signal — you removed coverage, not fat.
+The linter checks this mechanically, and it is worth running on any file you shortened:
+
+```bash
+node .claude/skills/frontile-docs/scripts/lint-docs.mjs --since HEAD <file>
+```
 
 For a multi-file audit, run the linter across everything first and work from its output —
 it's cheaper and more consistent than reading 31 files, and it won't miss the boring

--- a/.claude/skills/frontile-docs/SKILL.md
+++ b/.claude/skills/frontile-docs/SKILL.md
@@ -147,8 +147,10 @@ node .claude/skills/frontile-docs/scripts/lint-docs.mjs packages/frontile/src/co
 ```
 
 The linter handles the mechanical half — required sections, fence languages, `<Signature>`
-wiring, arguments used in demos that don't exist in the signature, arguments missing the
-JSDoc that populates the API table. It exits non-zero on errors, so it can run in CI. Fix
+wiring (including a tag naming a component that isn't in the generated data, which renders
+as an empty API entry and is otherwise only a line in the build log), arguments used in
+demos that don't exist in the signature, arguments missing the JSDoc that populates the
+API table. It exits non-zero on errors, so it can run in CI. Fix
 what it reports, then re-run rather than assuming.
 
 Then confirm the demos actually render, since the linter can't execute them:

--- a/.claude/skills/frontile-docs/SKILL.md
+++ b/.claude/skills/frontile-docs/SKILL.md
@@ -5,27 +5,30 @@ description: Write, review, and audit Frontile component documentation — the c
 
 # Frontile component documentation
 
-Frontile's docs are not a description of the library sitting beside it — they *are* the
-library's demo surface. Docfy renders every ` ```gts preview ` fence on frontile.dev as a
-live, running component. A wrong class name is a broken demo, not a typo. An argument you
-invent is a runtime error on a public page. That's the reason this skill leans so hard on
-reading source before writing prose: in this repo, documentation is executable.
+This skill is deliberately not a writing guide. It carries the mechanics of this repo's docs
+pipeline that you cannot infer from reading the code, and the two places where sensible
+instincts produce a wrong result here. Everything else — voice, structure, what makes a good
+example — you can read off the sibling `.md` files, and they're a better teacher than prose.
 
-## The one thing that surprises people
+Frontile's docs are the library's demo surface. Docfy renders every ` ```gts preview ` fence
+on frontile.dev as a live, running component, so a wrong class name is a broken page and an
+invented argument is a runtime error in public. Read the component's `.gts`, its theme file,
+and its tests before writing about it.
 
-**You do not hand-write the API table.** `## API` contains a single tag:
+## The API table is generated, not written
+
+`## API` contains one tag:
 
 ```md
 <Signature @component="Button" />
 ```
 
-That renders from `site/app/components/signature-data.ts`, which
-`site/lib/generate-signature-data.js` generates by running `glimmer-docgen-typescript`
-over `packages/*/declarations/`. So the description, type, and default of every argument
-come from **JSDoc on the `Args` interface in the `.gts` file**. An argument with no JSDoc
-renders as a blank row on the site.
-
-This means documenting an argument is usually a change to the `.gts`, not the `.md`:
+It renders from `site/app/components/signature-data.ts`, which
+`site/lib/generate-signature-data.js` builds with `glimmer-docgen-typescript` from
+`packages/*/declarations/`. Every argument's description and default comes from **JSDoc on
+the `Args` interface in the `.gts`**. So documenting an argument is usually an edit to the
+component file, and never a hand-written markdown table — a table drifts from the generated
+one and gives readers two conflicting sources.
 
 ```ts
 export interface ButtonArgs {
@@ -38,177 +41,95 @@ export interface ButtonArgs {
 }
 ```
 
-Use `@defaultValue` for anything with a default — it becomes its own column. Describe what
-the argument *is for*, not what its type already says ("The button appearance", not "A
-string that can be default, soft, outlined…"). Verify a default against the theme's
-`defaultVariants` rather than assuming one exists; several components genuinely have none.
+An argument with no JSDoc still appears in the table, as a row with a blank description.
+Comments written `/*` or `//` are silently ignored — only `/**` is collected. Check
+`@defaultValue` against the theme's `defaultVariants` instead of assuming one exists.
 
-After changing JSDoc, regenerate:
+After changing JSDoc:
 
 ```bash
 pnpm build && pnpm --filter site generate-signature-data
 ```
 
-**Build everything first, not just the package you touched.** The generator reads
-`packages/*/declarations/`, and it doesn't fail when those are missing — it writes a file
-covering only what it found, silently dropping thousands of lines of other packages'
-signatures and blanking their API tables. If you regenerate before a full build, recover
-with `git checkout -- site/app/components/signature-data.ts`, build, and regenerate again.
-Check `git diff --stat` on that file afterwards: a diff far larger than your change means
-this happened.
+**Build everything, not just the package you touched.** The generator doesn't fail on
+missing declarations — it writes a file covering only what it found, silently dropping other
+packages' signatures and blanking their API tables. If you regenerate before a full build,
+`git checkout -- site/app/components/signature-data.ts`, build, regenerate. Then check
+`git diff --stat` on that file: a diff much larger than your change, or one with mass
+deletions, means this happened.
 
-Two related traps worth knowing before you go looking for them:
+Two blind spots that follow from this:
 
-- **A component with no `.md` is never checked.** The linter only inspects a `.gts` when a
-  sibling doc exists, so components without a page accumulate undocumented arguments
-  invisibly. When you create a page for one, audit its whole `Args` interface for JSDoc
-  first — otherwise you ship a beautiful page whose API table is a column of blank cells.
-- **Utilities hardcoded in a component's `.gts` are never generated.** The site's Tailwind
-  scans `site/` and `packages/theme/src` only. A class written directly into a component
-  template under `packages/frontile` produces no CSS on the docs site. Style through the
-  theme's variants instead.
+- **A component with no `.md` is never linted**, so it quietly accumulates undocumented
+  arguments. Before writing a page for one, audit its whole `Args` interface — otherwise you
+  ship a polished page whose API table is a column of blank cells. Check inherited
+  interfaces too: `FormControlSharedArgs` feeds Input, Select, Checkbox, Switch and more, so
+  documenting it fixes many tables at once.
+- **Utilities hardcoded in a component's `.gts` produce no CSS on the docs site.** Tailwind
+  scans `site/` and `packages/theme/src` only. Style through the theme's variants.
 
-Never restate the full argument list as a prose table in the `.md` — it will drift from the
-generated one, and readers get two conflicting sources. Prose earns its place by covering
-what the type signature *can't* say: when to reach for one appearance over another, which
-arguments interact, what happens on mobile.
-
-## Workflow
-
-### 1. Ground yourself in the source before writing a word
-
-Docs that describe an API the model half-remembers are the main failure mode here, and they
-are expensive because a wrong demo ships to a public site. Read, for the component you're
-documenting:
-
-- **`<name>.gts`** — the `Args` interface (every argument, which are required, which have
-  `@defaultValue`), the `Blocks` type (what it yields, and with what), the `Element` type,
-  and any yielded sub-components (`<Form.Input>`, `<Dropdown.Menu>`) it exposes.
-- **The theme file** in `packages/theme/src/components/` — the real variant names. If the
-  theme has no `size="xl"`, the docs must not either.
-- **`test-app/tests/integration/components/`** — the tests encode the behaviors worth
-  documenting, especially keyboard and ARIA behavior for the Accessibility section.
-- **A sibling `.md` in the same category** — for house voice and section rhythm.
-
-If the source and an existing doc disagree, the source wins and the doc is a bug. Say so
-rather than quietly documenting the old behavior.
-
-### 2. Follow the canonical structure
-
-Full template, frontmatter schema, and the approved heading vocabulary are in
-**`references/structure.md`** — read it before creating a new doc or reordering an existing
-one. The shape in brief:
+## Structure
 
 ```
 frontmatter (imports: Signature)
-# ComponentName            ← one-sentence purpose, no marketing adjectives
+# ComponentName            ← one sentence on what it's for
 ## Import
-## Usage                   ← the simplest thing that works, no options
+## Usage                   ← the simplest thing that works
 ## <Feature sections>      ← one per axis: appearances, intents, sizes, states…
-## Accessibility           ← required; see step 4
+## Accessibility           ← required
 ## API                     ← <Signature @component="X" />
 ```
 
-### 3. Write demos that actually run
+Full template, frontmatter schema (`imports` / `label` / `url`), approved heading vocabulary,
+and the anatomy pattern for yielding components: **`references/structure.md`**.
 
-Every demo is real code executing on the site. The rules that keep them running are in
-**`references/demos.md`** — read it before writing your first fence. The traps that bite
-most often:
+`## Accessibility` is required because it's the one section a type signature can't generate:
+keyboard table, roles and ARIA the consumer must supply, focus management, screen-reader
+notes. Read the component's tests and document what you verified — if there's no test file,
+say your claims came from source.
 
-- Fence ` ```gts preview `. Plain ` ```gts ` renders as a dead code block; ` ```gjs preview `
-  is the legacy form and should be converted when you touch a file.
-- Every demo is standalone: it must import everything it uses, including `frontile` itself.
-- `eq` does not exist. Import `hash`, `array`, `fn`, `get`, `concat` from `@ember/helper`
-  and `on` from `@ember/modifier`.
-- Only semantic color utilities — `bg-primary`, `text-neutral-strong`, `text-on-primary-firm`.
-  There is no numbered scale; `bg-primary-500` silently renders unstyled.
-- Icons come from `site/components/icons`. Never paste an inline `<svg>` into a doc.
+## Demos
+
+Mechanics, fence rules, and the helper/icon conventions are in **`references/demos.md`**.
+The four that bite most often:
+
+- Fence ` ```gts preview `. Plain ` ```gts ` renders dead; ` ```gjs preview ` is legacy.
+- Every demo is a standalone module — import everything, including `frontile` itself.
+- `eq` doesn't exist. Import `hash`, `array`, `fn`, `get`, `concat` from `@ember/helper`.
+- **No numbered color scale.** `bg-primary-500` isn't a class and fails silently as unstyled
+  output. Use named levels: `subtle`, `muted`, `soft`, `mild`, DEFAULT, `firm`, `strong`,
+  `bolder`, and `text-on-{category}-{level}` on filled backgrounds.
+- Icons come from `site/components/icons`; never inline an `<svg>`.
 
 ### Demos should be made of Frontile
 
-A demo is an implicit recommendation. When a doc hand-rolls a `<button class='bg-primary
-…'>` while the library ships a `<Button>`, it teaches the reader to rebuild the component —
-and that markup then has to be maintained as the theme evolves. So if Frontile has a
-component for the thing being shown, the demo uses it, and it's styled with our generated
-utilities rather than raw Tailwind palette classes.
+A demo is an implicit recommendation. Hand-rolling a `<button class='bg-primary …'>` when the
+library ships `<Button>` teaches the reader to rebuild the component, and that markup then
+has to be maintained as the theme changes.
 
 The honest exception is documentation whose subject *is* the token. In
-`docs/theming/design-tokens/`, a bare `<div class='bg-surface-card'>` is the better demo:
-putting a `<Button>` around it would obscure the one thing the reader came to see. Roughly
-35 of the 36 component-free demos in the theming docs are legitimate for exactly this
-reason. Raw palette classes (`bg-blue-500`, `bg-gray-300`) are likewise fine — but only as
-explicitly labeled ✗ counter-examples, never as the recommended path.
+`docs/theming/design-tokens/`, a bare `<div class='bg-surface-card'>` is the better demo —
+a component around it would hide the thing the reader came to see. Roughly 35 of the 36
+component-free demos in the theming docs are legitimate for that reason. Raw palette classes
+(`bg-blue-500`) are fine too, but only as labeled ✗ counter-examples.
 
-So the test isn't "does this demo import `frontile`", it's **"would a reader copying this
-end up reimplementing something we already give them?"** If yes, use the component.
+So the test isn't "does this import `frontile`", it's **"would a reader copying this end up
+reimplementing something we already give them?"**
 
-### 4. Treat Accessibility as load-bearing
+## Shortening a doc
 
-This is the section a type signature can never generate, and it's the largest gap in the
-existing docs. A component library is chosen partly on whether someone can trust its
-keyboard and screen-reader behavior without reading the implementation — so document what
-you verified, not what you assume. Cover, where each applies:
-
-- **Keyboard** — every key that does something, as a two-column table. Read the tests; if a
-  key isn't tested, either try it or don't claim it.
-- **ARIA and roles** — the roles the component sets, and any `aria-*` the consumer is
-  responsible for supplying (a `@label` on an icon-only control, for instance).
-- **Focus management** — where focus moves on open, where it returns on close, what is
-  trapped. Link `docs/accessibility/focus-management.md` rather than restating it.
-- **Screen reader notes** — announcements, live regions, anything visually implied that
-  needs a text equivalent.
-
-For a genuinely presentational component (Divider, Spinner, Skeleton) the honest section is
-short — say what role it takes and what the consumer must label. Don't pad it.
-
-### 5. Verify before you claim it's done
-
-```bash
-node .claude/skills/frontile-docs/scripts/lint-docs.mjs      # all component docs
-node .claude/skills/frontile-docs/scripts/lint-docs.mjs packages/frontile/src/components/forms/input.md
-```
-
-The linter handles the mechanical half — required sections, fence languages, `<Signature>`
-wiring (including a tag naming a component that isn't in the generated data, which renders
-as an empty API entry and is otherwise only a line in the build log), arguments used in
-demos that don't exist in the signature, arguments missing the JSDoc that populates the
-API table. It exits non-zero on errors, so it can run in CI. Fix
-what it reports, then re-run rather than assuming.
-
-Then confirm the demos actually render, since the linter can't execute them:
-
-```bash
-cd site && pnpm build
-```
-
-Report honestly: if `pnpm build` didn't run, say the demos are unverified.
-
-### Keep the change the size of the request
-
-Reading the source to document a component surfaces adjacent problems — a wrong class in a
-neighbouring doc, a theme variant that looks broken, a missing test. Documenting one
-component is not licence to fix them. Report what you found and leave it, unless your change
-is actually wrong without it; a docs edit that also rewrites the theme package is hard to
-review and hard to revert, and it buries the part the user asked for. When you do have to
-reach outside the doc and its component, say so explicitly and say why it was necessary.
-
-## Reviewing and auditing existing docs
-
-You have editorial authority over prose. Length is a real defect — `form.md` is 1,903 lines
-and nobody reads to the end — and most of that weight is text: restated types, marketing
-adjectives ("powerful", "flexible", "modern"), orphaned notes, and paragraphs explaining
-what the demo below already shows. Cut all of it freely.
+You have editorial authority over prose. Length is a real defect — `form.md` was 1,903 lines
+— and most of that weight is text: restated types, marketing adjectives, orphaned notes, and
+paragraphs explaining what the demo below already shows. Cut all of it freely.
 
 **Demos are not prose, and the same authority does not extend to them.** Prose can be
-rewritten from the source at any time; a working demo is executable proof that a particular
-combination of arguments does what the docs claim, it is the thing readers copy, and it is
-the only part of the page the site actually runs. Replacing a demo with a sentence
-describing it converts checked behavior into an unchecked assertion. That trade is almost
-never worth it, and it is invisible in review — the page gets shorter and reads better,
-while coverage quietly drops.
+rewritten from the source at any time; a demo is executable proof that a combination of
+arguments does what the docs claim, it is what readers copy, and it is the only part of the
+page the site runs. Replacing a demo with a sentence describing it converts checked behavior
+into an unchecked assertion — and it's invisible in review, because the page gets shorter
+and reads better while coverage drops.
 
-So the two edits pull in opposite directions, and the reduction you're after comes from
-prose. Before removing any demo, do this explicitly:
+The reduction you want comes from prose. Before removing any demo:
 
 1. Name the state it exercises — which arguments, which mode, which interaction.
 2. Find a demo you are **keeping** that exercises that same state.
@@ -217,45 +138,64 @@ prose. Before removing any demo, do this explicitly:
 "Both demos are about `@isOpen`" is not step 2. Two demos sharing an argument can still
 exercise different states — controlled vs. uncontrolled, single vs. multiple selection, one
 panel vs. several, nested vs. flat, initially-open vs. opening on interaction. Readers also
-navigate by scenario rather than by argument: someone looking for an accordion doesn't
-recognize their problem in a demo titled "Basic".
+navigate by scenario: someone looking for an accordion won't recognize their problem in a
+demo called "Basic".
 
 When two demos genuinely do exercise the same state, **consolidate rather than delete** —
-fold them into one demo with several instances, or an `{{#each}}` over the varying values.
-That keeps the coverage and still removes the duplication.
+one demo with several instances, or an `{{#each}}` over the varying values. The duplication
+goes, the coverage stays.
 
-The one thing prose should keep is a footgun: the `class` vs. `@class` note in `button.md`
-is exactly the kind of fact a reader can't derive from a demo, and it would be lost in an
-undifferentiated cut.
+Keep footguns in prose: the `class` vs. `@class` note in `button.md` is a fact no demo
+conveys, and it would be lost in an undifferentiated cut.
 
-Then report what you did, because a shorter file is not self-evidently a better one:
+Then report demo count before → after, the retained demo covering each removal, and one line
+on what prose you cut. If that list is uncomfortable to write, you removed coverage, not fat.
 
-- demo count before → after
-- for each demo removed, the retained demo that covers its state
-- what prose you cut, in one line
+## Keep the change the size of the request
 
-If that list is uncomfortable to write, that's the signal — you removed coverage, not fat.
-The linter checks this mechanically, and it is worth running on any file you shortened:
+Reading the source surfaces adjacent problems — a wrong class in a neighbouring doc, a broken
+theme variant, a missing test. Documenting one component is not licence to fix them. Report
+what you found and leave it, unless your change is actually wrong without it. A docs edit
+that also rewrites the theme package is hard to review and buries the part that was asked
+for. When you must reach outside the doc and its component, say so and say why.
+
+## Verify
 
 ```bash
-node .claude/skills/frontile-docs/scripts/lint-docs.mjs --since HEAD <file>
+node .claude/skills/frontile-docs/scripts/lint-docs.mjs                    # everything
+node .claude/skills/frontile-docs/scripts/lint-docs.mjs --since HEAD FILE   # + demo loss
 ```
 
-For a multi-file audit, run the linter across everything first and work from its output —
-it's cheaper and more consistent than reading 31 files, and it won't miss the boring
-mechanical failures while chasing the interesting editorial ones.
+Zero dependencies, so it runs without `node_modules`, and it exits non-zero on errors for
+CI. It covers required sections, fence languages, `<Signature>` wiring including tags naming
+a component that doesn't exist, arguments used in demos that aren't in the signature,
+arguments missing the JSDoc that fills the API table, numbered color utilities, raw palette
+classes, inline `<svg>`, and — with `--since` — runnable demos removed since a git ref.
 
-## Repo facts worth not re-deriving
+Demo loss warns, and errors only when more than a third of the page's demos are gone. A
+warning isn't a verdict: removing one demo of seven is often real cleanup. It's a prompt to
+say which retained demo covers the removed state. An error means the page lost most of its
+executable coverage, which is not cleanup.
+
+Then confirm the demos actually render, which the linter can't do:
+
+```bash
+cd site && pnpm build
+```
+
+If that didn't run, say the demos are unverified rather than implying they were checked.
+
+## Repo facts
 
 - Component source and docs live **only** in `packages/frontile/src/components/<category>/`.
-  The `buttons/`, `forms/`, `collections/`, etc. packages are deprecation wrappers — never
-  add docs there.
-- Everything imports from the single `frontile` package: `import { Button } from 'frontile';`
-- Docfy sources the repo-root `docs/` directory too (theming, migrations, accessibility).
-  Component API changes with migration impact belong in `docs/migrations/` as well.
-- Notifications are the exception to co-location: `NotificationCard` and
+  The `buttons/`, `forms/`, `collections/` packages are deprecation wrappers — never add
+  docs there.
+- Everything imports from one package: `import { Button } from 'frontile';`
+- Docfy also sources the repo-root `docs/` (theming, migrations, accessibility). API changes
+  with migration impact belong in `docs/migrations/` too.
+- Notifications are the co-location exception: `NotificationCard` and
   `NotificationsContainer` are documented together in
-  `packages/frontile/docs/notifications-usage.md`, because they're only ever used as a pair.
-  The linter reports them as missing docs — that's expected, not a gap.
-- New components get `label: New` in frontmatter, which renders a sidebar badge. Remove it
-  once the component has shipped for a release or two.
+  `packages/frontile/docs/notifications-usage.md`. The linter reports them as missing docs;
+  that's expected.
+- New components get `label: New` in frontmatter for a sidebar badge. Drop it after a
+  release or two.

--- a/.claude/skills/frontile-docs/references/demos.md
+++ b/.claude/skills/frontile-docs/references/demos.md
@@ -1,0 +1,166 @@
+# Writing demos that run
+
+Every ` ```gts preview ` fence is compiled and rendered on frontile.dev. A demo that
+doesn't compile is a broken public page, so the cost of guessing at an API here is higher
+than in ordinary docs.
+
+Contents:
+- [Fence languages](#fence-languages)
+- [Demos are standalone modules](#demos-are-standalone-modules)
+- [Template helpers](#template-helpers)
+- [State in a demo](#state-in-a-demo)
+- [Styling inside demos](#styling-inside-demos)
+- [Content and length](#content-and-length)
+
+## Fence languages
+
+| Fence | Renders as | Use for |
+| --- | --- | --- |
+| ` ```gts preview ` | Live component **and** source | Every demo. The default |
+| ` ```gjs preview ` | Live component and source | Legacy. 50 blocks remain; convert to `gts` when you touch the file |
+| ` ```js ` | Static code block | The `## Import` line |
+| ` ```gts ` | Static code block | A fragment that intentionally can't run on its own |
+| ` ```css ` | Static code block | Consumer-side CSS, e.g. styling a `data-*` attribute |
+
+The `preview` keyword is what makes it live. Dropping it is the most common accidental
+regression: the demo still looks right in the diff and silently stops rendering on the site.
+
+## Demos are standalone modules
+
+Each fence is compiled independently. Nothing carries over from an earlier demo in the same
+file — every import must be repeated, including `frontile` itself.
+
+```gts preview
+import { Button } from 'frontile';
+
+<template>
+  <Button>Button</Button>
+</template>
+```
+
+Top-level `<template>` is the template-only form. Anything needing state uses a class (see
+below).
+
+## Template helpers
+
+Glimmer's built-in helper set is smaller than people expect, and the gap surfaces as a
+build error rather than a fallback:
+
+```ts
+import { hash, array, fn, get, concat } from '@ember/helper';
+import { on } from '@ember/modifier';
+```
+
+**`eq` does not exist**, nor do `not`, `and`, `or`, `gt`. Restructure to avoid a comparison
+in the template — pass a boolean in from JS, or iterate an array — rather than reaching for
+a helper package the demo can't import.
+
+## State in a demo
+
+Use a class component with `@glimmer/tracking`. `button.md`'s press-counter demo is the
+reference shape:
+
+```gts preview
+import { Button } from 'frontile';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class ButtonPressExample extends Component {
+  @tracked pressCount = 0;
+
+  handlePress = () => {
+    this.pressCount++;
+  };
+
+  <template>
+    <Button @onPress={{this.handlePress}}>
+      Press me! ({{this.pressCount}})
+    </Button>
+  </template>
+}
+```
+
+Name the class after what it demonstrates (`ButtonPressExample`), not `Demo` — the class
+name is visible in the rendered source, so it's documentation too.
+
+## Styling inside demos
+
+Demo markup uses the same semantic utilities as the library. **There is no numbered color
+scale**: `bg-primary-500` isn't a class, and it fails silently as unstyled output rather
+than erroring.
+
+Categories: `neutral`, `primary`, `secondary`, `tertiary`, `success`, `warning`, `danger`,
+`inverse`, `surface-*`. Levels, low to high emphasis: `subtle`, `muted`, `soft`, `mild`,
+DEFAULT (no suffix), `firm`, `strong`, `bolder`. Text that must contrast against a filled
+background uses `text-on-{category}-{level}`.
+
+```
+bg-primary            text-neutral-strong     text-on-primary-firm
+border-neutral-soft   bg-surface-mild
+```
+
+These adapt to dark mode through CSS variables, so a demo built from them is correct in
+both themes with no extra work. A hardcoded `bg-teal-100` is not — reserve raw Tailwind
+colors for demos whose whole point is showing custom styling (as `button.md` does for
+`@appearance='custom'`), and say so in the surrounding prose.
+
+For layout, keep wrappers minimal and consistent with neighbors:
+
+```html
+<div class='flex flex-wrap items-center gap-3'>
+```
+
+## Icons and helper components
+
+Demos live in the `site` app's module space, so they can import from `site/components/…`.
+Three shared resources already exist, and reaching for them beats inventing a local one:
+
+| Import | What it is |
+| --- | --- |
+| `site/components/icons` | 25 SVG icon components, headed "Common icons used in documentation examples": `Accessibility`, `Archive`, `Book`, `Check`, `ChevronDown`, `Code`, `Component`, `Delete`, `Download`, `Duplicate`, `Edit`, `Logout`, `Moon`, `Package`, `Palette`, `Rocket`, `Search`, `Settings`, `Share`, `Sparkles`, `Star`, `Sun`, `Target`, `User`, `View` — each suffixed `Icon` |
+| `site/components/table-demo-data` | Realistic `users` / `products` / `employees` fixtures with exported types, used across `table.md` |
+| `site/components/theme-docs/*` | Purpose-built doc widgets — `ColorPaletteGrid`, `ColorSwatch`, `SurfaceShowcase` |
+
+```gts preview
+import { Button } from 'frontile';
+import { DownloadIcon } from 'site/components/icons';
+
+<template>
+  <Button>
+    <DownloadIcon />
+    Download
+  </Button>
+</template>
+```
+
+**Never inline an `<svg>` in a doc.** Currently zero component docs do, and it's worth
+keeping that way: an inline icon is a wall of path data between the reader and the API
+being demonstrated, and it can't pick up `size-icon-*` sizing or `currentColor` consistently.
+If the icon you need isn't in `site/app/components/icons.gts`, add it there — match the
+existing shape (24×24 viewBox, `stroke="currentColor"`, `class="size-icon-lg"`,
+`...attributes`) and export it with the `*Icon` suffix.
+
+The same applies one level up: if a doc needs a widget to explain something — a swatch grid,
+a live token preview, a spec table — build it as a real component in
+`site/app/components/`, the way `theme-docs/color-palette-grid.gts` does, rather than
+assembling it inline in markdown. Components used outside a fence are declared in
+frontmatter:
+
+```yaml
+imports:
+  - import ColorPaletteGrid from 'site/components/theme-docs/color-palette-grid';
+```
+
+Inside a ` ```gts preview ` fence, import normally in the demo body instead.
+
+## Content and length
+
+A demo is doing two jobs: proving the API works, and being pasteable. Both argue for short.
+
+- Show one idea per demo. If you're adding a second concept "while we're here", it's a
+  second demo or it's noise.
+- Use realistic content — a demo labeled `foo` / `bar` teaches nothing about what the
+  component is for, while `Save changes` / `Cancel` shows a real pairing.
+- Prefer `{{#each}}` over repetition when demonstrating an enumerable axis. Twenty
+  near-identical tags make the reader diff them by eye; a loop over `(array 'sm' 'md' 'lg')`
+  states the axis directly.

--- a/.claude/skills/frontile-docs/references/structure.md
+++ b/.claude/skills/frontile-docs/references/structure.md
@@ -1,0 +1,166 @@
+# Canonical structure for a component doc
+
+Read this before creating a new `.md` or reordering an existing one.
+
+Contents:
+- [File location and naming](#file-location-and-naming)
+- [Frontmatter](#frontmatter)
+- [The template](#the-template)
+- [Section-by-section](#section-by-section)
+- [Approved heading vocabulary](#approved-heading-vocabulary)
+- [Compound and yielding components](#compound-and-yielding-components)
+
+## File location and naming
+
+The doc is a sibling of the component, same basename:
+
+```
+packages/frontile/src/components/buttons/button.gts
+packages/frontile/src/components/buttons/button.md
+```
+
+Docfy picks it up from `site/docfy.config.mjs`, which globs
+`src/components/{buttons,utilities,status,collections,forms,notifications,overlays}/**/*.md`
+with `urlSchema: 'manual'`. A new file in one of those categories appears on the site with
+no registration step. A file in a category that isn't in that list will not — add the
+category to `docfy.config.mjs` `sources` **and** `sections` if you create one.
+
+## Frontmatter
+
+```yaml
+---
+label: New
+url: modal
+imports:
+  - import Signature from 'site/components/signature';
+---
+```
+
+| Key | When | Notes |
+| --- | --- | --- |
+| `imports` | Whenever the doc uses `<Signature>` — so, effectively always | Without it the tag renders as literal text |
+| `label` | New components only | Renders a sidebar badge. `New` is the only value in use. Drop it after a release or two |
+| `url` | Rare | Overrides the generated URL segment. Only `modal.md` and `drawer.md` use it, to keep short public URLs |
+
+There is no `title` key — the H1 is the title.
+
+## The template
+
+````md
+---
+imports:
+  - import Signature from 'site/components/signature';
+---
+
+# ComponentName
+
+One sentence on what it's for and when to reach for it. No adjectives that don't
+narrow anything down.
+
+## Import
+
+```js
+import { ComponentName } from 'frontile';
+```
+
+## Usage
+
+The simplest thing that works — no options, no styling, nothing the reader has to
+skip past to see the shape of the API.
+
+```gts preview
+import { ComponentName } from 'frontile';
+
+<template>
+  <ComponentName>Content</ComponentName>
+</template>
+```
+
+## <Feature section>
+
+One section per axis of variation. Prose only where the demo can't speak: which
+option to pick, what interacts with what.
+
+```gts preview
+…
+```
+
+## Accessibility
+
+Keyboard table, roles and ARIA, focus behavior, screen reader notes. See the
+Accessibility step in SKILL.md for what belongs here.
+
+## API
+
+<Signature @component="ComponentName" />
+````
+
+## Section-by-section
+
+**H1 title.** The component name as written in code (`ButtonGroup`, not `Button Group`),
+followed by one sentence. Compare `button.md`: "The Button component can be used to trigger
+an action, such as submitting a form, opening a modal, and more." It says what it's for and
+gives concrete occasions. That's the bar.
+
+**`## Import`** — a bare ` ```js ` fence with the import line, nothing else. Always from
+`'frontile'`.
+
+**`## Usage`** — the minimum viable demo. This is the section most readers copy, so it
+should work pasted into an empty file with no further reading. If the component genuinely
+can't be used without an argument, include only that one.
+
+**Feature sections** — one `##` per axis: appearances, intents, sizes, disabled/loading
+states, selection modes, positioning. Order them the way someone learns the component:
+appearance and size before edge-case behavior. Where an axis is combinatorial (every intent
+in every appearance), a single `{{#each}}` demo beats twenty hand-written tags — see
+`button.md`'s intents section.
+
+**`## Accessibility`** — required. Details in SKILL.md step 4.
+
+**`## API`** — only `<Signature @component="X" />`. If the component yields sub-components
+that have their own signatures, add a tag per component, in the order a reader meets them.
+
+## Approved heading vocabulary
+
+Use the standard headings so the sidebar and in-page TOC stay predictable across 30+ files:
+
+| Use | Instead of |
+| --- | --- |
+| `## Usage` | `## Basic Usage` |
+| Feature `##` sections, named for the axis | `## Key Features` (a list of features nobody reads) |
+| Prose inside the relevant section, or a `> Note:` callout | `## Important Notes` (orphaned facts) |
+| Guidance inside the section it applies to | `## Best Practices` |
+
+`## Key Features`, `## Important Notes`, and `## Best Practices` all exist in the current
+docs and all suffer the same problem: they collect facts away from the thing they describe,
+where readers scanning for a feature won't find them. When you touch a file that has one,
+redistribute its contents into the sections they belong to.
+
+## Compound and yielding components
+
+For components that yield sub-components or a rich block context (`Form`, `Field`, `Table`,
+`Dropdown`, `Listbox`, `Select`), the reader's first question is *what are the pieces and
+how do they fit*. Answer it immediately after `## Usage` with a short section showing the
+parts assembled — the existing `### Yielded Components` sections in `dropdown.md` and
+`listbox.md` are the pattern:
+
+````md
+## Anatomy
+
+```gts preview
+import { Dropdown } from 'frontile';
+
+<template>
+  <Dropdown as |d|>
+    <d.Trigger>Open</d.Trigger>
+    <d.Menu as |Item|>
+      <Item>Profile</Item>
+    </d.Menu>
+  </Dropdown>
+</template>
+```
+````
+
+Then document each part's own arguments with its own `<Signature>` tag under `## API`.
+Without this, a reader has to reverse-engineer the block structure from a feature demo that
+was trying to show them something else.

--- a/.claude/skills/frontile-docs/scripts/lint-docs.mjs
+++ b/.claude/skills/frontile-docs/scripts/lint-docs.mjs
@@ -216,6 +216,25 @@ function lineOf(source, index) {
   return source.slice(0, index).split('\n').length;
 }
 
+/**
+ * Component names present in the generated signature data, or null when it
+ * hasn't been generated. Entries are emitted as package/module/name/fileName
+ * groups; anchoring on the preceding `module:` avoids picking up the `name`
+ * keys that appear inside Blocks metadata.
+ */
+let signatureNamesCache;
+function knownSignatureComponents() {
+  if (signatureNamesCache !== undefined) return signatureNamesCache;
+  const dataPath = join(REPO_ROOT, 'site/app/components/signature-data.ts');
+  if (!existsSync(dataPath)) return (signatureNamesCache = null);
+  const source = readFileSync(dataPath, 'utf8');
+  const names = new Set();
+  for (const m of source.matchAll(/module:\s*'[^']*',\s*name:\s*'([^']+)'/g)) {
+    names.add(m[1]);
+  }
+  return (signatureNamesCache = names.size > 0 ? names : null);
+}
+
 // ---------------------------------------------------------------------------
 // The checks
 // ---------------------------------------------------------------------------
@@ -292,6 +311,24 @@ function lintDoc(mdPath) {
       '`<Signature />` used but not imported in frontmatter',
       "add `imports:\\n  - import Signature from 'site/components/signature';`"
     );
+  }
+
+  // A tag naming a component that isn't in the generated data renders as an
+  // empty API entry — the site only logs "No component found" during the build,
+  // which is easy to miss. Skipped when the data hasn't been generated yet,
+  // since a missing file would otherwise condemn every tag in the repo.
+  const known = knownSignatureComponents();
+  if (known) {
+    for (const tag of signatureTags) {
+      if (!known.has(tag[1])) {
+        add(
+          'error',
+          lineOf(source, tag.index),
+          `\`<Signature @component="${tag[1]}" />\` matches no component in signature-data.ts`,
+          'check the name, or run `pnpm --filter frontile build && pnpm --filter site generate-signature-data` if the component is new'
+        );
+      }
+    }
   }
 
   // --- Fences -------------------------------------------------------------

--- a/.claude/skills/frontile-docs/scripts/lint-docs.mjs
+++ b/.claude/skills/frontile-docs/scripts/lint-docs.mjs
@@ -531,7 +531,9 @@ function main() {
   const sinceFlag = argv.indexOf('--since');
   const since = sinceFlag === -1 ? null : (argv[sinceFlag + 1] ?? 'HEAD');
   const paths = argv.filter(
-    (a, i) => !a.startsWith('--') && i !== sinceFlag + 1
+    // Guard on sinceFlag !== -1: without it, `sinceFlag + 1` is 0 when --since
+    // is absent, which silently swallows the first file argument.
+    (a, i) => !a.startsWith('--') && !(sinceFlag !== -1 && i === sinceFlag + 1)
   );
 
   let docs;

--- a/.claude/skills/frontile-docs/scripts/lint-docs.mjs
+++ b/.claude/skills/frontile-docs/scripts/lint-docs.mjs
@@ -20,6 +20,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
 
 const REPO_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -432,6 +433,40 @@ function lintDoc(mdPath) {
 // Discovery + reporting
 // ---------------------------------------------------------------------------
 
+/**
+ * Compares a doc against a git ref and reports demos that disappeared.
+ *
+ * Shortening a page is usually an improvement, but the cheap way to shorten it
+ * is to delete demos, which silently trades executable coverage for prose. That
+ * loss is invisible in review — the page reads better — so it gets checked here
+ * rather than left to judgment.
+ */
+function demoRegressions(mdPath, ref) {
+  const rel = relative(REPO_ROOT, mdPath);
+  let before;
+  try {
+    before = execSync(`git show ${ref}:${rel}`, {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).toString();
+  } catch {
+    return []; // new file, or not in that ref — nothing to compare
+  }
+  const count = (s) => [...s.matchAll(/^```g[jt]s preview$/gm)].length;
+  const was = count(before);
+  const now = count(readFileSync(mdPath, 'utf8'));
+  if (now >= was) return [];
+  return [
+    {
+      file: rel,
+      level: 'error',
+      line: 1,
+      message: `${was - now} runnable demo(s) removed since ${ref} (${was} → ${now})`,
+      hint: 'name the retained demo covering each removed state, or consolidate instead of deleting — see SKILL.md'
+    }
+  ];
+}
+
 function walk(dir, out = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
@@ -482,7 +517,13 @@ function findOrphanComponents(files) {
 function main() {
   const argv = process.argv.slice(2);
   const json = argv.includes('--json');
-  const paths = argv.filter((a) => !a.startsWith('--'));
+  // `--since <ref>` additionally compares each doc against that ref and errors
+  // when runnable demos have been removed.
+  const sinceFlag = argv.indexOf('--since');
+  const since = sinceFlag === -1 ? null : (argv[sinceFlag + 1] ?? 'HEAD');
+  const paths = argv.filter(
+    (a, i) => !a.startsWith('--') && i !== sinceFlag + 1
+  );
 
   let docs;
   let findings = [];
@@ -506,6 +547,7 @@ function main() {
   for (const doc of docs) {
     if (!existsSync(doc) || !statSync(doc).isFile()) continue;
     findings = findings.concat(lintDoc(doc));
+    if (since) findings = findings.concat(demoRegressions(doc, since));
   }
 
   const errors = findings.filter((f) => f.level === 'error');

--- a/.claude/skills/frontile-docs/scripts/lint-docs.mjs
+++ b/.claude/skills/frontile-docs/scripts/lint-docs.mjs
@@ -456,13 +456,22 @@ function demoRegressions(mdPath, ref) {
   const was = count(before);
   const now = count(readFileSync(mdPath, 'utf8'));
   if (now >= was) return [];
+  const lost = was - now;
+  // Severity tracks scale, because the two cases are different in kind.
+  // Dropping one demo of seven is usually real cleanup with a defensible
+  // reason, and erroring on it would forbid all removal and get this check
+  // switched off. Losing a third of the page's demos is coverage collapse,
+  // which is what this check exists to stop.
+  const collapse = lost / was > 1 / 3;
   return [
     {
       file: rel,
-      level: 'error',
+      level: collapse ? 'error' : 'warn',
       line: 1,
-      message: `${was - now} runnable demo(s) removed since ${ref} (${was} → ${now})`,
-      hint: 'name the retained demo covering each removed state, or consolidate instead of deleting — see SKILL.md'
+      message: `${lost} runnable demo(s) removed since ${ref} (${was} → ${now})`,
+      hint: collapse
+        ? "that is most of the page's executable coverage — consolidate instead of deleting, see SKILL.md"
+        : 'fine if deliberate: name the retained demo covering the removed state in your summary'
     }
   ];
 }

--- a/.claude/skills/frontile-docs/scripts/lint-docs.mjs
+++ b/.claude/skills/frontile-docs/scripts/lint-docs.mjs
@@ -21,7 +21,10 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const REPO_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../..'
+);
 const COMPONENTS_DIR = join(REPO_ROOT, 'packages/frontile/src/components');
 
 const REQUIRED_SECTIONS = ['Import', 'Usage', 'API'];
@@ -177,7 +180,11 @@ function collectFences(source) {
     const m = /^```(.*)$/.exec(line);
     if (!m) return;
     if (open) {
-      fences.push({ ...open, endLine: i + 1, content: lines.slice(open.line, i).join('\n') });
+      fences.push({
+        ...open,
+        endLine: i + 1,
+        content: lines.slice(open.line, i).join('\n')
+      });
       open = null;
     } else {
       open = { info: m[1].trim(), line: i + 1 };
@@ -226,10 +233,17 @@ function lintDoc(mdPath) {
     text: m[2].trim(),
     line: lineOf(source, m.index)
   }));
-  const topLevel = new Set(headings.filter((h) => h.depth === 2).map((h) => h.text));
+  const topLevel = new Set(
+    headings.filter((h) => h.depth === 2).map((h) => h.text)
+  );
 
   if (!headings.some((h) => h.depth === 1)) {
-    add('warn', 1, 'No H1 title', 'the H1 is the page title; there is no `title` frontmatter key');
+    add(
+      'warn',
+      1,
+      'No H1 title',
+      'the H1 is the page title; there is no `title` frontmatter key'
+    );
   }
 
   for (const section of REQUIRED_SECTIONS) {
@@ -237,7 +251,12 @@ function lintDoc(mdPath) {
     // A file using `## Basic Usage` already gets the rename warning below; reporting
     // it as a missing section too would send someone looking for content that's there.
     if (section === 'Usage' && topLevel.has('Basic Usage')) continue;
-    add('error', 1, `Missing \`## ${section}\` section`, 'see references/structure.md');
+    add(
+      'error',
+      1,
+      `Missing \`## ${section}\` section`,
+      'see references/structure.md'
+    );
   }
   if (!topLevel.has('Accessibility')) {
     add(
@@ -250,11 +269,14 @@ function lintDoc(mdPath) {
 
   for (const h of headings) {
     const advice = DISCOURAGED_HEADINGS[h.text];
-    if (advice && h.depth <= 3) add('warn', h.line, `Heading \`${h.text}\``, advice);
+    if (advice && h.depth <= 3)
+      add('warn', h.line, `Heading \`${h.text}\``, advice);
   }
 
   // --- <Signature> wiring -------------------------------------------------
-  const signatureTags = [...source.matchAll(/<Signature\s+[^>]*@component="([^"]+)"/g)];
+  const signatureTags = [
+    ...source.matchAll(/<Signature\s+[^>]*@component="([^"]+)"/g)
+  ];
   if (topLevel.has('API') && signatureTags.length === 0) {
     add(
       'error',
@@ -275,7 +297,12 @@ function lintDoc(mdPath) {
   // --- Fences -------------------------------------------------------------
   for (const fence of collectFences(source)) {
     if (fence.info === 'gjs preview') {
-      add('warn', fence.line, 'Legacy ```gjs preview fence', 'convert to ```gts preview');
+      add(
+        'warn',
+        fence.line,
+        'Legacy ```gjs preview fence',
+        'convert to ```gts preview'
+      );
     }
     const isPreview = /\bpreview\b/.test(fence.info);
     if (!isPreview && /<template>/.test(fence.content) && fence.info !== '') {
@@ -322,14 +349,19 @@ function lintDoc(mdPath) {
   // --- Args drift ---------------------------------------------------------
   const gtsPath = mdPath.replace(/\.md$/, '.gts');
   if (existsSync(gtsPath)) {
-    const { args, complete } = parseComponentArgs(readFileSync(gtsPath, 'utf8'));
+    const { args, complete } = parseComponentArgs(
+      readFileSync(gtsPath, 'utf8')
+    );
     const gtsRel = relative(REPO_ROOT, gtsPath);
 
     // Only check the component this file actually declares. Docs routinely document
     // sub-components that live in their own files (PortalTarget in portal.md), and
     // checking those against the wrong Args interface invents errors.
-    const own = basename(mdPath, '.md').replace(/(^|-)(\w)/g, (_, __, c) => c.toUpperCase());
-    const primary = signatureTags.map((t) => t[1]).find((name) => name === own) ?? null;
+    const own = basename(mdPath, '.md').replace(/(^|-)(\w)/g, (_, __, c) =>
+      c.toUpperCase()
+    );
+    const primary =
+      signatureTags.map((t) => t[1]).find((name) => name === own) ?? null;
     if (primary && complete) {
       for (const [arg, line] of argsUsedOnTag(source, primary)) {
         if (!args.has(arg)) {
@@ -343,7 +375,9 @@ function lintDoc(mdPath) {
       }
     }
 
-    const undocumented = [...args.values()].filter((a) => !a.documented).map((a) => a.name);
+    const undocumented = [...args.values()]
+      .filter((a) => !a.documented)
+      .map((a) => a.name);
     if (undocumented.length > 0) {
       add(
         'warn',
@@ -381,7 +415,9 @@ function publiclyExported() {
     if (!category.isDirectory()) continue;
     const barrel = join(COMPONENTS_DIR, category.name, 'index.ts');
     if (!existsSync(barrel)) continue;
-    for (const m of readFileSync(barrel, 'utf8').matchAll(/from\s+'\.\/([\w-]+)'/g)) {
+    for (const m of readFileSync(barrel, 'utf8').matchAll(
+      /from\s+'\.\/([\w-]+)'/g
+    )) {
       exported.add(join(COMPONENTS_DIR, category.name, `${m[1]}.gts`));
     }
   }
@@ -415,10 +451,14 @@ function main() {
   let findings = [];
 
   if (paths.length > 0) {
-    docs = paths.map((p) => resolve(process.cwd(), p)).filter((p) => p.endsWith('.md'));
+    docs = paths
+      .map((p) => resolve(process.cwd(), p))
+      .filter((p) => p.endsWith('.md'));
   } else {
     if (!existsSync(COMPONENTS_DIR)) {
-      console.error(`Cannot find ${COMPONENTS_DIR} — run from inside the frontile repo.`);
+      console.error(
+        `Cannot find ${COMPONENTS_DIR} — run from inside the frontile repo.`
+      );
       process.exit(2);
     }
     const all = walk(COMPONENTS_DIR);
@@ -435,7 +475,9 @@ function main() {
   const warnings = findings.filter((f) => f.level === 'warn');
 
   if (json) {
-    console.log(JSON.stringify({ docs: docs.length, errors, warnings }, null, 2));
+    console.log(
+      JSON.stringify({ docs: docs.length, errors, warnings }, null, 2)
+    );
   } else {
     const byFile = new Map();
     for (const f of findings) {

--- a/.claude/skills/frontile-docs/scripts/lint-docs.mjs
+++ b/.claude/skills/frontile-docs/scripts/lint-docs.mjs
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+/**
+ * Lints Frontile component docs against the conventions in
+ * .claude/skills/frontile-docs/references/structure.md.
+ *
+ * The point of this script is to take the mechanical half of a docs review off the
+ * model's plate: required sections, fence languages, <Signature> wiring, and drift
+ * between a doc's demos and the component's actual Args. Those checks are boring,
+ * easy to get wrong by eye across 30+ files, and identical every time — exactly the
+ * shape of thing that should be code rather than a checklist item.
+ *
+ * Usage:
+ *   node .claude/skills/frontile-docs/scripts/lint-docs.mjs
+ *   node .claude/skills/frontile-docs/scripts/lint-docs.mjs path/to/one.md [more.md]
+ *   node .claude/skills/frontile-docs/scripts/lint-docs.mjs --json
+ *
+ * Exits 1 when there is at least one error, so it can gate CI.
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, relative, resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const COMPONENTS_DIR = join(REPO_ROOT, 'packages/frontile/src/components');
+
+const REQUIRED_SECTIONS = ['Import', 'Usage', 'API'];
+const DISCOURAGED_HEADINGS = {
+  'Basic Usage': 'use `## Usage`',
+  'Key Features': 'fold each feature into the section that demonstrates it',
+  'Important Notes': 'move each note next to the thing it describes',
+  'Best Practices': 'move guidance into the section it applies to'
+};
+const SEMANTIC_CATEGORIES =
+  'neutral|primary|secondary|tertiary|success|warning|danger|inverse|surface';
+const UTILITY_PREFIXES =
+  'bg|text|border|ring|from|to|via|fill|stroke|divide|outline|shadow|accent|caret|decoration|placeholder';
+
+// ---------------------------------------------------------------------------
+// Tiny TS parsing. Deliberately tolerant: when it can't confidently resolve an
+// Args type it reports that it gave up rather than inventing findings. A linter
+// that cries wolf on valid docs gets switched off.
+// ---------------------------------------------------------------------------
+
+/** Returns the source spanning the braces of the block starting at `openIndex` (the `{`). */
+function readBlock(source, openIndex) {
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(openIndex + 1, i);
+    }
+  }
+  return null;
+}
+
+function findInterfaceBlock(source, name) {
+  const re = new RegExp(`interface\\s+${name}\\b[^{]*\\{`, 'm');
+  const match = re.exec(source);
+  if (!match) return null;
+  return {
+    body: readBlock(source, match.index + match[0].length - 1),
+    extends: /\bextends\b/.test(match[0])
+  };
+}
+
+/**
+ * Top-level members of an interface body, with whether each carries a JSDoc block.
+ * Members are only counted at brace depth 0 so nested object types don't leak in.
+ */
+function parseMembers(body) {
+  const members = [];
+  let depth = 0;
+  let lineStart = 0;
+  const lines = body.split('\n');
+  let pendingDoc = false;
+  let inDoc = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (inDoc) {
+      if (line.includes('*/')) inDoc = false;
+      continue;
+    }
+    if (line.startsWith('/**')) {
+      pendingDoc = true;
+      if (!line.includes('*/')) inDoc = true;
+      continue;
+    }
+
+    if (depth === 0) {
+      const m = /^(?:readonly\s+)?(\w+)\s*\??\s*:/.exec(line);
+      if (m) members.push({ name: m[1], documented: pendingDoc });
+      if (m || line !== '') pendingDoc = line === '' ? pendingDoc : false;
+    }
+
+    for (const ch of rawLine) {
+      if (ch === '{' || ch === '(' || ch === '[') depth++;
+      else if (ch === '}' || ch === ')' || ch === ']') depth--;
+    }
+    lineStart += rawLine.length;
+  }
+  return members;
+}
+
+/**
+ * Collects every argument declared by the component file, plus whether we're
+ * confident the list is complete. Incomplete lists suppress "unknown argument"
+ * errors — a false positive there sends someone chasing a bug that isn't there.
+ */
+function parseComponentArgs(gtsSource) {
+  const args = new Map();
+  let complete = true;
+  let found = false;
+
+  const argsTypeNames = new Set();
+  const signatureRe = /interface\s+(\w*Signature)\b[^{]*\{/g;
+  let sig;
+  while ((sig = signatureRe.exec(gtsSource))) {
+    const body = readBlock(gtsSource, sig.index + sig[0].length - 1);
+    if (!body) continue;
+    const inline = /Args\s*:\s*\{/.exec(body);
+    if (inline) {
+      const inlineBody = readBlock(body, inline.index + inline[0].length - 1);
+      if (inlineBody) {
+        found = true;
+        for (const m of parseMembers(inlineBody)) args.set(m.name, m);
+      }
+      continue;
+    }
+    const named = /Args\s*:\s*(\w+)/.exec(body);
+    if (named) argsTypeNames.add(named[1]);
+  }
+
+  // Any interface named *Args counts too — several components declare and export
+  // one without ever naming it in a Signature in the same file.
+  const namedRe = /interface\s+(\w*Args)\b/g;
+  let named;
+  while ((named = namedRe.exec(gtsSource))) argsTypeNames.add(named[1]);
+
+  for (const typeName of argsTypeNames) {
+    const block = findInterfaceBlock(gtsSource, typeName);
+    if (!block || !block.body) {
+      complete = false; // imported from elsewhere; we can't see its members
+      continue;
+    }
+    found = true;
+    if (block.extends) complete = false;
+    for (const m of parseMembers(block.body)) args.set(m.name, m);
+  }
+
+  if (!found) complete = false;
+  return { args, complete };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown inspection
+// ---------------------------------------------------------------------------
+
+function parseFrontmatter(source) {
+  if (!source.startsWith('---\n')) return { body: source, raw: '', offset: 0 };
+  const end = source.indexOf('\n---', 4);
+  if (end === -1) return { body: source, raw: '', offset: 0 };
+  const raw = source.slice(4, end);
+  const offset = source.slice(0, end + 4).split('\n').length;
+  return { body: source.slice(end + 4), raw, offset };
+}
+
+function collectFences(source) {
+  const fences = [];
+  const lines = source.split('\n');
+  let open = null;
+  lines.forEach((line, i) => {
+    const m = /^```(.*)$/.exec(line);
+    if (!m) return;
+    if (open) {
+      fences.push({ ...open, endLine: i + 1, content: lines.slice(open.line, i).join('\n') });
+      open = null;
+    } else {
+      open = { info: m[1].trim(), line: i + 1 };
+    }
+  });
+  return fences;
+}
+
+/** Argument names applied to `<Tag ...>` anywhere in the doc. */
+function argsUsedOnTag(source, tag) {
+  const used = new Map();
+  const re = new RegExp(`<${tag}\\b`, 'g');
+  let m;
+  while ((m = re.exec(source))) {
+    const end = source.indexOf('>', m.index);
+    if (end === -1) continue;
+    const attrs = source.slice(m.index, end);
+    const argRe = /@(\w+)\s*=/g;
+    let a;
+    while ((a = argRe.exec(attrs))) {
+      const line = source.slice(0, m.index).split('\n').length;
+      if (!used.has(a[1])) used.set(a[1], line);
+    }
+  }
+  return used;
+}
+
+function lineOf(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
+// ---------------------------------------------------------------------------
+// The checks
+// ---------------------------------------------------------------------------
+
+function lintDoc(mdPath) {
+  const findings = [];
+  const source = readFileSync(mdPath, 'utf8');
+  const { raw: frontmatter } = parseFrontmatter(source);
+  const rel = relative(REPO_ROOT, mdPath);
+  const add = (level, line, message, hint) =>
+    findings.push({ file: rel, level, line, message, hint });
+
+  const headings = [...source.matchAll(/^(#{1,6})\s+(.+)$/gm)].map((m) => ({
+    depth: m[1].length,
+    text: m[2].trim(),
+    line: lineOf(source, m.index)
+  }));
+  const topLevel = new Set(headings.filter((h) => h.depth === 2).map((h) => h.text));
+
+  if (!headings.some((h) => h.depth === 1)) {
+    add('warn', 1, 'No H1 title', 'the H1 is the page title; there is no `title` frontmatter key');
+  }
+
+  for (const section of REQUIRED_SECTIONS) {
+    if (topLevel.has(section)) continue;
+    // A file using `## Basic Usage` already gets the rename warning below; reporting
+    // it as a missing section too would send someone looking for content that's there.
+    if (section === 'Usage' && topLevel.has('Basic Usage')) continue;
+    add('error', 1, `Missing \`## ${section}\` section`, 'see references/structure.md');
+  }
+  if (!topLevel.has('Accessibility')) {
+    add(
+      'warn',
+      1,
+      'Missing `## Accessibility` section',
+      'keyboard, roles/ARIA, focus management — the part a type signature can never generate'
+    );
+  }
+
+  for (const h of headings) {
+    const advice = DISCOURAGED_HEADINGS[h.text];
+    if (advice && h.depth <= 3) add('warn', h.line, `Heading \`${h.text}\``, advice);
+  }
+
+  // --- <Signature> wiring -------------------------------------------------
+  const signatureTags = [...source.matchAll(/<Signature\s+[^>]*@component="([^"]+)"/g)];
+  if (topLevel.has('API') && signatureTags.length === 0) {
+    add(
+      'error',
+      headings.find((h) => h.text === 'API')?.line ?? 1,
+      '`## API` has no `<Signature />` tag',
+      'the API table is generated — see SKILL.md'
+    );
+  }
+  if (signatureTags.length > 0 && !/import Signature from/.test(frontmatter)) {
+    add(
+      'error',
+      1,
+      '`<Signature />` used but not imported in frontmatter',
+      "add `imports:\\n  - import Signature from 'site/components/signature';`"
+    );
+  }
+
+  // --- Fences -------------------------------------------------------------
+  for (const fence of collectFences(source)) {
+    if (fence.info === 'gjs preview') {
+      add('warn', fence.line, 'Legacy ```gjs preview fence', 'convert to ```gts preview');
+    }
+    const isPreview = /\bpreview\b/.test(fence.info);
+    if (!isPreview && /<template>/.test(fence.content) && fence.info !== '') {
+      add(
+        'warn',
+        fence.line,
+        `\`\`\`${fence.info} block contains a <template> but is not a preview`,
+        'add ` preview` so it renders live, or confirm it is intentionally static'
+      );
+    }
+    if (/<svg\b/.test(fence.content)) {
+      add(
+        'warn',
+        fence.line,
+        'Inline <svg> in a demo',
+        'import from `site/components/icons` instead, adding the icon there if it is missing'
+      );
+    }
+    const rawPalette =
+      /\b(?:bg|text|border|ring|fill|stroke)-(?:slate|gray|zinc|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}\b/.exec(
+        fence.content
+      );
+    if (rawPalette) {
+      add(
+        'warn',
+        fence.line,
+        `Raw Tailwind palette class \`${rawPalette[0]}\``,
+        'use semantic utilities so the demo adapts to dark mode — unless this demo is deliberately showing custom styling'
+      );
+    }
+    const badColor = new RegExp(
+      `\\b(?:${UTILITY_PREFIXES})-(?:${SEMANTIC_CATEGORIES})-\\d{2,3}\\b`
+    ).exec(fence.content);
+    if (badColor) {
+      add(
+        'error',
+        fence.line,
+        `Numbered color utility \`${badColor[0]}\``,
+        'Frontile has no numeric scale; use named levels (subtle/muted/soft/mild/DEFAULT/firm/strong/bolder)'
+      );
+    }
+  }
+
+  // --- Args drift ---------------------------------------------------------
+  const gtsPath = mdPath.replace(/\.md$/, '.gts');
+  if (existsSync(gtsPath)) {
+    const { args, complete } = parseComponentArgs(readFileSync(gtsPath, 'utf8'));
+    const gtsRel = relative(REPO_ROOT, gtsPath);
+
+    // Only check the component this file actually declares. Docs routinely document
+    // sub-components that live in their own files (PortalTarget in portal.md), and
+    // checking those against the wrong Args interface invents errors.
+    const own = basename(mdPath, '.md').replace(/(^|-)(\w)/g, (_, __, c) => c.toUpperCase());
+    const primary = signatureTags.map((t) => t[1]).find((name) => name === own) ?? null;
+    if (primary && complete) {
+      for (const [arg, line] of argsUsedOnTag(source, primary)) {
+        if (!args.has(arg)) {
+          add(
+            'error',
+            line,
+            `\`<${primary} @${arg}>\` is not an argument of ${basename(gtsRel)}`,
+            'renamed, removed, or a typo — check the Args interface'
+          );
+        }
+      }
+    }
+
+    const undocumented = [...args.values()].filter((a) => !a.documented).map((a) => a.name);
+    if (undocumented.length > 0) {
+      add(
+        'warn',
+        1,
+        `${undocumented.length} argument(s) have no JSDoc: ${undocumented.join(', ')}`,
+        `they render as blank rows in the API table — document them in ${gtsRel}`
+      );
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery + reporting
+// ---------------------------------------------------------------------------
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+/**
+ * A component is "expected to have docs" when its category barrel re-exports it —
+ * that's what makes it public API. Internal parts (`drawer/body.gts`, `table/cell.gts`)
+ * are documented inside their parent's page and shouldn't be reported as missing.
+ */
+function publiclyExported() {
+  const exported = new Set();
+  for (const category of readdirSync(COMPONENTS_DIR, { withFileTypes: true })) {
+    if (!category.isDirectory()) continue;
+    const barrel = join(COMPONENTS_DIR, category.name, 'index.ts');
+    if (!existsSync(barrel)) continue;
+    for (const m of readFileSync(barrel, 'utf8').matchAll(/from\s+'\.\/([\w-]+)'/g)) {
+      exported.add(join(COMPONENTS_DIR, category.name, `${m[1]}.gts`));
+    }
+  }
+  return exported;
+}
+
+function findOrphanComponents(files) {
+  const orphans = [];
+  const expected = publiclyExported();
+  for (const file of files) {
+    if (!expected.has(file)) continue;
+    if (!existsSync(file.replace(/\.gts$/, '.md'))) {
+      orphans.push({
+        file: relative(REPO_ROOT, file),
+        level: 'warn',
+        line: 1,
+        message: 'Component has no co-located `.md`',
+        hint: 'add one, or confirm it is an internal component that should not be documented'
+      });
+    }
+  }
+  return orphans;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const json = argv.includes('--json');
+  const paths = argv.filter((a) => !a.startsWith('--'));
+
+  let docs;
+  let findings = [];
+
+  if (paths.length > 0) {
+    docs = paths.map((p) => resolve(process.cwd(), p)).filter((p) => p.endsWith('.md'));
+  } else {
+    if (!existsSync(COMPONENTS_DIR)) {
+      console.error(`Cannot find ${COMPONENTS_DIR} — run from inside the frontile repo.`);
+      process.exit(2);
+    }
+    const all = walk(COMPONENTS_DIR);
+    docs = all.filter((f) => f.endsWith('.md'));
+    findings = findings.concat(findOrphanComponents(all));
+  }
+
+  for (const doc of docs) {
+    if (!existsSync(doc) || !statSync(doc).isFile()) continue;
+    findings = findings.concat(lintDoc(doc));
+  }
+
+  const errors = findings.filter((f) => f.level === 'error');
+  const warnings = findings.filter((f) => f.level === 'warn');
+
+  if (json) {
+    console.log(JSON.stringify({ docs: docs.length, errors, warnings }, null, 2));
+  } else {
+    const byFile = new Map();
+    for (const f of findings) {
+      if (!byFile.has(f.file)) byFile.set(f.file, []);
+      byFile.get(f.file).push(f);
+    }
+    for (const [file, items] of [...byFile].sort()) {
+      console.log(`\n${file}`);
+      for (const i of items.sort((a, b) => a.line - b.line)) {
+        const tag = i.level === 'error' ? 'error' : 'warn ';
+        console.log(`  ${tag} ${String(i.line).padStart(4)}  ${i.message}`);
+        if (i.hint) console.log(`               ↳ ${i.hint}`);
+      }
+    }
+    console.log(
+      `\n${docs.length} doc(s) checked — ${errors.length} error(s), ${warnings.length} warning(s)`
+    );
+  }
+
+  process.exit(errors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,7 +83,8 @@ module.exports = {
         'site/eslint.config.mjs',
         'test-app/eslint.config.mjs',
         'packages/*/rollup.config.mjs',
-        'scripts/**/*.mjs'
+        'scripts/**/*.mjs',
+        '.claude/skills/**/*.mjs'
       ],
       env: {
         node: true


### PR DESCRIPTION
Adds a project skill at `.claude/skills/frontile-docs/` for writing, reviewing, and auditing Frontile component docs, plus a zero-dependency linter.

**This has been through four rounds of A/B evaluation against no-skill baselines, and the rounds changed the skill substantially — including finding one place where it made results actively worse.** Details below, because the negative results are the useful part of the review.

## Why a skill at all

Component docs here are executable: Docfy renders every ` ```gts preview ` fence as a live component on frontile.dev. A wrong class is a broken page, not a typo.

The non-obvious mechanic it's built around: **the API table is generated.** `<Signature @component="Button" />` renders from `site/app/components/signature-data.ts`, which `generate-signature-data.js` builds from JSDoc on each component's `Args` interface. Documenting an argument is usually an edit to the `.gts`, and an undocumented one renders as a blank row.

## What the evals found

Four tasks, each run with the skill and with no skill at all, in isolated worktrees.

| task | with skill | baseline |
| --- | --- | --- |
| add `@isLoading` to Button | 7/7 | 7/7 — also added `@loadingLabel` for screen readers |
| write NativeSelect's page | 8/8 | 8/8 structurally, but **blank API table** — never touched the `.gts` |
| shorten collapsible.md | **worse**: demos 7 → 3 | demos 7 → 4 |
| write FormControl's page | 10 JSDoc blocks, fixed 3 sub-components | 10 JSDoc blocks, more demos, fixed 0 |

Two honest conclusions:

**The writing guidance wasn't earning its cost.** Baselines wrote correct JSDoc with `@defaultValue` unprompted, added real accessibility sections, and found source bugs. So `SKILL.md` now states up front that it is not a writing guide, and carries only pipeline mechanics and the places where sensible instincts go wrong here. 261 → 201 lines.

**The skill caused the demo deletion.** It said "cut verbose prose, merge redundant examples" and listed "three examples demonstrating one idea" as fat, with one soft bullet as counterweight. It got what it asked for. Rewritten so the asymmetry is reasoned — prose can be rewritten from source; a demo is executable proof, is what readers copy, and is the only part the site runs — and the caution is now a procedure: name the state a demo exercises, find a demo you're *keeping* that exercises it, and if you can't, it stays. Backed by `--since`, so it doesn't rest on prose being persuasive.

After the fix, on four docs (three held out from the rewrite):

```
collapsible.md   567 -> 379 lines, demos 7 -> 6 (removal named and justified)
form.md         1903 -> 1475 lines, demos 13 -> 13
form-control     new page, 0 -> 10 JSDoc blocks
portal.md        demos 5 -> 7
```

## What the linter checks

Required sections, fence languages, `<Signature>` wiring including tags naming a component that doesn't exist, arguments used in demos that aren't in the signature, arguments missing JSDoc, numbered color utilities, raw palette classes, inline `<svg>`, and with `--since`, demos removed since a git ref.

```bash
node .claude/skills/frontile-docs/scripts/lint-docs.mjs
node .claude/skills/frontile-docs/scripts/lint-docs.mjs --since HEAD path/to/doc.md
```

Zero dependencies, so it runs without `node_modules`; exits non-zero on errors for CI.

Demo loss **warns**, and errors only past a third of the page. As a flat error it forbade justified removal — a run that dropped one demo of seven and named its replacement was told it had failed, which is how you get `--since` switched off.

## Bugs this surfaced

- **13 demos** styled `bg-success-50` / `bg-warning-50` — not classes Frontile generates, so they were rendering unstyled in production (fixed in #480)
- A `<Signature>` tag naming a component that doesn't exist (#481)
- **47 arguments** with no JSDoc, rendering as blank API rows (#482)
- Three sub-components with descriptions written `/*` instead of `/**`, silently dropped by docgen
- A `gts` fence missing `preview` in `portal.md`, so that demo had been rendering dead
- `packages/theme/src/components/spinner.ts` has trailing commas inside the `sm`/`md` class strings, making those heights invalid — `md` is the default variant
- `form-control.gts` guards on `has-block "Description"` while the block is `description`, so `:description` never renders

The last two are component bugs, not docs bugs, and aren't fixed here.

## Review notes

Heuristics tuned against false positives: the orphan check only fires for components the category barrel re-exports (otherwise 30+ internal parts drown the output), and the unknown-argument check only validates the component matching the file's own name (checking `<PortalTarget>` against `portal.gts` produced a false error).

Also worth knowing: **regenerating signature data before a full `pnpm build` silently truncates the file** and blanks other packages' API tables. The skill previously told people to build only `frontile` first, which causes it. Now documented with the recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)