### PR TITLE
Add docs pages for FormControl and NativeSelect

### DIFF
--- a/packages/frontile/src/components/forms/form-control.gts
+++ b/packages/frontile/src/components/forms/form-control.gts
@@ -7,18 +7,75 @@ import Label, { type LabelSignature } from './label';
 import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 interface FormControlSharedArgs {
+  /**
+   * The label text rendered above the control and associated with it via `for`.
+   * Use the `:label` block instead when the label needs markup.
+   */
   label?: string;
+
+  /**
+   * Whether the field is required. Adds an asterisk to the label; it does not
+   * set the `required` attribute on the control itself.
+   *
+   * @defaultValue false
+   */
   isRequired?: boolean;
+
+  /**
+   * Help text rendered between the label and the control, and referenced by the
+   * ids `describedBy` returns.
+   */
   description?: string;
+
+  /**
+   * Validation messages for the field. A non-empty value also marks the control
+   * invalid, and an array is joined with `; ` when displayed.
+   */
   errors?: string[] | string;
+
+  /**
+   * Marks the control invalid without supplying messages, for validation that is
+   * reported elsewhere.
+   *
+   * @defaultValue false
+   */
   isInvalid?: boolean;
+
+  /**
+   * Whether the field is disabled. FormControl passes this through for styling;
+   * the control it wraps is responsible for the `disabled` attribute.
+   *
+   * @defaultValue false
+   */
   isDisabled?: boolean;
 }
 
 interface Args extends FormControlSharedArgs {
+  /**
+   * The id given to the control, and the base for the description and feedback
+   * ids. Generated when omitted, so pass one only when something outside the
+   * block has to reference it.
+   */
   id?: string;
+
+  /**
+   * The size of the label, description and feedback text.
+   *
+   * @defaultValue 'md'
+   */
   size?: 'sm' | 'md' | 'lg';
+
+  /**
+   * Suppresses the automatic error feedback, for when the block renders the
+   * yielded `Feedback` itself or places messages elsewhere.
+   *
+   * @defaultValue false
+   */
   preventErrorFeedback?: boolean;
+
+  /**
+   * Class names for the wrapping element.
+   */
   class?: string;
 }
 

--- a/packages/frontile/src/components/forms/form-control.md
+++ b/packages/frontile/src/components/forms/form-control.md
@@ -1,0 +1,197 @@
+---
+label: New
+imports:
+  - import Signature from 'site/components/signature';
+---
+
+# FormControl
+
+FormControl provides the label, description and error feedback that surround a form
+control, and the ids that tie them together for assistive technology. Reach for it when
+you need a field Frontile doesn't ship — a file picker, a range slider, a third-party
+date picker — and want it to look and announce itself like `Input`, `Select` and
+`Checkbox`, which are all built on it.
+
+## Import
+
+```js
+import { FormControl } from 'frontile';
+```
+
+## Usage
+
+Pass `@label` and give the wrapped control the yielded `id`. That single wiring is what
+associates the rendered `<label>` with your control.
+
+```gts preview
+import { FormControl } from 'frontile';
+
+<template>
+  <FormControl @label='Attachment' as |c|>
+    <input
+      type='file'
+      id={{c.id}}
+      class='text-neutral-strong font-body text-base'
+    />
+  </FormControl>
+</template>
+```
+
+## Description and Errors
+
+`@description` renders help text above the control and `@errors` renders messages below
+it. Neither is connected to the control on its own: the block is responsible for the
+ARIA, using the two values FormControl yields for exactly that.
+
+- `c.describedBy` takes two flags — whether there is a description, and whether there is
+  feedback — and returns the matching ids for `aria-describedby`.
+- `c.isInvalid` is true when `@isInvalid` is set or `@errors` is non-empty, and is what
+  you put on `aria-invalid`.
+
+```gts preview
+import { FormControl } from 'frontile';
+
+<template>
+  <FormControl
+    @label='Budget'
+    @description='Whole dollars, no separators.'
+    @errors='Enter an amount above 0'
+    as |c|
+  >
+    <input
+      type='number'
+      id={{c.id}}
+      value='0'
+      aria-invalid={{if c.isInvalid 'true'}}
+      aria-describedby={{c.describedBy true c.isInvalid}}
+      class='bg-surface-input text-neutral-strong border-neutral-soft aria-invalid:border-danger-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
+    />
+  </FormControl>
+</template>
+```
+
+## Placing the Parts Yourself
+
+The default order — label, description, control, feedback — is what you get from the
+string arguments. When a control needs a different order, such as a checkbox whose label
+sits after it, use the yielded `Label`, `Description` and `Feedback` components instead
+and drop the corresponding argument. They arrive with `for`, `id`, `size` and (for
+`Feedback`) the error messages already bound.
+
+`@preventErrorFeedback` suppresses the automatic feedback at the bottom so `c.Feedback`
+is the only copy rendered.
+
+```gts preview
+import { FormControl } from 'frontile';
+
+<template>
+  <FormControl
+    @errors='Accept the terms to continue'
+    @preventErrorFeedback={{true}}
+    as |c|
+  >
+    <c.Feedback />
+    <div class='flex items-center gap-2'>
+      <input
+        type='checkbox'
+        id={{c.id}}
+        aria-invalid={{if c.isInvalid 'true'}}
+        aria-describedby={{c.describedBy false c.isInvalid}}
+      />
+      <c.Label>I accept the terms</c.Label>
+    </div>
+  </FormControl>
+</template>
+```
+
+When the label itself needs markup rather than a plain string, use the `:label` block —
+it renders inside the same `<label>` element that `@label` would have produced.
+
+```gts preview
+import { FormControl } from 'frontile';
+
+<template>
+  <FormControl @isRequired={{true}}>
+    <:label>
+      API token
+      <a href='#docs' class='text-primary underline'>Where do I find this?</a>
+    </:label>
+    <:default as |c|>
+      <input
+        id={{c.id}}
+        required
+        class='bg-surface-input text-neutral-strong border-neutral-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
+      />
+    </:default>
+  </FormControl>
+</template>
+```
+
+## Sizes
+
+`@size` scales the label, description and feedback text. It does not touch the control
+inside the block — size that yourself so the two stay in proportion.
+
+```gts preview
+import { array } from '@ember/helper';
+import { FormControl } from 'frontile';
+
+<template>
+  <div class='flex flex-col gap-6'>
+    {{#each (array 'sm' 'md' 'lg') as |size|}}
+      <FormControl
+        @size={{size}}
+        @label='Team name'
+        @description='Shown to everyone in the workspace.'
+        @errors='This name is taken'
+        as |c|
+      >
+        <input
+          id={{c.id}}
+          value='Platform'
+          aria-invalid='true'
+          aria-describedby={{c.describedBy true true}}
+          class='bg-surface-input text-neutral-strong border-neutral-soft aria-invalid:border-danger-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
+        />
+      </FormControl>
+    {{/each}}
+  </div>
+</template>
+```
+
+## Accessibility
+
+FormControl renders a plain `<div>` and has no keyboard behavior of its own — the control
+you place inside it keeps whatever behavior it already had. What FormControl does is hand
+you the pieces needed to describe that control correctly, and it is the block's job to
+apply them:
+
+| Yielded value   | Where it goes                                                                                 |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| `c.id`          | The control's `id`. The rendered `<label>` already points at it with `for`                    |
+| `c.isInvalid`   | `aria-invalid` on the control                                                                 |
+| `c.describedBy` | `aria-describedby` on the control, called with whether a description and feedback are present |
+
+Notes worth knowing before you rely on it:
+
+- **Required is visual.** `@isRequired` adds an asterisk to the label. Set `required` or
+  `aria-required` on the control yourself.
+- **Disabled is visual.** `@isDisabled` is passed through for styling only; the control
+  owns its own `disabled` attribute.
+- **Error feedback is announced.** The feedback element carries `aria-live`, assertive at
+  the default `danger` intent and polite otherwise, so messages appearing after the
+  initial render are read out.
+- **It groups nothing.** There is no `role='group'` and the label's `for` can only point
+  at one control, so wrapping several inputs in a single FormControl leaves them
+  unlabelled. Use `CheckboxGroup` or `RadioGroup`, or add `role='group'` and
+  `aria-labelledby` yourself.
+
+## API
+
+<Signature @component="FormControl" />
+
+<Signature @component="Label" />
+
+<Signature @component="FormDescription" />
+
+<Signature @component="FormFeedback" />

--- a/packages/frontile/src/components/forms/form-description.gts
+++ b/packages/frontile/src/components/forms/form-description.gts
@@ -3,12 +3,22 @@ import { useStyles, type FormDescriptionVariants } from '@frontile/theme';
 
 interface FormDescriptionSignature {
   Args: {
+    /**
+     * The id of the description element, referenced by the control's
+     * `aria-describedby`.
+     */
     id?: string;
-    /*
+
+    /**
+     * The size of the description text.
+     *
      * @defaultValue 'md'
      */
     size?: FormDescriptionVariants['size'];
 
+    /**
+     * Class names for the description element, merged with the theme's.
+     */
     class?: string;
   };
   Element: HTMLDivElement;

--- a/packages/frontile/src/components/forms/form-feedback.gts
+++ b/packages/frontile/src/components/forms/form-feedback.gts
@@ -3,22 +3,35 @@ import { useStyles, type FormFeedbackVariants } from '@frontile/theme';
 
 interface FormFeedbackSignature {
   Args: {
+    /**
+     * The id of the feedback element, referenced by the control's
+     * `aria-describedby`.
+     */
     id?: string;
-    /*
-     * A list of messages or a single message string
+
+    /**
+     * A list of messages or a single message string. An array is joined with `; `.
      */
     messages?: string[] | string;
 
-    /*
-     * The intent of the feedback
+    /**
+     * The intent of the feedback, which also decides whether it is announced
+     * assertively (`danger`) or politely.
+     *
      * @defaultValue 'danger'
      */
     intent?: FormFeedbackVariants['intent'];
 
-    /*
+    /**
+     * The size of the feedback text.
+     *
      * @defaultValue 'md'
      */
     size?: FormFeedbackVariants['size'];
+
+    /**
+     * Class names for the feedback element, merged with the theme's.
+     */
     class?: string;
   };
   Element: HTMLDivElement;

--- a/packages/frontile/src/components/forms/label.gts
+++ b/packages/frontile/src/components/forms/label.gts
@@ -13,10 +13,16 @@ interface LabelSignature {
      */
     for?: string;
 
-    /*
+    /**
+     * The size of the label text.
+     *
      * @defaultValue 'md'
      */
     size?: LabelVariants['size'];
+
+    /**
+     * Class names for each slot of the component, merged with the theme's.
+     */
     classes?: SlotsToClasses<LabelSlots>;
 
     /**
@@ -24,8 +30,9 @@ interface LabelSignature {
      */
     class?: string;
 
-    /*
+    /**
      * Whether the field is required or not, if true, an asterisk will be added to the label.
+     *
      * @defaultValue false
      */
     isRequired?: boolean;

--- a/packages/frontile/src/components/forms/native-select.gts
+++ b/packages/frontile/src/components/forms/native-select.gts
@@ -24,12 +24,50 @@ type ItemCompBounded = WithBoundArgs<typeof NativeSelectItem, 'manager'>;
 
 // Base interface for shared properties
 interface BaseArgs<T> extends FormControlSharedArgs {
+  /**
+   * Keys of the options that cannot be selected. Disabled options are still
+   * rendered and announced, they just cannot be picked.
+   */
   disabledKeys?: string[];
+
+  /**
+   * Renders an extra empty option, letting the user clear the selection.
+   * Label it with the placeholder argument.
+   *
+   * @defaultValue false
+   */
   allowEmpty?: boolean;
+
+  /**
+   * Collection used to render the options. Strings and numbers become both the
+   * key and the label; objects use key or id for the key and label, value,
+   * name or title for the label. Use the :item block when your data does not
+   * follow those conventions.
+   */
   items?: T[];
+
+  /**
+   * Id applied to the select element and referenced by its label. One is
+   * generated when omitted.
+   */
   id?: string;
+
+  /**
+   * Name of the select element, used when the surrounding form is submitted.
+   */
   name?: string;
+
+  /**
+   * The size of the control.
+   *
+   * @defaultValue 'md'
+   */
   size?: NativeSelectVariants['size'];
+
+  /**
+   * Per-slot class overrides: base, innerContainer, input, startContent,
+   * endContent and icon.
+   */
   classes?: SlotsToClasses<NativeSelectSlots>;
 
   /**
@@ -37,6 +75,10 @@ interface BaseArgs<T> extends FormControlSharedArgs {
    */
   placeholder?: string;
 
+  /**
+   * Called with the key of an option whenever it is acted upon, including when
+   * the same option is picked again. Use onSelectionChange to track state.
+   */
   onAction?: (key: string) => void;
 
   /**
@@ -65,17 +107,56 @@ interface BaseArgs<T> extends FormControlSharedArgs {
 
 // Single selection mode interface
 interface SingleNativeSelectArgs<T> extends BaseArgs<T> {
+  /**
+   * Whether one option or several can be selected. Multiple renders the native
+   * multi-select list box and switches to selectedKeys.
+   *
+   * @defaultValue 'single'
+   */
   selectionMode?: 'single' | undefined;
+
+  /**
+   * The selected key in single selection mode. The component is controlled:
+   * update this from onSelectionChange.
+   */
   selectedKey?: string | null;
+
+  /**
+   * Not available in single selection mode; use selectedKey.
+   */
   selectedKeys?: never;
+
+  /**
+   * Called with the newly selected key, or null when the selection is cleared
+   * through the allowEmpty option.
+   */
   onSelectionChange?: (key: string | null) => void;
 }
 
 // Multiple selection mode interface
 interface MultipleNativeSelectArgs<T> extends BaseArgs<T> {
+  /**
+   * Whether one option or several can be selected. Multiple renders the native
+   * multi-select list box and switches to selectedKeys.
+   *
+   * @defaultValue 'single'
+   */
   selectionMode: 'multiple';
+
+  /**
+   * Not available in multiple selection mode; use selectedKeys.
+   */
   selectedKey?: never;
+
+  /**
+   * The selected keys in multiple selection mode. The component is controlled:
+   * update this from onSelectionChange.
+   */
   selectedKeys?: string[];
+
+  /**
+   * Called with every selected key each time the selection changes.
+   */
   onSelectionChange?: (keys: string[]) => void;
 }
 
@@ -299,8 +380,22 @@ class NativeSelect<T = unknown> extends Component<NativeSelectSignature<T>> {
 
 export interface SelectItemSignature {
   Args: {
+    /**
+     * The ListManager that tracks selection for the parent select. It is bound
+     * for you on the yielded Item component.
+     */
     manager: ListManager;
+
+    /**
+     * Value of the rendered option, and the key reported by onSelectionChange,
+     * selectedKey or selectedKeys, and disabledKeys.
+     */
     key: string;
+
+    /**
+     * Text representation of the option, used for matching. Defaults to the
+     * option's rendered text content.
+     */
     textValue?: string;
   };
   Element: HTMLOptionElement;

--- a/packages/frontile/src/components/forms/native-select.md
+++ b/packages/frontile/src/components/forms/native-select.md
@@ -1,0 +1,283 @@
+---
+label: New
+imports:
+  - import Signature from 'site/components/signature';
+---
+
+# NativeSelect
+
+A select built on the browser's own `<select>` element, styled to match the rest of the form components. Reach for it when you want the platform's picker — the native dropdown on mobile, the OS list box on desktop — instead of the custom listbox that [Select](./select) renders.
+
+## Import
+
+```js
+import { NativeSelect } from 'frontile';
+```
+
+## Usage
+
+Pass a collection to `@items` and read the selection back from `@onSelectionChange`. Strings and numbers are used as both the key and the label.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { NativeSelect } from 'frontile';
+
+const animals = ['Cheetah', 'Crocodile', 'Elephant'];
+
+export default class NativeSelectUsage extends Component {
+  @tracked selectedKey: string | null = 'Cheetah';
+
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
+  };
+
+  <template>
+    <NativeSelect
+      @label='Favorite animal'
+      @items={{animals}}
+      @selectedKey={{this.selectedKey}}
+      @onSelectionChange={{this.onSelectionChange}}
+    />
+    <p class='mt-4 text-sm text-neutral'>Selected: {{this.selectedKey}}</p>
+  </template>
+}
+```
+
+The component is controlled. `@selectedKey` is what the user sees selected, so it has to be updated from `@onSelectionChange` — without that, the browser's change is reverted on the next render.
+
+## Items
+
+Objects work too. The key comes from `key` or `id`, and the label from `label`, `value`, `name` or `title`. Anything else needs the `:item` block, which yields the raw item along with an `Item` component to render it with.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { NativeSelect } from 'frontile';
+
+const countries = [
+  { code: 'br', country: 'Brazil' },
+  { code: 'ca', country: 'Canada' },
+  { code: 'jp', country: 'Japan' }
+];
+
+export default class NativeSelectItemBlock extends Component {
+  @tracked selectedKey: string | null = null;
+
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
+  };
+
+  <template>
+    <NativeSelect
+      @label='Country'
+      @items={{countries}}
+      @selectedKey={{this.selectedKey}}
+      @onSelectionChange={{this.onSelectionChange}}
+    >
+      <:item as |o|>
+        <o.Item @key={{o.item.code}}>{{o.item.country}}</o.Item>
+      </:item>
+    </NativeSelect>
+    <p class='mt-4 text-sm text-neutral'>Selected: {{this.selectedKey}}</p>
+  </template>
+}
+```
+
+When the options are a fixed, hand-written list, drop `@items` entirely and use the default block, which yields the same `Item` component.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { array } from '@ember/helper';
+import { NativeSelect } from 'frontile';
+
+export default class NativeSelectStaticItems extends Component {
+  @tracked selectedKey: string | null = 'standard';
+
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
+  };
+
+  <template>
+    <NativeSelect
+      @label='Shipping'
+      @selectedKey={{this.selectedKey}}
+      @disabledKeys={{(array 'overnight')}}
+      @onSelectionChange={{this.onSelectionChange}}
+      as |l|
+    >
+      <l.Item @key='standard'>Standard — 5 business days</l.Item>
+      <l.Item @key='express'>Express — 2 business days</l.Item>
+      <l.Item @key='overnight'>Overnight — unavailable</l.Item>
+    </NativeSelect>
+  </template>
+}
+```
+
+`@disabledKeys` renders those options as disabled: still listed, still announced, not selectable.
+
+## Empty Option
+
+A native `<select>` always has something selected, so an initial "nothing chosen" state has to be a real option. `@allowEmpty` adds one, labeled with `@placeholder`, and picking it reports `null`.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { NativeSelect } from 'frontile';
+
+const roles = ['Owner', 'Editor', 'Viewer'];
+
+export default class NativeSelectAllowEmpty extends Component {
+  @tracked selectedKey: string | null = null;
+
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
+  };
+
+  <template>
+    <NativeSelect
+      @label='Role'
+      @items={{roles}}
+      @allowEmpty={{true}}
+      @placeholder='Select a role'
+      @selectedKey={{this.selectedKey}}
+      @onSelectionChange={{this.onSelectionChange}}
+    />
+    <p class='mt-4 text-sm text-neutral'>Selected:
+      {{if this.selectedKey this.selectedKey 'none'}}</p>
+  </template>
+}
+```
+
+## Multiple Selection
+
+`@selectionMode='multiple'` renders the native multi-select list box. The state arguments change with it: use `@selectedKeys` instead of `@selectedKey`, and `@onSelectionChange` receives an array. Mixing them logs a warning.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { NativeSelect } from 'frontile';
+
+const languages = ['Elixir', 'Go', 'Rust', 'TypeScript'];
+
+export default class NativeSelectMultiple extends Component {
+  @tracked selectedKeys: string[] = ['Rust'];
+
+  onSelectionChange = (keys: string[]) => {
+    this.selectedKeys = keys;
+  };
+
+  <template>
+    <NativeSelect
+      @label='Languages'
+      @description='Hold Cmd or Ctrl to select more than one.'
+      @selectionMode='multiple'
+      @items={{languages}}
+      @selectedKeys={{this.selectedKeys}}
+      @onSelectionChange={{this.onSelectionChange}}
+    />
+  </template>
+}
+```
+
+## Sizes
+
+`@size` accepts `sm`, `md` (the default) and `lg`, matching the other form controls.
+
+```gts preview
+import { array, concat } from '@ember/helper';
+import { NativeSelect } from 'frontile';
+
+const plans = ['Basic', 'Pro'];
+
+<template>
+  <div class='flex flex-col gap-4'>
+    {{#each (array 'sm' 'md' 'lg') as |size|}}
+      <NativeSelect
+        @label={{concat 'Plan (' size ')'}}
+        @size={{size}}
+        @items={{plans}}
+      />
+    {{/each}}
+  </div>
+</template>
+```
+
+## Description and Validation
+
+NativeSelect is built on the same `FormControl` as the other form components, so `@label`, `@description`, `@isRequired`, `@errors` and `@isInvalid` behave identically. Errors are wired to the control through `aria-describedby` and set `aria-invalid`.
+
+```gts preview
+import { array } from '@ember/helper';
+import { NativeSelect } from 'frontile';
+
+const environments = ['Development', 'Staging', 'Production'];
+
+<template>
+  <div class='flex flex-col gap-4'>
+    <NativeSelect
+      @label='Environment'
+      @description='Where the build will be deployed.'
+      @isRequired={{true}}
+      @items={{environments}}
+    />
+
+    <NativeSelect
+      @label='Environment'
+      @errors={{(array 'Select an environment to continue.')}}
+      @allowEmpty={{true}}
+      @placeholder='Select an environment'
+      @items={{environments}}
+    />
+  </div>
+</template>
+```
+
+## Start and End Content
+
+The `:startContent` and `:endContent` named blocks place content inside the control. The chevron the component draws stays at the end, after whatever `:endContent` yields.
+
+By default pointer events pass through end content to the select and are captured by start content; `@startContentPointerEvents` and `@endContentPointerEvents` flip that when the content itself needs to be clickable.
+
+```gts preview
+import { NativeSelect } from 'frontile';
+import { SearchIcon } from 'site/components/icons';
+
+const teams = ['Design', 'Engineering', 'Support'];
+
+<template>
+  <NativeSelect @label='Team' @items={{teams}}>
+    <:startContent>
+      <SearchIcon class='size-icon-md text-neutral' />
+    </:startContent>
+  </NativeSelect>
+</template>
+```
+
+## Accessibility
+
+NativeSelect renders a real `<select>`, so keyboard behavior, type-ahead and the mobile picker are the browser's own and match whatever the user's platform does elsewhere. That is the main reason to choose it over `Select`.
+
+| Key                                                                                    | Behavior                                          |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| <kbd>Space</kbd> / <kbd>Alt</kbd> + <kbd>↓</kbd>                                       | Open the picker (browser dependent)               |
+| <kbd>↑</kbd> / <kbd>↓</kbd>                                                            | Move through options                              |
+| <kbd>Home</kbd> / <kbd>End</kbd>                                                       | First / last option                               |
+| Printable characters                                                                   | Jump to the option starting with those characters |
+| <kbd>Enter</kbd> / <kbd>Esc</kbd>                                                      | Commit / dismiss the open picker                  |
+| <kbd>Cmd</kbd> / <kbd>Ctrl</kbd> + click, <kbd>Shift</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> | Extend the selection in `multiple` mode           |
+
+The component's own responsibilities:
+
+- `@label` renders a `<label>` bound to the select by `id`. Always provide it — there is no visual affordance that substitutes for it, and an unlabeled select is announced only by its current value.
+- `@description` and `@errors` are referenced through `aria-describedby`, and an invalid control gets `aria-invalid="true"`.
+- `@disabledKeys` sets the `disabled` attribute on the corresponding `<option>`, which screen readers announce as unavailable.
+- The chevron is decorative and is not exposed to assistive technology.
+
+For multiple selection, say so in `@description` as the demo above does: nothing in the native list box announces that Cmd or Ctrl extends the selection, and it is the most commonly missed interaction in the component.
+
+## API
+
+<Signature @component="NativeSelect" />
+<Signature @component="NativeSelectItem" />

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -513,9 +513,7 @@ export default class CustomContentBlocksSelect extends Component {
 
 ### Using NativeSelect
 
-The `NativeSelect` component is a lightweight version of the select component that renders a native HTML `<select>` element. This is especially useful when you need maximum accessibility or want to rely on the browser’s native behavior.
-It supports most of the same features as the custom `Select` component, such as passing an array of items, managing selection state, and handling selection changes.
-By using `NativeSelect` directly, you can simplify your markup while still benefiting from Frontile’s APIs.
+When you want the browser's own picker instead of this custom listbox — the native dropdown on mobile, the OS list box on desktop — use [NativeSelect](./native-select). It renders a real `<select>` and takes the same `@items`, `@selectedKey` and `@onSelectionChange` arguments.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -533,6 +531,7 @@ export default class NativeSelectExample extends Component {
 
   <template>
     <NativeSelect
+      @allowEmpty={{true}}
       @placeholder='Select an option'
       @items={{options}}
       @selectedKey={{this.selectedKey}}
@@ -547,5 +546,3 @@ export default class NativeSelectExample extends Component {
 
 <Signature @component="Select" />
 <Signature @component="ListboxItem" />
-<Signature @component="NativeSelect" />
-<Signature @component="NativeSelectItem" />

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -4764,7 +4764,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -4842,7 +4843,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -4976,8 +4978,10 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isLoading',
@@ -4993,8 +4997,10 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'items',
@@ -5009,7 +5015,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -5561,7 +5568,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -5573,7 +5581,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -5581,31 +5590,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'label',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -5719,7 +5735,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -5731,7 +5748,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -5739,31 +5757,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'label',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -6021,7 +6046,7 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description: 'Class names for the wrapping element.',
         tags: {},
       },
       {
@@ -6029,7 +6054,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -6041,7 +6067,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -6049,7 +6076,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The id given to the control, and the base for the description and feedback\nids. Generated when omitted, so pass one only when something outside the\nblock has to reference it.',
         tags: {},
       },
       {
@@ -6057,31 +6085,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'label',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -6089,8 +6124,10 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Suppresses the automatic error feedback, for when the block renders the\nyielded `Feedback` itself or places messages elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'size',
@@ -6101,8 +6138,9 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description: 'The size of the label, description and feedback text.',
+        tags: { defaultValue: { name: 'defaultValue', value: "'md'" } },
+        defaultValue: '<span class="hljs-string">\'md\'</span>',
       },
     ],
     Blocks: [
@@ -6234,7 +6272,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          "Class names for the description element, merged with the theme's.",
         tags: {},
       },
       {
@@ -6242,7 +6281,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          "The id of the description element, referenced by the control's\n`aria-describedby`.",
         tags: {},
       },
       {
@@ -6254,8 +6294,9 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description: 'The size of the description text.',
+        tags: { defaultValue: { name: 'defaultValue', value: "'md'" } },
+        defaultValue: '<span class="hljs-string">\'md\'</span>',
       },
     ],
     Blocks: [
@@ -6293,7 +6334,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          "Class names for the feedback element, merged with the theme's.",
         tags: {},
       },
       {
@@ -6301,7 +6343,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          "The id of the feedback element, referenced by the control's\n`aria-describedby`.",
         tags: {},
       },
       {
@@ -6320,8 +6363,10 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'The intent of the feedback, which also decides whether it is announced\nassertively (`danger`) or politely.',
+        tags: { defaultValue: { name: 'defaultValue', value: "'danger'" } },
+        defaultValue: '<span class="hljs-string">\'danger\'</span>',
       },
       {
         identifier: 'messages',
@@ -6332,7 +6377,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'A list of messages or a single message string. An array is joined with `; `.',
         tags: {},
       },
       {
@@ -6344,8 +6390,9 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description: 'The size of the feedback text.',
+        tags: { defaultValue: { name: 'defaultValue', value: "'md'" } },
+        defaultValue: '<span class="hljs-string">\'md\'</span>',
       },
     ],
     Blocks: [
@@ -6726,7 +6773,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -6752,7 +6800,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -6768,31 +6817,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'label',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -6939,7 +6995,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          "Class names for each slot of the component, merged with the theme's.",
         tags: {},
       },
       {
@@ -6955,8 +7012,10 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required or not, if true, an asterisk will be added to the label.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'size',
@@ -6967,8 +7026,9 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description: 'The size of the label text.',
+        tags: { defaultValue: { name: 'defaultValue', value: "'md'" } },
+        defaultValue: '<span class="hljs-string">\'md\'</span>',
       },
     ],
     Blocks: [
@@ -7006,8 +7066,10 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Renders an extra empty option, letting the user clear the selection.\nLabel it with the placeholder argument.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'classes',
@@ -7016,7 +7078,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Per-slot class overrides: base, innerContainer, input, startContent,\nendContent and icon.',
         tags: {},
       },
       {
@@ -7024,7 +7087,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -7035,7 +7099,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Keys of the options that cannot be selected. Disabled options are still\nrendered and announced, they just cannot be picked.',
         tags: {},
       },
       {
@@ -7061,7 +7126,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -7069,7 +7135,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Id applied to the select element and referenced by its label. One is\ngenerated when omitted.',
         tags: {},
       },
       {
@@ -7077,31 +7144,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'items',
         type: { type: '<span class="hljs-built_in">Array</span>', raw: 'T[]' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Collection used to render the options. Strings and numbers become both the\nkey and the label; objects use key or id for the key and label, value,\nname or title for the label. Use the :item block when your data does not\nfollow those conventions.',
         tags: {},
       },
       {
@@ -7109,7 +7183,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -7117,7 +7192,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Name of the select element, used when the surrounding form is submitted.',
         tags: {},
       },
       {
@@ -7128,7 +7204,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Called with the key of an option whenever it is acted upon, including when\nthe same option is picked again. Use onSelectionChange to track state.',
         tags: {},
       },
       {
@@ -7150,7 +7227,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Called with the newly selected key, or null when the selection is cleared\nthrough the allowEmpty option.\nCalled with every selected key each time the selection changes.',
         tags: {},
       },
       {
@@ -7167,7 +7245,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The selected key in single selection mode. The component is controlled:\nupdate this from onSelectionChange.\nNot available in multiple selection mode; use selectedKeys.',
         tags: {},
       },
       {
@@ -7178,7 +7257,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Not available in single selection mode; use selectedKey.\nThe selected keys in multiple selection mode. The component is controlled:\nupdate this from onSelectionChange.',
         tags: {},
       },
       {
@@ -7190,8 +7270,13 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether one option or several can be selected. Multiple renders the native\nmulti-select list box and switches to selectedKeys.',
+        tags: {
+          defaultValue: { name: 'defaultValue', value: "'single'\n'single'" },
+        },
+        defaultValue:
+          '<span class="hljs-string">\'single\'</span>\n<span class="hljs-string">\'single\'</span>',
       },
       {
         identifier: 'size',
@@ -7202,8 +7287,9 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description: 'The size of the control.',
+        tags: { defaultValue: { name: 'defaultValue', value: "'md'" } },
+        defaultValue: '<span class="hljs-string">\'md\'</span>',
       },
       {
         identifier: 'startContentPointerEvents',
@@ -7360,7 +7446,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: true,
         isInternal: false,
-        description: '',
+        description:
+          'Value of the rendered option, and the key reported by onSelectionChange,\nselectedKey or selectedKeys, and disabledKeys.',
         tags: {},
       },
       {
@@ -7368,7 +7455,8 @@ const data: ComponentDoc[] = [
         type: { type: 'ListManager' },
         isRequired: true,
         isInternal: false,
-        description: '',
+        description:
+          'The ListManager that tracks selection for the parent select. It is bound\nfor you on the yielded Item component.',
         tags: {},
       },
       {
@@ -7376,7 +7464,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          "Text representation of the option, used for matching. Defaults to the\noption's rendered text content.",
         tags: {},
       },
     ],
@@ -7462,7 +7551,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -7474,7 +7564,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -7482,31 +7573,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'label',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -7640,7 +7738,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -7652,7 +7751,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -7660,31 +7760,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'label',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -7943,7 +8050,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -8011,7 +8119,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -8128,8 +8237,9 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          'Whether the select should be disabled, preventing user interaction.',
-        tags: {},
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.\nWhether the select should be disabled, preventing user interaction.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isFilterable',
@@ -8146,8 +8256,10 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isLoading',
@@ -8163,8 +8275,10 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'items',
@@ -8179,7 +8293,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -8765,7 +8880,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -8777,7 +8893,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -8815,16 +8932,20 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isSelected',
@@ -8840,7 +8961,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {
@@ -8981,7 +9103,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Help text rendered between the label and the control, and referenced by the\nids `describedBy` returns.',
         tags: {},
       },
       {
@@ -8993,7 +9116,8 @@ const data: ComponentDoc[] = [
         },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'Validation messages for the field. A non-empty value also marks the control\ninvalid, and an array is joined with `; ` when displayed.',
         tags: {},
       },
       {
@@ -9010,31 +9134,38 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is disabled. FormControl passes this through for styling;\nthe control it wraps is responsible for the `disabled` attribute.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isInvalid',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Marks the control invalid without supplying messages, for validation that is\nreported elsewhere.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'isRequired',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
-        tags: {},
+        description:
+          'Whether the field is required. Adds an asterisk to the label; it does not\nset the `required` attribute on the control itself.',
+        tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
+        defaultValue: '<span class="hljs-literal">false</span>',
       },
       {
         identifier: 'label',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: '',
+        description:
+          'The label text rendered above the control and associated with it via `for`.\nUse the `:label` block instead when the label needs markup.',
         tags: {},
       },
       {


### PR DESCRIPTION
Fifth in the stack: #479 → #480 → #481 → #482 → this.

Two components exported from `frontile` had no page. That also meant neither was ever linted — the linter only inspects a `.gts` when a sibling `.md` exists — so their arguments had quietly gone undocumented.

## The pages

**FormControl** is the primitive behind the built-in form components, for wrapping a control Frontile doesn't ship. Covers the yielded `c.id` / `c.isInvalid` / `c.describedBy` wiring, description and errors, repositioning the yielded parts with `@preventErrorFeedback`, the `:label` block, and sizes. Its demos deliberately use bare native inputs rather than `<Input>`, since a custom control is the entire point of the component.

**NativeSelect** covers item shapes, `@allowEmpty` / `@placeholder`, multiple selection, sizes, validation, start/end content, and a keyboard/ARIA section that leans on it being a real `<select>`.

## Most of this is JSDoc, not markdown

The API tables are generated from JSDoc on the `Args` interfaces, so a page alone would have shipped a table of blank cells:

- `form-control.gts` — `Args` had **no JSDoc at all**
- `label.gts`, `form-description.gts`, `form-feedback.gts` — descriptions written `/*` instead of `/**`, which docgen silently drops
- `native-select.gts` — undocumented

Because `FormControlSharedArgs` is inherited, documenting it also fills in the previously blank `label`, `description`, `errors`, `isInvalid`, `isRequired` and `isDisabled` rows for **Input, Textarea, Select, Checkbox, Radio and Switch**. That's why the `signature-data.ts` diff is larger than two components' worth.

`select.md` loses its duplicated `NativeSelect` / `NativeSelectItem` signature tags and keeps a short cross-link instead, so each component's API table has one home. Flagging that as the one editorial deletion in case you'd rather keep the fuller section on both pages.

## Two things left alone deliberately

- **`form-control.gts` has a bug**: the description region is guarded on `has-block "Description"` while the block is declared and yielded as `description`, so `:description` never renders. The page documents only `:label` rather than promising broken behavior. Not fixed here — it's a component change.
- **There is no `form-control-test.gts`** anywhere in `test-app`, so the accessibility notes come from reading the component, and the page says so.

## Verification

- `pnpm build` **then** `generate-signature-data`, in that order — the generator silently truncates the file otherwise. The diff deletes **0** component entries.
- `cd site && pnpm build` clean, so every demo compiles.
- `pnpm --filter frontile lint:types` clean.
- API tables checked programmatically: FormControl 10 args, NativeSelect 22, Label 5, FormFeedback 5 — **0 blank descriptions** across all four.

## Provenance

These pages were produced by subagents during the skill's evaluation rounds, then reviewed and re-verified before landing here. I checked that the `.gts` changes are comment-only, re-ran the full build and regeneration myself rather than trusting theirs, and confirmed the cross-link style matches the `./table` convention used elsewhere in component docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)