### PR TITLE
Convert legacy gjs fences to gts, fix a dead Signature tag

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -44,7 +44,7 @@ Add Frontile's theme configuration to your `app/styles/app.css` for Tailwind CSS
 
 ### Your First Component
 
-```gjs
+```gts
 import Component from '@glimmer/component';
 import { Button } from 'frontile';
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Add Frontile's theme configuration to your `app/styles/app.css` for Tailwind CSS
 
 ### Your First Component
 
-```gjs
+```gts
 import Component from '@glimmer/component';
 import { Button } from 'frontile';
 

--- a/packages/frontile/src/components/buttons/button-group.md
+++ b/packages/frontile/src/components/buttons/button-group.md
@@ -16,7 +16,7 @@ import { ButtonGroup } from 'frontile';
 
 ## Usage
 
-```gjs preview
+```gts preview
 import { ButtonGroup } from 'frontile';
 
 <template>
@@ -71,7 +71,7 @@ export default class Example extends Component {
 A common use case for `ButtonGroup` is to create a split button. 
 
 
-```gjs preview
+```gts preview
 import { ButtonGroup } from 'frontile';
 import { ChevronDownIcon } from 'site/components/icons';
 
@@ -88,7 +88,7 @@ import { ChevronDownIcon } from 'site/components/icons';
 You pass pass arguments to `ButtonGroup` and they will be passed in to each of the yielded component. 
 You can overwrite at the specific component as well.
 
-```gjs preview
+```gts preview
 import { ButtonGroup } from 'frontile';
 
 <template>

--- a/packages/frontile/src/components/buttons/button.md
+++ b/packages/frontile/src/components/buttons/button.md
@@ -15,7 +15,7 @@ import { Button } from 'frontile';
 
 ## Usage
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -25,7 +25,7 @@ import { Button } from 'frontile';
 
 ## Button Appearances
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -48,7 +48,7 @@ The default styles are mainly structural. Intent colors are applied as `color`.
 Every intent is available in every appearance. The label on each row is the
 `@appearance` value; the button labels are the `@intent` values.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { array } from '@ember/helper';
 
@@ -87,7 +87,7 @@ const intents = [
 
 ## Button Sizes
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -104,7 +104,7 @@ import { Button } from 'frontile';
 
 ## With Icons
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { DownloadIcon, ShareIcon, CheckIcon } from 'site/components/icons';
 
@@ -121,7 +121,7 @@ import { DownloadIcon, ShareIcon, CheckIcon } from 'site/components/icons';
 
 Icons can be placed before or after text. They inherit the button's text color via `currentColor`.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { DownloadIcon, ShareIcon, CheckIcon } from 'site/components/icons';
 
@@ -145,7 +145,7 @@ down the scale.
 Wrap the pair so the unit sits tight against the label: the button's own `gap`
 spaces the icon slots, while the wrapper's narrower gap spaces label from unit.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { StarIcon } from 'site/components/icons';
 
@@ -182,7 +182,7 @@ change with `@size`:
 | `xl`    | `text-strong-2xl` | `text-body-md`    | `gap-1`     |
 | `2xl`   | `text-strong-3xl` | `text-body-lg`    | `gap-1.5`   |
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -217,7 +217,7 @@ import { Button } from 'frontile';
 
 ## Disabled
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -239,7 +239,7 @@ Sometimes a button element is not ideal for a given case, but the same styles ar
 Frontile provides the option to disable rendering the `button` element, but instead it yields back an object with
 the class names it would use.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -253,7 +253,7 @@ import { Button } from 'frontile';
 
 You can compose appearance with intents and more to create the button that best fits your needs.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -267,7 +267,7 @@ import { Button } from 'frontile';
 
 You can use TailwindCSS classes to customize even further.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -279,7 +279,7 @@ import { Button } from 'frontile';
 
 Here is another example using TailwindCSS classes with the `custom` appearance.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 
 <template>
@@ -300,7 +300,7 @@ argument `@class` will override and merge TailwindCSS class names.
 
 The Button component supports press interactions through the `@onPress` callback, which provides cross-platform support for mouse, touch, and keyboard events.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/packages/frontile/src/components/buttons/chip.md
+++ b/packages/frontile/src/components/buttons/chip.md
@@ -16,7 +16,7 @@ import { Chip } from 'frontile';
 
 ## Usage
 
-```gjs preview
+```gts preview
 import { Chip } from 'frontile';
 
 <template>
@@ -26,7 +26,7 @@ import { Chip } from 'frontile';
 
 ## Chip Appearances
 
-```gjs preview
+```gts preview
 import { Chip } from 'frontile';
 
 <template>
@@ -40,7 +40,7 @@ import { Chip } from 'frontile';
 
 ## Chip Intents
 
-```gjs preview
+```gts preview
 import { Chip } from 'frontile';
 
 <template>
@@ -76,7 +76,7 @@ import { Chip } from 'frontile';
 
 ## Chip with Dots
 
-```gjs preview
+```gts preview
 import { Chip } from 'frontile';
 
 <template>
@@ -120,7 +120,7 @@ import { Chip } from 'frontile';
 
 If you pass the `@onClose` argument, the close button will be visible.
 
-```gjs preview
+```gts preview
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { Chip } from 'frontile';
@@ -150,7 +150,7 @@ export default class DemoComponent extends Component {
 
 ## Chip Sizes
 
-```gjs preview
+```gts preview
 import { Chip } from 'frontile';
 
 <template>
@@ -164,7 +164,7 @@ import { Chip } from 'frontile';
 
 You can pass the argument `@isDisabled` to represent a disabled chip.
 
-```gjs preview
+```gts preview
 import { Chip } from 'frontile';
 
 <template>
@@ -182,7 +182,7 @@ import { Chip } from 'frontile';
 
 You can also use TailwindCSS classes to customize even further.
 
-```gjs preview
+```gts preview
 import { Chip } from 'frontile';
 
 <template>

--- a/packages/frontile/src/components/buttons/close-button.md
+++ b/packages/frontile/src/components/buttons/close-button.md
@@ -43,7 +43,7 @@ import { CloseButton } from 'frontile';
 
 The CloseButton component supports press interactions through the `@onPress` callback, providing cross-platform support for mouse, touch, and keyboard events.
 
-```gjs preview
+```gts preview
 import { CloseButton } from 'frontile';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/packages/frontile/src/components/buttons/toggle-button.md
+++ b/packages/frontile/src/components/buttons/toggle-button.md
@@ -17,7 +17,7 @@ import { ToggleButton } from 'frontile';
 
 ## Usage
 
-```gjs preview
+```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
@@ -84,7 +84,7 @@ export default class Example extends Component {
 
 ## ToggleButton Sizes
 
-```gjs preview
+```gts preview
 import { ToggleButton } from 'frontile';
 
 <template>
@@ -100,7 +100,7 @@ import { ToggleButton } from 'frontile';
 
 You can pass the attribute `disabled` to disable a toggle button.
 
-```gjs preview
+```gts preview
 import { ToggleButton } from 'frontile';
 
 <template>

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -546,6 +546,6 @@ export default class NativeSelectExample extends Component {
 ## API
 
 <Signature @component="Select" />
-<Signature @component="SelectItem" />
+<Signature @component="ListboxItem" />
 <Signature @component="NativeSelect" />
 <Signature @component="NativeSelectItem" />

--- a/packages/frontile/src/components/overlays/popover.md
+++ b/packages/frontile/src/components/overlays/popover.md
@@ -28,7 +28,7 @@ import { Popover } from 'frontile';
 
 ## Usage
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { Popover } from 'frontile';
 
@@ -51,7 +51,7 @@ Prevents the user from tabbing outside of the popover content while it's open,
 ensuring better accessibility and usability. To enable this option, ensure a
 focusable element is rendered at all times within the popover content.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { Popover } from 'frontile';
 import { Input } from 'frontile';
@@ -79,7 +79,7 @@ such as `open`, `close`, or `toggle`, offering convenient control over the popov
 
 In the example below, the popover is showned when the user hovers the trigger button.
 
-```gjs preview
+```gts preview
 import { on } from '@ember/modifier';
 import { Popover } from 'frontile';
 import { Button } from 'frontile';
@@ -107,7 +107,7 @@ import { Button } from 'frontile';
 Prevent scrolling of the main window when the popover is open, focusing the
 user's attention on the popover content.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { Popover } from 'frontile';
 import { Input } from 'frontile';
@@ -131,7 +131,7 @@ import { Input } from 'frontile';
 
 Choose from various backdrop options such as none, faded, blur, or transparent.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { Popover } from 'frontile';
 import { Input } from 'frontile';
@@ -165,7 +165,7 @@ const backdrops = ['none', 'faded', 'blur', 'transparent'];
 Easily specify the placement of the popover relative to its trigger element,
 ensuring optimal positioning in various UI layouts.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { Popover } from 'frontile';
 
@@ -205,7 +205,7 @@ const placements = [
 The size of the content. It can be overwritten by passing width Tailwind classes
 to the `Content` yielded component.
 
-```gjs preview
+```gts preview
 import { Button } from 'frontile';
 import { Popover } from 'frontile';
 
@@ -289,7 +289,7 @@ added overlay and closes it, ensuring a natural and intuitive user experience.
 Similarly, clicking outside of the overlays prioritizes the most recent addition,
 closing it before proceeding to the underlying layers.
 
-```gjs preview
+```gts preview
 import { Popover } from 'frontile';
 import { Button } from 'frontile';
 

--- a/packages/frontile/src/components/overlays/portal.md
+++ b/packages/frontile/src/components/overlays/portal.md
@@ -24,7 +24,7 @@ The `Portal` and `PortalTarget` components are fully compatible with server-side
 
 The `Portal` component renders its content to a specified target or, by default, to the closest available target. You can use it to decouple your UI elements from their usual place in the DOM.
 
-```gjs
+```gts
 import { Portal, PortalTarget } from 'frontile';
 
 <template>
@@ -40,7 +40,7 @@ import { Portal, PortalTarget } from 'frontile';
 
 You can also nest `Portal` components within each other. The inner `Portal` elements can append to the parent portal if configured that way.
 
-```gjs preview
+```gts preview
 import { Portal, PortalTarget } from 'frontile';
 
 <template>
@@ -72,7 +72,7 @@ In this example, the inner `Portal` renders its content inside the destination o
 
 The `PortalTarget` component is used to create named or unnamed locations where content can be rendered using the `Portal` component. This allows for more control over where a portal's content is displayed.
 
-```gjs preview
+```gts preview
 import { Portal, PortalTarget } from 'frontile';
 
 <template>
@@ -103,7 +103,7 @@ The `Portal` component has a `target` argument that allows you to specify where 
 
 If you set the `@renderInPlace` argument to `true`, the content will be rendered inline without creating a new portal.
 
-```gjs preview
+```gts preview
 import { Portal, PortalTarget } from 'frontile';
 
 <template>
@@ -119,7 +119,7 @@ import { Portal, PortalTarget } from 'frontile';
 
 You can use a target element directly by passing its ID or a reference to the `@target` argument.
 
-```gjs preview
+```gts preview
 import { Portal, PortalTarget } from 'frontile';
 
 <template>
@@ -140,7 +140,7 @@ In this example, the portal content is rendered inside the element with the ID `
 
 By default, `Portal` components append their content to the parent portal if one exists. This behavior can be disabled by setting the `@appendToParentPortal` argument to `false`.
 
-```gjs preview
+```gts preview
 import { Portal, PortalTarget } from 'frontile';
 
 <template>

--- a/packages/frontile/src/components/status/progress-bar.md
+++ b/packages/frontile/src/components/status/progress-bar.md
@@ -16,7 +16,7 @@ import { ProgressBar } from 'frontile';
 
 ## Usage
 
-```gjs preview
+```gts preview
 import { ProgressBar } from 'frontile';
 
 <template><ProgressBar @progress={{50}} @label='Progress' /></template>
@@ -24,7 +24,7 @@ import { ProgressBar } from 'frontile';
 
 ## ProgressBar Intents
 
-```gjs preview
+```gts preview
 import { ProgressBar } from 'frontile';
 
 <template>
@@ -66,7 +66,7 @@ import { ProgressBar } from 'frontile';
 
 ## ProgressBar Sizes
 
-```gjs preview
+```gts preview
 import { ProgressBar } from 'frontile';
 
 <template>
@@ -96,7 +96,7 @@ import { ProgressBar } from 'frontile';
 
 ## ProgressBar Radius
 
-```gjs preview
+```gts preview
 import { ProgressBar } from 'frontile';
 
 <template>
@@ -135,7 +135,7 @@ import { ProgressBar } from 'frontile';
 
 ## ProgressBar Labels
 
-```gjs preview
+```gts preview
 import { ProgressBar } from 'frontile';
 import { hash } from '@ember/helper';
 
@@ -163,7 +163,7 @@ import { hash } from '@ember/helper';
 
 ## ProgressBar Description
 
-```gjs preview
+```gts preview
 import { ProgressBar } from 'frontile';
 
 <template>
@@ -179,7 +179,7 @@ import { ProgressBar } from 'frontile';
 
 You can pass the argument `@isIndeterminate` to represent when the effort or duration can not be calculated
 
-```gjs preview
+```gts preview
 import { ProgressBar } from 'frontile';
 
 <template>


### PR DESCRIPTION
Third in the stack: #479 (skill) → #480 (broken demos) → this. **Review the two below it first.**

Two mechanical corrections to the docs' machine-readable parts. No demo code changed.

## Fence language

52 demo blocks were still tagged ` ```gjs `. The project standard is `.gts` — CLAUDE.md says "Prefer `.gts` over `.gjs` for all components" — and the demo source is displayed verbatim on the site, so every one of these was advertising the legacy format to readers of `button.md`, `chip.md`, `popover.md`, `portal.md`, `progress-bar.md`, and the two "Your First Component" examples in the getting-started guides.

Tag-only change: ` ```gjs preview ` → ` ```gts preview `, ` ```gjs ` → ` ```gts `.

## A Signature tag that resolved to nothing

`select.md` had `<Signature @component="SelectItem" />`. No such component exists — `Select`'s `Blocks` extend `ListboxSignature`'s and it yields `l.Item`, so it's `ListboxItem`. The docfy plugin logged `No component found for <Signature @component="SelectItem" />` on every build and the page rendered an empty API entry.

This is exactly one instance across all docs; #479 gained a linter check for it so it can't come back silently.

## Verification

A passing build wasn't enough here — a broken preview can degrade to a plain code block without failing anything. So I ran the site dev server and inspected the rendered page:

- `/docs/components/buttons/button` — **56 `.docfy-demo` containers**, **23 live Frontile buttons** carrying real theme classes (`inline-flex items-center justify-center [&_svg]:size-[1em] font-header`), confirming the demos still execute rather than rendering as source
- No console errors
- No remaining `No component found` warning in the dev-server output
- `cd site && pnpm build` clean
- Linter: **0 errors, 68 warnings** (down from 117 before this stack)

## Remaining after this

- 20 docs with no `## Accessibility` section
- 21 discouraged headings (`## Key Features`, `## Important Notes`)
- ~50 component arguments with no JSDoc, rendering as blank API rows
- 8 publicly-exported components with no doc page

🤖 Generated with [Claude Code](https://claude.com/claude-code)