### PR TITLE
Tighten collapsible, form and portal pages

### DIFF
--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -6,7 +6,9 @@ imports:
 
 # Form
 
-A powerful form wrapper component that automatically handles form data extraction and provides real-time updates via dedicated `@onChange` and `@onSubmit` callbacks. It uses `form-data-utils` under the hood to serialize form data efficiently and supports all native HTML form elements as well as Frontile form components.
+Form wraps a native `<form>` element, serializes its fields with `form-data-utils`, and hands
+the result to `@onChange` on every change and `@onSubmit` on submission. Through the yielded
+`Field` component it also runs validation and tracks which fields the user has modified.
 
 ## Import
 
@@ -16,9 +18,52 @@ import { Form } from 'frontile';
 
 ## Usage
 
-### Basic Form
+Give every control a `@name` and Form collects it. `@onSubmit` is the only required argument;
+it receives the serialized data and the `SubmitEvent`, with `preventDefault()` already applied.
 
-The most basic usage of the Form component with automatic data extraction.
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Button, Form, Input, type FormResultData } from 'frontile';
+
+export default class SimpleForm extends Component {
+  @tracked submitted: FormResultData | null = null;
+
+  handleSubmit = (data: FormResultData) => {
+    this.submitted = data;
+  };
+
+  <template>
+    <div class='flex flex-col gap-4 w-80'>
+      <Form @onSubmit={{this.handleSubmit}}>
+        <div class='flex flex-col gap-4'>
+          <Input @name='firstName' @label='First Name' />
+          <Input @name='email' @label='Email' @type='email' />
+          <Button type='submit'>Submit</Button>
+        </div>
+      </Form>
+
+      {{#if this.submitted}}
+        <pre class='p-4 bg-neutral-subtle rounded text-sm'>{{JSON.stringify
+            this.submitted.data
+            null
+            2
+          }}</pre>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
+## Controlled and Uncontrolled Forms
+
+Passing `@onChange` makes the form controlled: you own the state, and the data you assign back
+to `@data` flows into the inputs. Reach for it when you need the values as they are typed —
+live previews, dependent fields, computed summaries.
+
+Without `@onChange` the form is uncontrolled. `@data` seeds the initial values, Form keeps the
+current values internally, and you only see them in `@onSubmit`. Both patterns support
+`@schema` and `@validate`.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -98,111 +143,11 @@ export default class BasicForm extends Component {
 }
 ```
 
-### Real-time Form Updates
+## Form Components
 
-The Form component provides real-time updates as users interact with form elements.
-
-```gts preview
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { Form, Input, Checkbox, Select, type FormResultData } from 'frontile';
-import { Button } from 'frontile';
-
-export default class RealtimeForm extends Component {
-  @tracked inputData: FormResultData = {};
-  @tracked submitData: FormResultData = {};
-  @tracked selectedRole: string | null = null;
-
-  roles = [
-    { label: 'User', key: 'user' },
-    { label: 'Admin', key: 'admin' },
-    { label: 'Moderator', key: 'moderator' },
-    { label: 'Guest', key: 'guest' }
-  ];
-
-  handleFormChange = (data: FormResultData, event: Event) => {
-    this.inputData = data;
-    console.log('Input event:', { data, event });
-  };
-
-  handleFormSubmit = (data: FormResultData, event: SubmitEvent) => {
-    this.submitData = data;
-    console.log('Submit event:', { data, event });
-  };
-
-  handleRoleChange = (selectedKey: string | null) => {
-    this.selectedRole = selectedKey;
-  };
-
-  <template>
-    <div class='flex flex-col gap-4'>
-      <Form
-        @onChange={{this.handleFormChange}}
-        @onSubmit={{this.handleFormSubmit}}
-      >
-        <div class='flex flex-col gap-4'>
-          <Input
-            @name='username'
-            @label='Username'
-            placeholder='Enter username'
-          />
-
-          <Input
-            @name='password'
-            @label='Password'
-            @type='password'
-            placeholder='Enter password'
-          />
-
-          <Select
-            @name='role'
-            @label='User Role'
-            @items={{this.roles}}
-            @placeholder='Select your role'
-            @selectedKey={{this.selectedRole}}
-            @onSelectionChange={{this.handleRoleChange}}
-          />
-
-          <Checkbox @name='rememberMe' @label='Remember me' />
-
-          <Checkbox
-            @name='agreeToTerms'
-            @label='I agree to the terms and conditions'
-          />
-
-          <Button type='submit'>
-            Sign In
-          </Button>
-        </div>
-      </Form>
-
-      <div class='grid grid-cols-1 md:grid-cols-2 gap-4'>
-        <div class='p-4 bg-warning-subtle rounded'>
-          <h4 class='font-medium mb-2'>Input Events (Real-time):</h4>
-          <pre class='text-sm overflow-auto'>{{JSON.stringify
-              this.inputData
-              null
-              2
-            }}</pre>
-        </div>
-
-        <div class='p-4 bg-success-subtle rounded'>
-          <h4 class='font-medium mb-2'>Submit Events:</h4>
-          <pre class='text-sm overflow-auto'>{{JSON.stringify
-              this.submitData
-              null
-              2
-            }}</pre>
-        </div>
-      </div>
-    </div>
-  </template>
-}
-```
-
-### Form with All Component Types
-
-Demonstrate how the Form component works with all Frontile form components.
+Every Frontile form component participates, as do plain HTML form elements. Data types follow
+the markup: text inputs give strings, checkboxes and switches booleans, multi-selects arrays,
+file inputs `File` objects.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -344,13 +289,16 @@ export default class ComprehensiveForm extends Component {
 }
 ```
 
-### Form Validation Integration
+## Validation
 
-The Form component works seamlessly with any [Standard Schema](https://standardschema.dev/)-compliant validation library, such as Valibot, for scalable form validation. Frontile does not ship with a validation library by default, so you can choose which is right for you. The only requirement is that it is compatible with Standard Schema. _Validation logic_, however, is built in--concerns such as running validation on submit and blur events. The following example demonstrates how to use Valibot for comprehensive form validation. The use of hand-rolled custom validators is also supported.
+Validation is built in — running it on the right events, mapping issues back to fields, and
+rendering the messages — but the schema is yours. Any
+[Standard Schema](https://standardschema.dev/) library works; the examples use
+[Valibot](https://valibot.dev/). `@validate` adds a hand-rolled check on top, for rules a
+schema can't express (comparing two fields, for instance) and returns Standard Schema issues.
 
-**Note**: When using built-in form validation, the `Field` component _must_ be used (see example below). The `Field` component handles automatic error binding. Use of `Field` is unnecessary when not using built-in form validation. [Learn more about the `Field` component and see more form validation examples](field).
-
-**Validation timing:** Most form components support field-level validation (validates on change/blur/input events). However, `CheckboxGroup` currently only supports validation on form submit, not field-level validation events. See the [CheckboxGroup](checkbox-group) and [Field](field) documentation for more details.
+Built-in validation requires the yielded `Field` component — it is what binds a field's errors
+to its control. See [Field](field) for its own arguments and more examples.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -559,13 +507,50 @@ export default class ValidatedForm extends Component {
 }
 ```
 
-### Dirty Field Tracking
+### Validation Timing
 
-The Form component automatically tracks which fields have been modified by the user. This is useful for showing unsaved changes warnings or enabling/disabling submit buttons.
+`@validateOn` controls which events trigger validation. It defaults to
+`{{array 'change' 'blur' 'submit'}}`.
 
-Enable dirty field tracking by specifying a field in the initial `@data` passed into a `Form` component. Dirty tracking is enabled only for fields specified in initial data.
+| Value    | Validates                                                                 |
+| -------- | ------------------------------------------------------------------------- |
+| `change` | one field, when its value was modified and it loses focus (HTML `change`) |
+| `blur`   | one field, whenever it loses focus — even if nothing changed              |
+| `input`  | one field, on every keystroke                                             |
+| `submit` | the whole form; on failure `@onError` runs and `@onSubmit` does not       |
 
-Dirty fields reset on submit. After a sucessful submit, any tracked data is considered clean.
+```gts
+{{! validate as the user types, and again on submit }}
+<Form
+  @schema={{schema}}
+  @validateOn={{array 'input' 'submit'}}
+  @onSubmit={{this.handleSubmit}}
+  as |form|
+>
+  <form.Field @name='password' as |field|>
+    <field.Input @label='Password' @type='password' />
+  </form.Field>
+</Form>
+```
+
+Which to pick: `change` is the least intrusive and catches most mistakes; add `blur` to flag
+required fields a user tabbed straight past; use `input` only where per-keystroke feedback
+earns the noise, such as password strength. Drop `submit` for long forms where an error summary
+on submit would be jarring.
+
+An empty array (`@validateOn={{array}}`) skips validation entirely: `@onSubmit` is called
+regardless of validity and `@onError` never fires. That's the path for multi-step forms, draft
+saves, or validating by hand inside `@onSubmit`. Everything else — dirty tracking, reset, data
+snapshots — keeps working.
+
+Two limits worth knowing: the field-level values (`change`, `blur`, `input`) need
+`form.Field`, and [CheckboxGroup](checkbox-group) validates only on submit.
+
+## Dirty Field Tracking
+
+`form.dirty` is a `Set` of the fields whose value differs from the initial `@data`. Tracking
+covers only the keys present in that initial data, so a field you never seeded is never
+reported dirty. Submitting clears the set.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -641,9 +626,10 @@ export default class DirtyTrackingForm extends Component {
 }
 ```
 
-### Custom Form Handling
+## Validating Without a Schema
 
-Advanced usage showing how to handle complex form logic and custom validation.
+`Field` is unnecessary when you are not using built-in validation. Pass `@errors` to each
+control yourself and you keep full control of when and how validation runs.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -829,463 +815,12 @@ export default class CustomHandlingForm extends Component {
 }
 ```
 
-## Key Features
-
-### Automatic Data Extraction
-
-- Uses `form-data-utils` to automatically serialize form data
-- Works with all HTML form elements and Frontile components
-- Handles complex data types including arrays and nested objects
-
-### Event Handling
-
-- **`@onChange`**: Fired on every form input change for real-time updates and receives `(data, event)`
-- **`@onSubmit`**: Fired when the form is submitted with `preventDefault()` applied and receives `(data, submitEvent)`
-- Access to the original DOM event for advanced use cases in both handlers
-
-### Data Types Support
-
-- Strings, numbers, and booleans
-- Arrays from multi-select elements
-- Nested objects from grouped form elements
-- File uploads (when using file inputs)
-
-### Controlled vs Uncontrolled Forms
-
-The Form component supports both controlled and uncontrolled patterns, similar to React form handling:
-
-**Controlled Forms** (with `@onChange` + `@data`)
-
-- You provide both `@data` and `@onChange`
-- Form values are controlled by your component state
-- You update state in `@onChange`, which flows back to form inputs
-- Best for forms where you need to validate or transform data in real-time
-- Example: `<Form @data={{this.formData}} @onChange={{this.handleChange}}>`
-
-**Uncontrolled Forms** (without `@onChange`)
-
-- You provide only `@data` for initial values (or omit it entirely)
-- Form manages its own internal state
-- You receive final data only in `@onSubmit`
-- Simpler pattern for basic forms
-- Example: `<Form @data={{this.initialData}} @onSubmit={{this.handleSubmit}}>`
-
-**Choosing Between Patterns:**
-
-- Use **controlled** when you need real-time form data access, validation as user types, or complex interdependent fields
-- Use **uncontrolled** for simpler forms where you only care about the final submitted data
-- Both patterns support validation via `@schema` and `@validate`
-
-## Best Practices
-
-### Form Validation
-
-For scalable form validation, use built-in validation with a library that implements [Standard Schema](https://standardschema.dev/), such as [Valibot](https://valibot.dev/):
-
-```gts
-// Define a Valibot schema for type-safe validation
-schema = v.object({
-  email: v.pipe(
-    v.string(),
-    v.nonEmpty('Email is required'),
-    v.email('Please enter a valid email address')
-  ),
-  password: v.pipe(
-    v.string(),
-    v.minLength(6, 'Password must be at least 6 characters')
-  )
-});
-
-<template>
-  <Form @schema={{schema}} as |form|>
-    ...
-  </Form>
-</template>
-```
-
-### Validation Timing
-
-By default, the Form component validates data both on field changes and form submission. You can control when validation runs using the `@validateOn` argument.
-
-**Available options:**
-
-- `change` - Validate individual fields when users change a value and blur/defocus the field (per-field validation)
-- `input` - Validate individual fields as users type (real-time validation on every keystroke)
-- `blur` - Validate individual fields when they lose focus, regardless of whether the value changed
-- `submit` - Validate the entire form when submitted
-
-**Default behavior:** `@validateOn={{array 'change' 'submit'}}` - validates on both field changes (blur) and form submission.
-
-**Note on `'change'` vs `'blur'`:** The `'change'` option validates on the HTML `change` event, which fires when a field loses focus (blur) **only if** its value has been modified. The `'blur'` option validates on the HTML `blur` event, which fires whenever a field loses focus, regardless of whether the value changed. The `'input'` option validates on the HTML `input` event, which fires on every keystroke as the user types.
-
-**Usage:**
-
-```gts
-// Default behavior - validates on both change and submit
-<Form @schema={{schema}} @onSubmit={{this.handleSubmit}} as |form|>
-  ...
-</Form>
-
-// Equivalent to default - explicit both change and submit
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'change' 'submit'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-
-// Change validation only - validate on blur after modification, but not on submit
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'change'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-
-// Blur validation only - validate on any focus loss, but not on submit
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'blur'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-
-// Input validation only - validate as users type, but not on submit
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'input'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-
-// Combined validation - validate on change, blur, AND as users type
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'change' 'blur' 'input' 'submit'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-
-// Submit validation only - validate only when form is submitted
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'submit'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-
-// Skip validation entirely by omitting a schema or setting `validateOn` to an
-// empty array.  `onSubmit` is called regardless of data validity.
-<Form
-  @schema={{schema}}
-  @validateOn={{array}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-```
-
-**Validation behavior details:**
-
-**Change validation (`'change'`)**:
-
-- Individual fields validate when users change a value and then blur/defocus the field
-- Validation errors appear after the user moves to the next field
-- Each field validates independently using its specific validation rules
-- Provides feedback without waiting for form submission
-- Uses the Field component's `handleChange` action to trigger validation
-- Based on the HTML `change` event (fires on blur after value modification, not on every keystroke)
-
-**Blur validation (`'blur'`)**:
-
-- Individual fields validate whenever they lose focus, regardless of whether the value changed
-- Validation errors appear immediately when the user tabs away or clicks outside the field
-- Each field validates independently using its specific validation rules
-- Provides feedback as users navigate between fields
-- Uses the Field component's `handleBlur` action to trigger validation
-- Based on the HTML `blur` event (fires whenever a field loses focus)
-- Useful for ensuring fields are validated even when users skip over them without making changes
-
-**Input validation (`'input'`)**:
-
-- Individual fields validate as users type, on every keystroke
-- Validation errors appear in real-time as the user types
-- Each field validates independently using its specific validation rules
-- Provides immediate feedback while the user is still focused on the field
-- Uses the Field component's `handleInput` action to trigger validation
-- Based on the HTML `input` event (fires on every keystroke)
-- Best for fields where real-time feedback is valuable (e.g., password strength, character limits)
-
-**Submit validation (`'submit'`)**:
-
-- The entire form validates when the submit button is clicked
-- All fields are validated together before calling `@onSubmit`
-- If validation fails, `@onError` is called and `@onSubmit` is not called
-- Validation errors are displayed for all invalid fields
-
-**Common validation patterns:**
-
-**On-blur validation (recommended for most forms):**
-
-```gts
-// Default - validates when field loses focus after modification AND on submit
-<Form @schema={{schema}} @onSubmit={{this.handleSubmit}} as |form|>
-  <form.Field @name="email" as |field|>
-    <field.Input @label="Email" />
-  </form.Field>
-</Form>
-```
-
-**Explicit blur validation (validates on any focus loss):**
-
-```gts
-// Validates whenever field loses focus, even if value didn't change
-// Useful for catching empty required fields as users navigate
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'blur' 'submit'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  <form.Field @name="email" as |field|>
-    <field.Input @label="Email" />
-  </form.Field>
-</Form>
-```
-
-**Real-time validation (best for immediate feedback):**
-
-```gts
-// Validates as user types - great for password strength, character limits, etc.
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'input' 'submit'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  <form.Field @name="password" as |field|>
-    <field.Input @label="Password" @type="password" />
-  </form.Field>
-</Form>
-```
-
-**Combined blur and input validation:**
-
-```gts
-// Validates both as user types AND when field loses focus
-// Provides comprehensive feedback throughout the form-filling experience
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'blur' 'input' 'submit'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  <form.Field @name="password" as |field|>
-    <field.Input @label="Password" @type="password" />
-  </form.Field>
-</Form>
-```
-
-**Submit-only validation (less intrusive for long forms):**
-
-```gts
-// Only validates on submit - users can fill entire form without interruption
-<Form
-  @schema={{schema}}
-  @validateOn={{array 'submit'}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  <form.Field @name="email" as |field|>
-    <field.Input @label="Email" />
-  </form.Field>
-</Form>
-```
-
-**Manual validation (advanced use cases):**
-
-```gts
-// Skip automatic validation - handle it manually
-<Form
-  @schema={{schema}}
-  @validateOn={{array}}
-  @onSubmit={{this.handleSubmit}}
-  as |form|
->
-  ...
-</Form>
-```
-
-**When to skip validation:**
-
-- When you want to handle validation manually in your `@onSubmit` handler
-- When building multi-step forms where validation should only run on the final step
-- When you need to submit partial or draft data without validation
-
-**Important notes:**
-
-- When `@validateOn` includes `'change'`, `'blur'`, or `'input'`, you must use the `form.Field` component for automatic field-level validation
-- When `@validateOn` is an empty array, validation is completely skipped and `@onError` will never be called
-- All other form functionality (dirty state tracking, form reset, data snapshots) continues to work normally regardless of validation timing
-- **Difference between `'change'` and `'blur'`:**
-  - `'change'` validates only when a field's value has been modified AND the field loses focus
-  - `'blur'` validates whenever a field loses focus, even if the value didn't change
-  - Use `'blur'` to catch empty required fields as users navigate through the form
-  - Use `'change'` for a less intrusive experience that only validates when users actually modify fields
-- Change validation provides better user experience by catching errors as users move between fields
-- Blur validation ensures all fields are validated as users navigate, even if they skip over fields
-- Input validation provides immediate feedback but may be distracting for some use cases
-- The `'change'` event fires when a field loses focus (blur) after being modified, not on every keystroke
-- The `'blur'` event fires whenever a field loses focus, regardless of whether the value changed
-- The `'input'` event fires on every keystroke as the user types
-- Consider using `'input'` validation for fields where real-time feedback is valuable (password strength, character limits, username availability)
-- Consider using `'blur'` validation when you want to ensure required fields are validated even if users skip over them
-
-### Performance Considerations
-
-- The Form component only re-renders when necessary
-- Form data extraction is optimized using `form-data-utils`
-- Consider debouncing input validation for complex forms
-
-### Disabling Forms
-
-The Form component supports disabling all form fields at once using the `@disabled` argument. This is useful for preventing user interaction during form submission or when certain conditions aren't met.
-
-When `@disabled={{true}}` is passed to the Form component, all yielded Field components and their child form controls (Input, Checkbox, Select, Textarea, etc.) are automatically disabled.
-
-```gts preview
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
-import { Form, type FormResultData } from 'frontile';
-import { Button } from 'frontile';
-import * as v from 'valibot';
-
-const schema = v.object({
-  email: v.pipe(
-    v.string(),
-    v.nonEmpty('Email is required'),
-    v.email('Please enter a valid email address')
-  ),
-  password: v.pipe(
-    v.string(),
-    v.nonEmpty('Password is required'),
-    v.minLength(6, 'Password must be at least 6 characters')
-  )
-});
-
-type Schema = v.InferOutput<typeof schema>;
-
-export default class DisabledForm extends Component {
-  @tracked formData: Schema = {
-    email: '',
-    password: ''
-  };
-  @tracked isFormDisabled = false;
-  @tracked submitMessage = '';
-
-  handleFormChange = (data: FormResultData<Schema>) => {
-    this.formData = data.data;
-  };
-
-  handleFormSubmit = async (data: FormResultData<Schema>) => {
-    // Simulate API call
-    this.isFormDisabled = true;
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    this.submitMessage = 'Login successful!';
-    this.isFormDisabled = false;
-    console.log('Form submitted:', data);
-  };
-
-  toggleDisabled = () => {
-    this.isFormDisabled = !this.isFormDisabled;
-  };
-
-  or(a: unknown, b: unknown) {
-    return a || b;
-  }
-
-  <template>
-    <div class='flex flex-col gap-4 w-80'>
-      <div class='flex items-center gap-2 p-3 bg-neutral-subtle rounded'>
-        <label class='flex items-center gap-2 cursor-pointer'>
-          <input
-            type='checkbox'
-            checked={{this.isFormDisabled}}
-            {{on 'change' this.toggleDisabled}}
-            class='w-4 h-4'
-          />
-          <span class='text-sm font-medium'>Disable form</span>
-        </label>
-      </div>
-
-      <Form
-        @disabled={{this.isFormDisabled}}
-        @data={{this.formData}}
-        @schema={{schema}}
-        @onChange={{this.handleFormChange}}
-        @onSubmit={{this.handleFormSubmit}}
-        as |form|
-      >
-        <div class='flex flex-col gap-4'>
-          <form.Field @name='email' as |field|>
-            <field.Input @label='Email' @type='email' @isRequired={{true}} />
-          </form.Field>
-
-          <form.Field @name='password' as |field|>
-            <field.Input
-              @label='Password'
-              @type='password'
-              @isRequired={{true}}
-            />
-          </form.Field>
-
-          <Button
-            type='submit'
-            disabled={{this.or form.isLoading this.isFormDisabled}}
-          >
-            {{if form.isLoading 'Logging in...' 'Log In'}}
-          </Button>
-        </div>
-      </Form>
-
-      {{#if this.submitMessage}}
-        <div class='p-4 bg-success-subtle text-success-strong rounded'>
-          {{this.submitMessage}}
-        </div>
-      {{/if}}
-    </div>
-  </template>
-}
-```
-
-**Common use cases for disabled forms:**
-
-- **During submission**: Disable the form while an async operation is in progress to prevent duplicate submissions
-- **Conditional access**: Disable forms when user permissions or prerequisites aren't met
-- **Read-only mode**: Show form data in a non-editable state
-- **Multi-step forms**: Disable previous steps once completed
-
-**Note:** The `@disabled` argument affects only the yielded `Field` components. If you're using individual form components without `Field`, you'll need to manage their disabled state separately.
-
 ## Nested Fields
 
-The Form component fully supports nested data structures, allowing you to organize form data hierarchically while maintaining flat HTML form field names. Nested objects are automatically converted to dotted field notation (e.g., `user.profile.email`).
-
-### Basic Nested Form
+Nested data is addressed with dot notation: `@name='user.profile.email'`. Form flattens the
+object internally and unflattens it again for `@onChange` and `@onSubmit`, so your schema and
+your `@data` keep the shape you actually want. Errors and dirty entries are keyed by the same
+dotted path down to the leaf — `user.name.first`, never just `user`.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1385,9 +920,9 @@ export default class NestedForm extends Component {
 }
 ```
 
-### Nested Form with Validation
+### Nested Fields with Validation
 
-Nested fields work seamlessly with validation schemas. Use nested object structures in your schema that match your data structure.
+Mirror the data shape in the schema and issues land on the right control.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1524,9 +1059,9 @@ export default class ValidatedNestedForm extends Component {
 }
 ```
 
-### Mixed Flat and Nested Fields
+### Mixing Flat and Nested Fields
 
-You can freely mix flat and nested fields in the same form. The Form component automatically detects and handles both structures.
+Flat and nested names can sit side by side in one form.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1600,37 +1135,12 @@ export default class MixedFieldsForm extends Component {
 }
 ```
 
-### Key Points for Nested Fields
-
-**Field Naming Convention:**
-
-- Use dot notation for nested fields: `@name="user.profile.email"`
-- Validation errors are automatically mapped to dotted field names
-- Dirty tracking works at the leaf level (e.g., `user.name.first` not just `user`)
-
-**Data Structure:**
-
-- Pass nested objects via `@data`.
-- `@onChange` and `@onSubmit` callbacks receive nested data structure
-- The form automatically flattens data internally and unflattens for callbacks
-
-**Validation:**
-
-- Schema validators should mirror your data structure
-- Error messages are keyed by dotted paths (e.g., `"user.email": "Email is required"`)
-- Custom validators work with nested data structures
-
-**Dirty Field Tracking:**
-
-- Dirty fields are tracked using dotted notation
-- Deep comparison ensures nested object changes are detected
-- `form.dirty` contains paths like `"user.profile.email"`, not just `"user"`
-
 ## Resetting Forms
 
-The Form component provides a `reset` function that allows you to reset the form to its initial state. This is useful for implementing "Cancel" or "Reset" buttons in your forms.
-
-### Basic Reset
+`form.reset` calls the native form reset, restores `@data`'s initial values, clears validation
+errors, and empties the dirty set. In a controlled form it reports the initial data back through
+`@onChange`; in an uncontrolled one it updates the internal state. With no `@data` at all it
+just clears the fields.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1703,7 +1213,7 @@ export default class ResetForm extends Component {
 
 ### Reset with Validation
 
-The `reset` function clears validation errors and restores the form to its initial state, including resetting dirty field tracking.
+Errors already on screen are cleared along with the values.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1789,37 +1299,126 @@ export default class ResetValidationForm extends Component {
 }
 ```
 
-### Reset Behavior
+## Disabled Forms
 
-When you call `form.reset()`:
+`@disabled` disables every yielded `Field` and the control inside it at once — useful while a
+submission is in flight, in read-only views, or for steps of a wizard that are already done. It
+reaches `Field` children only; controls used without `Field` manage their own `disabled`.
 
-1. **Calls native form reset**: The underlying HTML form element's `reset()` method is called, which resets all form controls to their default values
-2. **Restores initial data**: The form data is restored to the values provided in the initial `@data` prop
-3. **Clears validation errors**: Any validation errors are cleared
-4. **Clears dirty state**: The dirty field tracking is reset to an empty set
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import { Form, type FormResultData } from 'frontile';
+import { Button } from 'frontile';
+import * as v from 'valibot';
 
-**For controlled forms** (with `@onChange`):
+const schema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.nonEmpty('Email is required'),
+    v.email('Please enter a valid email address')
+  ),
+  password: v.pipe(
+    v.string(),
+    v.nonEmpty('Password is required'),
+    v.minLength(6, 'Password must be at least 6 characters')
+  )
+});
 
-- Calls `@onChange` with the initial data, allowing your component to update its state
+type Schema = v.InferOutput<typeof schema>;
 
-**For uncontrolled forms** (without `@onChange`):
+export default class DisabledForm extends Component {
+  @tracked formData: Schema = {
+    email: '',
+    password: ''
+  };
+  @tracked isFormDisabled = false;
+  @tracked submitMessage = '';
 
-- Updates the internal form state to the initial data
+  handleFormChange = (data: FormResultData<Schema>) => {
+    this.formData = data.data;
+  };
 
-**With no initial data**:
+  handleFormSubmit = async (data: FormResultData<Schema>) => {
+    // Simulate API call
+    this.isFormDisabled = true;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    this.submitMessage = 'Login successful!';
+    this.isFormDisabled = false;
+    console.log('Form submitted:', data);
+  };
 
-- Simply calls the native form reset, clearing all fields to empty values
+  toggleDisabled = () => {
+    this.isFormDisabled = !this.isFormDisabled;
+  };
+
+  or(a: unknown, b: unknown) {
+    return a || b;
+  }
+
+  <template>
+    <div class='flex flex-col gap-4 w-80'>
+      <div class='flex items-center gap-2 p-3 bg-neutral-subtle rounded'>
+        <label class='flex items-center gap-2 cursor-pointer'>
+          <input
+            type='checkbox'
+            checked={{this.isFormDisabled}}
+            {{on 'change' this.toggleDisabled}}
+            class='w-4 h-4'
+          />
+          <span class='text-sm font-medium'>Disable form</span>
+        </label>
+      </div>
+
+      <Form
+        @disabled={{this.isFormDisabled}}
+        @data={{this.formData}}
+        @schema={{schema}}
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+        as |form|
+      >
+        <div class='flex flex-col gap-4'>
+          <form.Field @name='email' as |field|>
+            <field.Input @label='Email' @type='email' @isRequired={{true}} />
+          </form.Field>
+
+          <form.Field @name='password' as |field|>
+            <field.Input
+              @label='Password'
+              @type='password'
+              @isRequired={{true}}
+            />
+          </form.Field>
+
+          <Button
+            type='submit'
+            disabled={{this.or form.isLoading this.isFormDisabled}}
+          >
+            {{if form.isLoading 'Logging in...' 'Log In'}}
+          </Button>
+        </div>
+      </Form>
+
+      {{#if this.submitMessage}}
+        <div class='p-4 bg-success-subtle text-success-strong rounded'>
+          {{this.submitMessage}}
+        </div>
+      {{/if}}
+    </div>
+  </template>
+}
+```
 
 ## Feedback Messages
 
-When a field fails validation, `Form`/`Field` automatically render a `FormFeedback`
-element with the `danger` intent and the appropriate `aria-live` announcement — you don't
-need to wire this up yourself (see the [Form Validation](#form-validation-integration)
-examples above).
+When a field fails validation, `Form`/`Field` render a `FormFeedback` with the `danger` intent
+and an assertive `aria-live` region — no wiring needed.
 
-For feedback outside of validation errors — hints, confirmations, or warnings — render the
-standalone `FormFeedback` component and choose an `@intent`. Available intents are
-`primary`, `secondary`, `tertiary`, `success`, `warning`, and `danger`.
+For feedback that isn't a validation error — hints, confirmations, warnings — render
+`FormFeedback` yourself and pick an `@intent` from `primary`, `secondary`, `tertiary`,
+`success`, `warning`, or `danger`. Anything other than `danger` announces politely.
 
 ```gts preview
 import { FormFeedback } from 'frontile';
@@ -1847,57 +1446,30 @@ import { FormFeedback } from 'frontile';
 
 ## Accessibility
 
-The Form component maintains all standard HTML form accessibility features:
+Form renders a native `<form>`, so submission on <kbd>Enter</kbd>, field labelling, and
+`...attributes` pass-through all behave natively.
 
-- Proper form semantics with native `<form>` element
-- Submit handling with keyboard support (Enter key)
-- Works with screen readers and assistive technologies
-- Maintains focus management and navigation
-- Supports all ARIA attributes when passed through `...attributes`
-- Disabled form fields are properly marked with the `disabled` attribute and announced by screen readers
+- **Invalid fields** get `aria-invalid='true'` from `Field`, removed again once the field
+  validates.
+- **Error messages** render in a `FormFeedback` with `aria-live='assertive'` and are associated
+  with the control, so a screen reader announces them as they appear.
+- **Disabled fields** carry the real `disabled` attribute rather than a styling-only state.
+- **Focus** is not managed or trapped by Form; it stays where the browser puts it. If you
+  redirect focus to the first invalid field in `@onError`, see
+  [focus management](/docs/accessibility/focus-management).
 
 ## API
 
-### Yielded Context
+The default block yields a context object:
 
-The Form component yields an object with the following properties:
-
-- **`data`**: The current form data as key/value pairs (matches the `@data` prop in controlled forms)
-- **`isLoading`**: Boolean indicating if the form is currently submitting (async `@onSubmit` in progress)
-- **`isValid`**: Boolean indicating if the form has no validation errors
-- **`isInvalid`**: Boolean indicating if the form has validation errors
-- **`errors`**: Object containing validation errors keyed by field name
-- **`dirty`**: Set containing field names that have changed from their initial values
-- **`reset`**: Function to reset the form to its initial state (clears fields, errors, and dirty tracking)
-- **`Field`**: The Field component with `errors` and `formData` already bound
-
-Example usage:
-
-```gts
-<Form @data={{this.formData}} @onSubmit={{this.handleSubmit}} as |form|>
-  {{! Access current form data }}
-  <div>Current email: {{form.data.email}}</div>
-
-  {{! Show loading state }}
-  <button type="submit" disabled={{form.isLoading}}>
-    {{if form.isLoading "Saving..." "Save"}}
-  </button>
-
-  {{! Reset form to initial state }}
-  <button type="button" {{on "click" form.reset}}>
-    Reset
-  </button>
-
-  {{! Check validation state }}
-  {{#if form.isInvalid}}
-    <div class="error">Please fix errors before submitting</div>
-  {{/if}}
-
-  {{! Check for unsaved changes }}
-  {{#if form.dirty.size}}
-    <div class="warning">You have unsaved changes</div>
-  {{/if}}
-</Form>
-```
+| Property                | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `data`                  | Current form data as key/value pairs                              |
+| `isLoading`             | `true` while an async `@onSubmit` is in flight                    |
+| `isValid` / `isInvalid` | Whether the form currently has validation errors                  |
+| `errors`                | Validation errors keyed by field name                             |
+| `dirty`                 | `Set` of fields changed from their initial values                 |
+| `reset`                 | Resets values, errors, and dirty tracking                         |
+| `Field`                 | The `Field` component, with `errors` and `formData` already bound |
 
 <Signature @component="Form" />

--- a/packages/frontile/src/components/overlays/portal-target.gts
+++ b/packages/frontile/src/components/overlays/portal-target.gts
@@ -3,7 +3,11 @@ import type { TOC } from '@ember/component/template-only';
 const PortalTarget: TOC<{
   Args: {
     /**
-     * Target name
+     * Name of this target, matched against a `Portal`'s `@target` argument.
+     *
+     * When omitted, the target is unnamed: any `Portal` rendered below it that
+     * has no `@target` and no parent portal will render here. A named target is
+     * only used by portals that ask for it by name.
      */
     for?: string;
   };

--- a/packages/frontile/src/components/overlays/portal.md
+++ b/packages/frontile/src/components/overlays/portal.md
@@ -6,7 +6,7 @@ imports:
 
 # Portal & PortalTarget
 
-The `Portal` and `PortalTarget` components are designed to make it easy to render content into a different part of the DOM. This is useful for scenarios such as rendering modals, popovers, or other UI elements that should not be restricted by parent container overflow or need to be placed in a specific area of the page for accessibility or UX considerations.
+`Portal` renders its content somewhere else in the DOM, and `PortalTarget` marks the places it can render to. Reach for them when content has to escape a parent's `overflow: hidden` or stacking context — modals, drawers, popovers, tooltips, toasts — or when it belongs in a specific region of the page for reading order or z-index reasons.
 
 ## Import
 
@@ -14,31 +14,119 @@ The `Portal` and `PortalTarget` components are designed to make it easy to rende
 import { Portal, PortalTarget } from 'frontile';
 ```
 
-## Server-Side Rendering Support
-
-The `Portal` and `PortalTarget` components are fully compatible with server-side rendering (SSR). This ensures that your content is properly rendered and accessible, even when the application is being served from the server, making these components suitable for SEO and initial page load performance considerations.
-
 ## Usage
 
-### Basic Example
+With no arguments, `Portal` renders into the closest destination it can find, falling back to `document.body`.
 
-The `Portal` component renders its content to a specified target or, by default, to the closest available target. You can use it to decouple your UI elements from their usual place in the DOM.
-
-```gts
-import { Portal, PortalTarget } from 'frontile';
+```gts preview
+import { Portal } from 'frontile';
 
 <template>
   <Portal>
-    <div class='p-4 border rounded shadow-md'>
+    <div class='p-4 border border-neutral-soft rounded shadow-md'>
       This content is rendered in a portal.
     </div>
   </Portal>
 </template>
 ```
 
-### Nesting Portals
+## PortalTarget
 
-You can also nest `Portal` components within each other. The inner `Portal` elements can append to the parent portal if configured that way.
+`PortalTarget` renders a `div` marked with `data-portal-target="true"` and, when `@for` is
+given, `data-portal-for="<name>"`. It takes attributes and a block, so it can be positioned
+and styled like any other element and can hold content of its own.
+
+A target with no `@for` is **unnamed**: it is the default destination for any `Portal`
+rendered below it that has no `@target` of its own. A target with `@for` is only used by
+portals that ask for it by name, so it never captures unrelated content.
+
+```gts preview
+import { Portal, PortalTarget } from 'frontile';
+
+<template>
+  <div class='flex flex-col space-y-4'>
+    <PortalTarget />
+    <PortalTarget @for='target-1' />
+
+    <Portal @target='target-1'>
+      <div class='p-4 border border-neutral-soft rounded shadow-md'>
+        Rendered to target-1
+      </div>
+    </Portal>
+  </div>
+</template>
+```
+
+### Named targets as slots
+
+Because named targets are opt-in, several can coexist and each `Portal` picks one by name.
+The target's own block content stays put; portal content is appended after it.
+
+```gts preview
+import { Button, Portal, PortalTarget } from 'frontile';
+
+<template>
+  <div class='flex gap-4'>
+    <PortalTarget
+      @for='toolbar'
+      class='flex-1 flex items-center gap-2 p-3 border border-neutral-soft rounded'
+    >
+      <span class='text-neutral-strong'>Toolbar</span>
+    </PortalTarget>
+
+    <PortalTarget
+      @for='footer'
+      class='flex-1 flex items-center gap-2 p-3 border border-neutral-soft rounded'
+    >
+      <span class='text-neutral-strong'>Footer</span>
+    </PortalTarget>
+
+    <Portal @target='toolbar'>
+      <Button @size='sm'>Save changes</Button>
+    </Portal>
+
+    <Portal @target='footer'>
+      <Button @size='sm' @appearance='outlined'>Cancel</Button>
+    </Portal>
+  </div>
+</template>
+```
+
+### An application-level target
+
+Without a target, overlays land in `document.body`, outside the element your app styles and
+outside its stacking context. Rendering one unnamed `PortalTarget` near the end of the
+application template gives every overlay a predictable home you control — this documentation
+site does exactly that:
+
+```gts
+import { PortalTarget } from 'frontile';
+
+<template>
+  {{outlet}}
+
+  <PortalTarget class='relative z-20' />
+</template>
+```
+
+### How a destination is chosen
+
+`Portal` resolves its destination in this order:
+
+1. `@renderInPlace={{true}}` — no portal at all, the content stays where it is written.
+2. `@target` as an `Element` — that element.
+3. `@target` as a string beginning with `#` — the element with that id.
+4. `@target` as any other string — the nearest `PortalTarget` with a matching `@for`.
+5. Otherwise, the nearest parent portal, unless `@appendToParentPortal={{false}}`.
+6. Otherwise, the nearest **unnamed** `PortalTarget`.
+7. Otherwise, `document.body`.
+
+When the destination ends up being plain `document.body`, `Portal` wraps its content in a
+`PortalTarget` for you, so portals nested inside it still have somewhere to go.
+
+## Nesting Portals
+
+Portals nest: an inner `Portal` renders into the destination of the outer one.
 
 ```gts preview
 import { Portal, PortalTarget } from 'frontile';
@@ -66,48 +154,16 @@ import { Portal, PortalTarget } from 'frontile';
 </template>
 ```
 
-In this example, the inner `Portal` renders its content inside the destination of the outer `Portal`.
+## Rendering Inline
 
-### Using `PortalTarget`
-
-The `PortalTarget` component is used to create named or unnamed locations where content can be rendered using the `Portal` component. This allows for more control over where a portal's content is displayed.
-
-```gts preview
-import { Portal, PortalTarget } from 'frontile';
-
-<template>
-  <div class='flex flex-col space-y-4'>
-    <PortalTarget />
-    <PortalTarget @for='target-1' />
-
-    <Portal @target='target-1'>
-      <div class='p-4 border rounded shadow-md'>
-        Rendered to target-1
-      </div>
-    </Portal>
-  </div>
-</template>
-```
-
-In this example, the portal content is directed to the named target, `target-1`, ensuring it is rendered in the appropriate place within the DOM.
-
-## Controlling Where Content Renders
-
-The `Portal` component has a `target` argument that allows you to specify where the content should be rendered. This can be:
-
-- A DOM `Element` directly.
-- An ID prefixed with `#` to target a specific element by its ID.
-- A target name to match a `PortalTarget` with the `@for` argument.
-
-### Rendering Inline
-
-If you set the `@renderInPlace` argument to `true`, the content will be rendered inline without creating a new portal.
+`@renderInPlace={{true}}` skips the portal entirely and renders the content where it is
+written — useful for turning portalling off conditionally.
 
 ```gts preview
-import { Portal, PortalTarget } from 'frontile';
+import { Portal } from 'frontile';
 
 <template>
-  <div class='p-4 border rounded'>
+  <div class='p-4 border border-neutral-soft rounded'>
     <Portal @renderInPlace={{true}}>
       This content is rendered inline instead of a portal.
     </Portal>
@@ -115,30 +171,31 @@ import { Portal, PortalTarget } from 'frontile';
 </template>
 ```
 
-### Rendering Inside a Specific DOM Element
+## Rendering Inside a Specific DOM Element
 
-You can use a target element directly by passing its ID or a reference to the `@target` argument.
+`@target` also accepts an element id prefixed with `#`, or an `Element` reference, for
+destinations that are not `PortalTarget`s — a third-party container, for instance.
 
 ```gts preview
-import { Portal, PortalTarget } from 'frontile';
+import { Portal } from 'frontile';
 
 <template>
-  <div id='target' class='border p-4'>
+  <div id='target' class='border border-neutral-soft p-4'>
     Target Element
   </div>
   <Portal @target='#target'>
-    <div class='p-4 border rounded shadow-md'>
+    <div class='p-4 border border-neutral-soft rounded shadow-md'>
       Rendered inside target element.
     </div>
   </Portal>
 </template>
 ```
 
-In this example, the portal content is rendered inside the element with the ID `target`.
-
 ## Append to Parent Portal
 
-By default, `Portal` components append their content to the parent portal if one exists. This behavior can be disabled by setting the `@appendToParentPortal` argument to `false`.
+By default a `Portal` appends to the parent portal when there is one. Set
+`@appendToParentPortal={{false}}` to make it resolve a destination on its own instead, which
+sends it to the nearest unnamed `PortalTarget`.
 
 ```gts preview
 import { Portal, PortalTarget } from 'frontile';
@@ -155,14 +212,33 @@ import { Portal, PortalTarget } from 'frontile';
 </template>
 ```
 
-In this example, the inner `Portal` will not append its content to the parent portal, resulting in the content being rendered at a different level.
+## Server-Side Rendering
 
-## Accessibility and Considerations
+Both components work under FastBoot. `Portal` resolves its destination from the owner's
+document rather than the global `document`, so portalled content is present in the
+server-rendered HTML.
 
-- Ensure that portal content, especially dynamic elements like modals and popovers, has a clear focus and can be accessed by keyboard navigation.
-- Portals are useful when elements should escape any parent `overflow: hidden` constraints.
+## Accessibility
 
-The `Portal` and `PortalTarget` components provide a robust way to manage dynamic content placement within your Ember.js applications, making them a powerful tool for managing modals, popovers, tooltips, and more.
+Neither component adds a role or any ARIA attribute — `PortalTarget` is a plain `div`, and
+that is deliberate: the semantics belong to whatever you render inside it. What they do
+change is DOM position, and that has consequences:
+
+- **Reading and tab order follow the destination, not the source.** Content written next to a
+  button but portalled to the end of the page is announced and reached there. Place your
+  application-level `PortalTarget` after the main content so overlay content comes last.
+- **Focus management is not handled here.** `Portal` does not move, trap, or restore focus.
+  For dialogs use `Modal`, `Drawer`, or `Overlay`, which handle focus, focus trapping, and
+  the Escape key on top of `Portal`.
+- **Keep the relationship explicit.** When portalled content describes a control that stays
+  behind — a popover, a tooltip, an error message — wire it up with `aria-controls`,
+  `aria-describedby`, or `aria-labelledby`, since proximity in the DOM no longer implies it.
+- **Give a named target only one owner.** Two portals targeting the same name append in render
+  order; for a slot that should hold one thing at a time, render one `Portal` at a time.
+
+These notes come from reading `portal.gts` and `portal-target.gts` and the integration tests
+in `test-app/tests/integration/components/overlays/`; the tests cover destination resolution,
+not assistive-technology behavior.
 
 ## API
 

--- a/packages/frontile/src/components/utilities/collapsible.md
+++ b/packages/frontile/src/components/utilities/collapsible.md
@@ -5,7 +5,7 @@ imports:
 
 # Collapsible
 
-An unstyled component that provides smooth expand and collapse animations for content. Perfect for building accordions, FAQ sections, expandable cards, and other disclosure patterns.
+An unstyled wrapper that animates its content's height and opacity as it opens and closes, for building accordions, FAQ sections, expandable cards, and other disclosure patterns.
 
 ## Import
 
@@ -13,33 +13,21 @@ An unstyled component that provides smooth expand and collapse animations for co
 import { Collapsible } from 'frontile';
 ```
 
-## Key Features
-
-- **Smooth Animations**: Built-in height and opacity transitions with cubic-bezier easing
-- **Initial Height Support**: Show a preview of content when collapsed
-- **Fully Controlled**: Manage open/close state from parent component
-- **Unstyled**: Complete styling freedom
-- **Accessible**: Works with any accessible disclosure pattern
-- **Test-Friendly**: Built-in test waiters for reliable async testing
-
 ## Usage
 
-### Basic Collapsible
-
-A simple collapsible panel with toggle button.
+`@isOpen` is required and the component is fully controlled: keep the state in the parent and render your own trigger. Expanding animates height and opacity over `0.4s`, collapsing over `0.2s`; once expanded the height is set back to `auto` so content can keep growing.
 
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { Collapsible, Button } from 'frontile';
 
 export default class BasicCollapsible extends Component {
   @tracked isOpen = false;
 
-  @action toggle() {
+  toggle = () => {
     this.isOpen = !this.isOpen;
-  }
+  };
 
   <template>
     <div class='max-w-md'>
@@ -54,8 +42,7 @@ export default class BasicCollapsible extends Component {
         >
           <p class='text-neutral-strong'>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
-            malesuada lacus ex, sit amet blandit leo lobortis eget. Lorem ipsum
-            dolor sit amet, consectetur adipiscing elit.
+            malesuada lacus ex, sit amet blandit leo lobortis eget.
           </p>
         </div>
       </Collapsible>
@@ -64,91 +51,86 @@ export default class BasicCollapsible extends Component {
 }
 ```
 
-### With Initial Height
+## Initial Height
 
-Show a preview of content when collapsed using `@initialHeight`.
-
-> **Note:** Always include the unit (e.g., `px`, `rem`, `em`) in the height value.
+`@initialHeight` keeps part of the content visible while collapsed — the "Read more" pattern. Opacity stays at `1` instead of fading out, and only the height animates. Include the unit in the value (`80px`, `5rem`) — a bare number isn't a valid CSS height and is ignored.
 
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { Collapsible, Button } from 'frontile';
 
 export default class PreviewCollapsible extends Component {
   @tracked isOpen = false;
 
-  @action toggle() {
+  toggle = () => {
     this.isOpen = !this.isOpen;
-  }
+  };
 
   <template>
-    <div class='max-w-md'>
-      <div class='border border-neutral-subtle rounded-lg overflow-hidden'>
-        <Collapsible @isOpen={{this.isOpen}} @initialHeight='80px'>
-          <div class='p-6 bg-neutral-subtle'>
-            <h3 class='text-lg font-semibold mb-2'>Article Title</h3>
-            <p class='text-neutral'>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              Suspendisse malesuada lacus ex, sit amet blandit leo lobortis
-              eget. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-              Suspendisse malesuada lacus ex, sit amet blandit leo lobortis
-              eget. Sed hendrerit turpis nec dolor maximus, vitae facilisis
-              lectus scelerisque.
-            </p>
-          </div>
-        </Collapsible>
-
-        <div class='px-6 py-3 bg-neutral-subtle border-t border-neutral-subtle'>
-          <Button @size='sm' @appearance='minimal' @onPress={{this.toggle}}>
-            {{if this.isOpen 'Read Less' 'Read More'}}
-          </Button>
+    <div
+      class='max-w-md border border-neutral-subtle rounded-lg overflow-hidden'
+    >
+      <Collapsible @isOpen={{this.isOpen}} @initialHeight='80px'>
+        <div class='p-6 bg-neutral-subtle'>
+          <h3 class='text-lg font-semibold mb-2'>Article Title</h3>
+          <p class='text-neutral'>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            malesuada lacus ex, sit amet blandit leo lobortis eget. Lorem ipsum
+            dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada
+            lacus ex, sit amet blandit leo lobortis eget. Sed hendrerit turpis
+            nec dolor maximus, vitae facilisis lectus scelerisque.
+          </p>
         </div>
+      </Collapsible>
+
+      <div class='px-6 py-3 bg-neutral-subtle border-t border-neutral-subtle'>
+        <Button @size='sm' @appearance='minimal' @onPress={{this.toggle}}>
+          {{if this.isOpen 'Read Less' 'Read More'}}
+        </Button>
       </div>
     </div>
   </template>
 }
 ```
 
-### FAQ Accordion
+## Accordion
 
-Build an FAQ section with multiple collapsible items.
+For an accordion, hold a single open id in the parent so opening one panel closes the others.
 
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { fn } from '@ember/helper';
 import { Collapsible, Button } from 'frontile';
 
 export default class FaqAccordion extends Component {
-  @tracked openItem = null;
+  @tracked openItem: string | null = null;
 
   faqs = [
     {
       id: 'shipping',
       question: 'What are the shipping options?',
       answer:
-        'We offer standard shipping (5-7 business days) and express shipping (2-3 business days). Free standard shipping is available on orders over $50.'
+        'Standard shipping takes 5-7 business days and express shipping 2-3. Free standard shipping on orders over $50.'
     },
     {
       id: 'returns',
       question: 'What is your return policy?',
       answer:
-        'We accept returns within 30 days of purchase. Items must be unused and in original packaging. Refunds are processed within 5-10 business days.'
+        'Returns are accepted within 30 days of purchase, unused and in original packaging. Refunds are processed within 5-10 business days.'
     },
     {
       id: 'warranty',
       question: 'Do you offer a warranty?',
       answer:
-        'Yes, all products come with a 1-year manufacturer warranty covering defects in materials and workmanship. Extended warranties are available for purchase.'
+        'All products come with a 1-year manufacturer warranty covering defects in materials and workmanship.'
     }
   ];
 
-  @action toggleItem(id: string) {
+  toggleItem = (id: string) => {
     this.openItem = this.openItem === id ? null : id;
-  }
+  };
 
   isOpen = (id: string) => {
     return this.openItem === id;
@@ -158,20 +140,28 @@ export default class FaqAccordion extends Component {
     <div class='max-w-2xl space-y-2'>
       {{#each this.faqs as |faq|}}
         <div class='border border-neutral-subtle rounded-lg overflow-hidden'>
-          <Button
-            @appearance='minimal'
-            @class='w-full text-left px-6 py-4 hover:bg-neutral-subtle'
-            @onPress={{fn this.toggleItem faq.id}}
-          >
-            <div class='flex items-center justify-between'>
-              <span class='font-semibold'>{{faq.question}}</span>
-              <span class='text-neutral-soft'>
-                {{if (this.isOpen faq.id) '−' '+'}}
-              </span>
-            </div>
-          </Button>
+          <h3>
+            <Button
+              @appearance='minimal'
+              @class='w-full text-left px-6 py-4 hover:bg-neutral-subtle'
+              @onPress={{fn this.toggleItem faq.id}}
+              aria-expanded='{{this.isOpen faq.id}}'
+              aria-controls='faq-panel-{{faq.id}}'
+            >
+              <div class='flex items-center justify-between'>
+                <span class='font-semibold'>{{faq.question}}</span>
+                <span class='text-neutral-soft'>
+                  {{if (this.isOpen faq.id) '−' '+'}}
+                </span>
+              </div>
+            </Button>
+          </h3>
 
-          <Collapsible @isOpen={{this.isOpen faq.id}}>
+          <Collapsible
+            @isOpen={{this.isOpen faq.id}}
+            id='faq-panel-{{faq.id}}'
+            role='region'
+          >
             <div class='px-6 pb-4 text-neutral'>
               {{faq.answer}}
             </div>
@@ -183,61 +173,113 @@ export default class FaqAccordion extends Component {
 }
 ```
 
-### Expandable Card
+## Independent Panels
 
-Create an expandable card with additional details.
+Track one flag per panel instead of a single id and any number of them can be open at once.
 
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import { fn } from '@ember/helper';
 import { Collapsible, Button } from 'frontile';
 
-export default class ExpandableCard extends Component {
-  @tracked isExpanded = false;
+export default class IndependentPanels extends Component {
+  @tracked openPanels: Record<string, boolean> = {};
 
-  @action toggleExpand() {
-    this.isExpanded = !this.isExpanded;
-  }
+  panels = [
+    {
+      id: 'features',
+      title: 'Features',
+      body: 'Smooth animations, fully customizable markup, and no styling to fight.'
+    },
+    {
+      id: 'pricing',
+      title: 'Pricing',
+      body: 'Starting at $9.99/month with a 14-day free trial.'
+    },
+    {
+      id: 'support',
+      title: 'Support',
+      body: '24/7 email support with an average response time of 2 hours.'
+    }
+  ];
+
+  toggle = (id: string) => {
+    this.openPanels = { ...this.openPanels, [id]: !this.openPanels[id] };
+  };
+
+  isOpen = (id: string) => {
+    return !!this.openPanels[id];
+  };
 
   <template>
-    <div class='max-w-md border border-neutral-subtle rounded-lg overflow-hidden'>
-      <div class='p-6'>
-        <div class='flex items-start gap-4'>
-          <div
-            class='w-12 h-12 rounded-full bg-primary-subtle flex items-center justify-center'
-          >
-            <span class='text-primary font-semibold text-lg'>JD</span>
+    <div class='max-w-md space-y-4'>
+      {{#each this.panels as |panel|}}
+        <div class='border border-neutral-subtle rounded-lg overflow-hidden'>
+          <div class='p-4 bg-neutral-subtle border-b border-neutral-subtle'>
+            <Button
+              @appearance='minimal'
+              @class='w-full text-left font-semibold'
+              @onPress={{fn this.toggle panel.id}}
+              aria-expanded='{{this.isOpen panel.id}}'
+            >
+              {{panel.title}}
+              <span class='float-right'>
+                {{if (this.isOpen panel.id) '▲' '▼'}}
+              </span>
+            </Button>
           </div>
-          <div class='flex-1'>
-            <h3 class='font-semibold text-lg'>John Doe</h3>
-            <p class='text-neutral-soft text-sm'>Software Engineer</p>
-          </div>
+
+          <Collapsible @isOpen={{this.isOpen panel.id}}>
+            <p class='p-4 text-neutral'>{{panel.body}}</p>
+          </Collapsible>
         </div>
+      {{/each}}
+    </div>
+  </template>
+}
+```
 
-        <Collapsible @isOpen={{this.isExpanded}}>
-          <div class='mt-4 pt-4 border-t border-neutral-subtle'>
-            <dl class='space-y-2 text-sm'>
-              <div class='flex'>
-                <dt class='font-medium w-24'>Email:</dt>
-                <dd class='text-neutral'>john.doe@example.com</dd>
-              </div>
-              <div class='flex'>
-                <dt class='font-medium w-24'>Phone:</dt>
-                <dd class='text-neutral'>+1 (555) 123-4567</dd>
-              </div>
-              <div class='flex'>
-                <dt class='font-medium w-24'>Location:</dt>
-                <dd class='text-neutral'>San Francisco, CA</dd>
-              </div>
-            </dl>
-          </div>
-        </Collapsible>
-      </div>
+## Initially Open
 
-      <div class='px-6 py-3 bg-neutral-subtle border-t border-neutral-subtle'>
-        <Button @size='sm' @appearance='minimal' @onPress={{this.toggleExpand}}>
-          {{if this.isExpanded 'Show Less' 'Show More'}}
+Passing `@isOpen={{true}}` on the first render shows the content immediately, with no opening animation. Closing it afterwards animates as usual.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Collapsible, Button } from 'frontile';
+
+export default class InitiallyOpen extends Component {
+  @tracked isOpen = true;
+
+  toggle = () => {
+    this.isOpen = !this.isOpen;
+  };
+
+  <template>
+    <div class='max-w-md border border-primary-soft rounded-lg overflow-hidden'>
+      <h3
+        class='p-4 font-semibold bg-primary-subtle border-b border-primary-soft'
+      >
+        Welcome Message
+      </h3>
+
+      <Collapsible @isOpen={{this.isOpen}}>
+        <div class='p-4'>
+          <p class='text-neutral mb-4'>
+            Thank you for signing up! Here are some quick tips to get started.
+          </p>
+          <ul class='space-y-2 text-neutral'>
+            <li>→ Complete your profile</li>
+            <li>→ Connect your accounts</li>
+            <li>→ Explore the dashboard</li>
+          </ul>
+        </div>
+      </Collapsible>
+
+      <div class='px-4 py-3 bg-neutral-subtle border-t border-neutral-subtle'>
+        <Button @size='sm' @appearance='minimal' @onPress={{this.toggle}}>
+          {{if this.isOpen 'Dismiss' 'Show Again'}}
         </Button>
       </div>
     </div>
@@ -245,299 +287,93 @@ export default class ExpandableCard extends Component {
 }
 ```
 
-### Multiple Independent Panels
+## Nested Collapsibles
 
-Each panel can be controlled independently.
-
-```gts preview
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { Collapsible, Button } from 'frontile';
-
-export default class MultiplePanels extends Component {
-  @tracked isPanelOneOpen = false;
-  @tracked isPanelTwoOpen = false;
-  @tracked isPanelThreeOpen = false;
-
-  @action togglePanelOne() {
-    this.isPanelOneOpen = !this.isPanelOneOpen;
-  }
-
-  @action togglePanelTwo() {
-    this.isPanelTwoOpen = !this.isPanelTwoOpen;
-  }
-
-  @action togglePanelThree() {
-    this.isPanelThreeOpen = !this.isPanelThreeOpen;
-  }
-
-  <template>
-    <div class='max-w-md space-y-4'>
-      <div class='border border-neutral-subtle rounded-lg overflow-hidden'>
-        <div class='p-4 bg-primary-subtle border-b border-neutral-subtle'>
-          <Button
-            @appearance='minimal'
-            @class='w-full text-left font-semibold'
-            @onPress={{this.togglePanelOne}}
-          >
-            Features
-            <span class='float-right'>{{if this.isPanelOneOpen '▲' '▼'}}</span>
-          </Button>
-        </div>
-        <Collapsible @isOpen={{this.isPanelOneOpen}}>
-          <div class='p-4'>
-            <ul class='space-y-2 text-neutral'>
-              <li>✓ Smooth animations</li>
-              <li>✓ Fully customizable</li>
-              <li>✓ Accessible by default</li>
-            </ul>
-          </div>
-        </Collapsible>
-      </div>
-
-      <div class='border border-neutral-subtle rounded-lg overflow-hidden'>
-        <div class='p-4 bg-success-subtle border-b border-neutral-subtle'>
-          <Button
-            @appearance='minimal'
-            @class='w-full text-left font-semibold'
-            @onPress={{this.togglePanelTwo}}
-          >
-            Pricing
-            <span class='float-right'>{{if this.isPanelTwoOpen '▲' '▼'}}</span>
-          </Button>
-        </div>
-        <Collapsible @isOpen={{this.isPanelTwoOpen}}>
-          <div class='p-4'>
-            <p class='text-neutral'>
-              Starting at $9.99/month with a 14-day free trial.
-            </p>
-          </div>
-        </Collapsible>
-      </div>
-
-      <div class='border border-neutral-subtle rounded-lg overflow-hidden'>
-        <div class='p-4 bg-warning-subtle border-b border-neutral-subtle'>
-          <Button
-            @appearance='minimal'
-            @class='w-full text-left font-semibold'
-            @onPress={{this.togglePanelThree}}
-          >
-            Support
-            <span class='float-right'>{{if
-                this.isPanelThreeOpen
-                '▲'
-                '▼'
-              }}</span>
-          </Button>
-        </div>
-        <Collapsible @isOpen={{this.isPanelThreeOpen}}>
-          <div class='p-4'>
-            <p class='text-neutral'>
-              24/7 email support with average response time of 2 hours.
-            </p>
-          </div>
-        </Collapsible>
-      </div>
-    </div>
-  </template>
-}
-```
-
-### Initially Open
-
-Start with content expanded.
+A Collapsible can contain others. The outer one measures its content when it opens, so a nested panel that expands later grows the outer panel with it.
 
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
-import { Collapsible, Button } from 'frontile';
-
-export default class InitiallyOpen extends Component {
-  @tracked isOpen = true;
-
-  @action toggle() {
-    this.isOpen = !this.isOpen;
-  }
-
-  <template>
-    <div class='max-w-md'>
-      <div class='border border-primary-soft rounded-lg overflow-hidden'>
-        <div class='p-4 bg-primary-subtle border-b border-primary-soft'>
-          <h3 class='font-semibold'>Welcome Message</h3>
-        </div>
-
-        <Collapsible @isOpen={{this.isOpen}}>
-          <div class='p-4'>
-            <p class='text-neutral mb-4'>
-              Thank you for signing up! Here are some quick tips to get started
-              with our platform.
-            </p>
-            <ul class='space-y-2 text-neutral'>
-              <li>→ Complete your profile</li>
-              <li>→ Connect your accounts</li>
-              <li>→ Explore the dashboard</li>
-            </ul>
-          </div>
-        </Collapsible>
-
-        <div class='px-4 py-3 bg-neutral-subtle border-t border-neutral-subtle'>
-          <Button @size='sm' @appearance='minimal' @onPress={{this.toggle}}>
-            {{if this.isOpen 'Dismiss' 'Show Again'}}
-          </Button>
-        </div>
-      </div>
-    </div>
-  </template>
-}
-```
-
-### Nested Collapsibles
-
-Collapsibles can be nested within each other.
-
-```gts preview
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import { fn } from '@ember/helper';
 import { Collapsible, Button } from 'frontile';
 
 export default class NestedCollapsibles extends Component {
   @tracked isParentOpen = false;
-  @tracked isChildOneOpen = false;
-  @tracked isChildTwoOpen = false;
+  @tracked openChildren: Record<string, boolean> = {};
 
-  @action toggleParent() {
+  subcategories = [
+    { id: 'one', title: 'Subcategory 1', body: 'Details for subcategory 1' },
+    { id: 'two', title: 'Subcategory 2', body: 'Details for subcategory 2' }
+  ];
+
+  toggleParent = () => {
     this.isParentOpen = !this.isParentOpen;
-  }
+  };
 
-  @action toggleChildOne() {
-    this.isChildOneOpen = !this.isChildOneOpen;
-  }
+  toggleChild = (id: string) => {
+    this.openChildren = { ...this.openChildren, [id]: !this.openChildren[id] };
+  };
 
-  @action toggleChildTwo() {
-    this.isChildTwoOpen = !this.isChildTwoOpen;
-  }
+  isChildOpen = (id: string) => {
+    return !!this.openChildren[id];
+  };
 
   <template>
-    <div class='max-w-md'>
-      <div class='border border-neutral-subtle rounded-lg overflow-hidden'>
-        <div class='p-4 bg-neutral-subtle'>
-          <Button
-            @appearance='minimal'
-            @class='w-full text-left font-semibold'
-            @onPress={{this.toggleParent}}
-          >
-            Category
-            <span class='float-right'>{{if this.isParentOpen '▲' '▼'}}</span>
-          </Button>
-        </div>
-
-        <Collapsible @isOpen={{this.isParentOpen}}>
-          <div class='p-4 space-y-2'>
-            <div class='border border-neutral-subtle rounded overflow-hidden'>
-              <div class='p-3 bg-neutral-subtle'>
-                <Button
-                  @appearance='minimal'
-                  @size='sm'
-                  @class='w-full text-left'
-                  @onPress={{this.toggleChildOne}}
-                >
-                  Subcategory 1
-                  <span class='float-right'>{{if
-                      this.isChildOneOpen
-                      '−'
-                      '+'
-                    }}</span>
-                </Button>
-              </div>
-              <Collapsible @isOpen={{this.isChildOneOpen}}>
-                <div class='p-3 text-sm text-neutral'>
-                  Details for subcategory 1
-                </div>
-              </Collapsible>
-            </div>
-
-            <div class='border border-neutral-subtle rounded overflow-hidden'>
-              <div class='p-3 bg-neutral-subtle'>
-                <Button
-                  @appearance='minimal'
-                  @size='sm'
-                  @class='w-full text-left'
-                  @onPress={{this.toggleChildTwo}}
-                >
-                  Subcategory 2
-                  <span class='float-right'>{{if
-                      this.isChildTwoOpen
-                      '−'
-                      '+'
-                    }}</span>
-                </Button>
-              </div>
-              <Collapsible @isOpen={{this.isChildTwoOpen}}>
-                <div class='p-3 text-sm text-neutral'>
-                  Details for subcategory 2
-                </div>
-              </Collapsible>
-            </div>
-          </div>
-        </Collapsible>
+    <div
+      class='max-w-md border border-neutral-subtle rounded-lg overflow-hidden'
+    >
+      <div class='p-4 bg-neutral-subtle'>
+        <Button
+          @appearance='minimal'
+          @class='w-full text-left font-semibold'
+          @onPress={{this.toggleParent}}
+          aria-expanded='{{this.isParentOpen}}'
+        >
+          Category
+          <span class='float-right'>{{if this.isParentOpen '▲' '▼'}}</span>
+        </Button>
       </div>
+
+      <Collapsible @isOpen={{this.isParentOpen}}>
+        <div class='p-4 space-y-2'>
+          {{#each this.subcategories as |sub|}}
+            <div class='border border-neutral-subtle rounded overflow-hidden'>
+              <div class='p-3 bg-neutral-subtle'>
+                <Button
+                  @appearance='minimal'
+                  @size='sm'
+                  @class='w-full text-left'
+                  @onPress={{fn this.toggleChild sub.id}}
+                  aria-expanded='{{this.isChildOpen sub.id}}'
+                >
+                  {{sub.title}}
+                  <span class='float-right'>
+                    {{if (this.isChildOpen sub.id) '−' '+'}}
+                  </span>
+                </Button>
+              </div>
+
+              <Collapsible @isOpen={{this.isChildOpen sub.id}}>
+                <p class='p-3 text-sm text-neutral'>{{sub.body}}</p>
+              </Collapsible>
+            </div>
+          {{/each}}
+        </div>
+      </Collapsible>
     </div>
   </template>
 }
 ```
 
-## Important Notes
+## Accessibility
 
-### Animation Behavior
+Collapsible renders a plain `<div>` with no roles or ARIA of its own, and it has no trigger — the disclosure semantics are yours to supply. It forwards `...attributes`, so `id`, `role`, and `aria-*` can be set on it directly.
 
-The Collapsible component animates both height and opacity:
-
-- **Expanding**: Height and opacity transition smoothly to full size over 0.4s
-- **Collapsing**: Height and opacity transition to collapsed state over 0.2-0.3s
-- **Easing**: Uses cubic-bezier easing for smooth, natural motion
-
-After expansion completes, the height is set to `auto` and overflow is reset to allow dynamic content changes.
-
-### Initial Height
-
-When using `@initialHeight`:
-
-- Content is always visible up to the specified height, even when collapsed
-- Opacity remains at `1` when collapsed (instead of fading to `0`)
-- Useful for "Read More" patterns and content previews
-- Remember to include units (`px`, `rem`, `em`, etc.)
-
-### State Management
-
-The component is **fully controlled**:
-
-- You must manage the `@isOpen` state in your parent component
-- Toggle the state with your own button or trigger
-- This gives you complete control over when and how the collapsible opens
-
-### Styling
-
-The component is **unstyled** by default:
-
-- Apply your own classes and styles to the content wrapper
-- Style the trigger button however you need
-- Works with any CSS framework or custom styles
-- The component only manages height and opacity transitions
-
-### Accessibility
-
-When building collapsible UIs, remember to:
-
-- Use semantic HTML (buttons for triggers)
-- Add `aria-expanded` to toggle buttons
-- Add `aria-controls` linking trigger to content
-- Consider `aria-labelledby` for the content region
-- Use proper heading hierarchy for accordion items
-
-Example accessible pattern:
+- Use a real `<button>` (or Frontile's `Button`) as the trigger, so Enter, Space, and focus work without extra code.
+- Put `aria-expanded` on the trigger, mirroring the same state you pass to `@isOpen`.
+- Point `aria-controls` at the Collapsible's `id`, and give the Collapsible `role="region"` when it holds a self-contained chunk of content.
+- In an accordion, wrap each trigger in a heading (`<h3>` and so on) at the right level for the surrounding page.
+- Collapsed content stays in the DOM and remains focusable, so avoid interactive elements inside a panel that is expected to read as hidden.
 
 ```gts
 <button
@@ -554,13 +390,7 @@ Example accessible pattern:
 </Collapsible>
 ```
 
-### Testing
-
-The component includes built-in test waiters:
-
-- Transitions are properly tracked for test stability
-- Use `await settled()` in tests to wait for animations
-- The component waits for height and opacity transitions to complete
+> **Note:** Transitions are registered with an Ember test waiter, so `await settled()` in tests resolves only after the open or close animation has finished.
 
 ## API
 

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -11749,7 +11749,8 @@ const data: ComponentDoc[] = [
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,
         isInternal: false,
-        description: 'Target name',
+        description:
+          "Name of this target, matched against a `Portal`'s `@target` argument.\n\nWhen omitted, the target is unnamed: any `Portal` rendered below it that\nhas no `@target` and no parent portal will render here. A named target is\nonly used by portals that ask for it by name.",
         tags: {},
       },
     ],


### PR DESCRIPTION
Sixth in the stack, on top of #484. This is the one that most needs your judgment, because it deletes things.

```
collapsible.md   567 -> 379 lines, demos 7 -> 6
form.md         1903 -> 1475 lines, demos 13 -> 13
portal.md        170 -> 246 lines, demos 5 -> 7
```

## What was cut

All three carried the same shape of waste: a `## Key Features` list restating arguments, and an `## Important Notes` / `## Best Practices` section collecting facts *away* from the thing they describe, where a reader scanning for a feature won't find them. Those are dissolved into the sections that demonstrate them.

Both collapsible and form gained the `## Accessibility` section they were missing. In collapsible's case a11y had been buried as an `###` inside Important Notes.

## The demo removals — please check these two calls

The rule applied is that prose can be rewritten from source at any time, but a demo is executable proof and the only part of the page the site runs, so removing one needs a named replacement.

- **collapsible drops "Expandable Card."** Its state is a plain uncontrolled `@isOpen` toggle, which `## Usage` and the `## Initial Height` read-more card both exercise. Every other state keeps its own demo: `@initialHeight`, single-open accordion, independently-open panels, initially-open-on-first-render, nesting.
- **form drops "Real-time Form Updates."** Its state — live `@onChange` data plus `@onSubmit` — is exercised by the retained controlled-form demo, with Checkbox/CheckboxGroup/Radio/Textarea/NativeSelect coverage retained in `## Form Components`. form also *gains* a genuinely minimal `## Usage` demo, since the old opening example was a 77-line JSON dump.

Two survivors in collapsible were consolidated into `{{#each}}` loops rather than trimmed — same states proven in a third of the lines.

If you disagree with either removal, they're one revert each.

## portal.md gets longer

It was underdocumented rather than bloated — PortalTarget had no real coverage despite the page being titled after it. Two defects fixed:

- The "Basic Example" fence was missing `preview`, so **that demo had been rendering as dead source**.
- `for`'s JSDoc was the two words "Target name", making its generated API row useless.

## One doc-vs-source correction

`form.md` claimed `@validateOn` defaults to `['change', 'submit']`. [`form.gts:231`](packages/frontile/src/components/forms/form.gts) returns `['change', 'blur', 'submit']`.

Left alone deliberately: `validateOn`'s JSDoc still has no `@defaultValue`, so it renders without a default in the API table. That's a source edit, outside a prose-tightening change.

## Verification

- `pnpm build` then `generate-signature-data` (that order; deletes 0 component entries)
- `cd site && pnpm build` clean — every demo compiles
- Demo-loss guard: one expected warning for collapsible's justified removal, and one for a portal.md fragment containing `{{outlet}}`, which genuinely cannot run as a preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)