### PR TITLE
fix(theme): drop stray commas from Spinner size classes

### DIFF
--- a/packages/theme/src/components/spinner.ts
+++ b/packages/theme/src/components/spinner.ts
@@ -4,8 +4,8 @@ const spinner = tv({
   variants: {
     size: {
       xs: 'w-4 h-4',
-      sm: 'w-6 h-6,',
-      md: 'w-8 h-8,',
+      sm: 'w-6 h-6',
+      md: 'w-8 h-8',
       lg: 'w-10 h-10',
       xl: 'w-12 h-12'
     },

--- a/test-app/tests/integration/components/utilities/spinner-test.gts
+++ b/test-app/tests/integration/components/utilities/spinner-test.gts
@@ -13,6 +13,20 @@ module(
       assert.dom('[data-test-id="spinner"]').exists();
     });
 
+    test('it adds the size classes, including the default md size', async function (assert) {
+      await render(
+        <template>
+          <Spinner data-test-id="default" />
+          <Spinner @size="sm" data-test-id="sm" />
+        </template>
+      );
+
+      assert.dom('[data-test-id="default"]').hasClass('w-8');
+      assert.dom('[data-test-id="default"]').hasClass('h-8');
+      assert.dom('[data-test-id="sm"]').hasClass('w-6');
+      assert.dom('[data-test-id="sm"]').hasClass('h-6');
+    });
+
     test('it adds the class for the secondary intent', async function (assert) {
       await render(
         <template>


### PR DESCRIPTION
## Problem

`packages/theme/src/components/spinner.ts` had trailing commas *inside* two of the `size` variant strings:

```ts
sm: 'w-6 h-6,',
md: 'w-8 h-8,',
```

`h-6,` and `h-8,` are not valid Tailwind classes, so `<Spinner @size="sm" />` and `<Spinner @size="md" />` rendered with a width but no height. `md` is the `defaultVariant`, so **every Spinner rendered without an explicit size** was affected — including the loading spinners in Select, Autocomplete, Table, and Modal.

## Change

- Removed the stray commas from both strings.
- Added an integration test asserting `w-8 h-8` on the default Spinner and `w-6 h-6` on `@size="sm"`. It fails against the old strings.

Checked the co-located component docs and the test suite for anything compensating for the missing height — nothing was. The `h-24 w-24` in the `spinner.md` `@class` demo is a deliberate override example, not a workaround.

## Verification

```bash
pnpm --filter @frontile/theme build
cd test-app && CI=true pnpm ember test --filter="Spinner"
```

7 tests, 7 pass, 0 fail. `pnpm --filter @frontile/theme lint:types` clean; Prettier clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)