### PR TITLE
Document real accessibility behavior for overlays

### DIFF
--- a/packages/frontile/src/components/overlays/drawer.md
+++ b/packages/frontile/src/components/overlays/drawer.md
@@ -14,15 +14,6 @@ The Drawer component is a slide-out panel that appears from any edge of the scre
 import { Drawer } from 'frontile';
 ```
 
-## Key Features
-
-- **Multiple Placements**: Slide from top, bottom, left, or right
-- **Flexible Sizing**: Multiple size options from xs to full screen
-- **Built-in Components**: Header, Body, Footer, and CloseButton
-- **Accessible**: Proper ARIA attributes and focus management
-- **Customizable**: Control close button visibility and behavior
-- **All Overlay Features**: Focus trapping, keyboard support, portal rendering, etc.
-
 ## Usage
 
 ### Basic Drawer
@@ -703,53 +694,43 @@ export default class NavigationDrawer extends Component {
 }
 ```
 
-## Important Notes
+## Anatomy
 
-### Yielded Components
+Drawer yields the pieces you assemble it from:
 
-The Drawer component yields several components for easy composition:
+| Yielded       | Purpose                                                         |
+| ------------- | --------------------------------------------------------------- |
+| `Header`      | Heading region; applies the id that `aria-labelledby` points at |
+| `Body`        | Main content area                                               |
+| `Footer`      | Action row                                                      |
+| `CloseButton` | Styled close button wired to `@onClose`                         |
+| `headerId`    | The id `Header` uses, for labelling your own heading instead    |
 
-- **`CloseButton`**: A close button with proper styling and onPress handler
-- **`Header`**: A header section with proper ID for accessibility
-- **`Body`**: The main content area
-- **`Footer`**: A footer section for actions or additional content
-- **`headerId`**: A unique ID string for the header (used for aria-labelledby)
+## Accessibility
 
-### Accessibility
+The drawer renders as `role="dialog"` with `tabindex="0"`, labelled by `aria-labelledby`
+pointing at the id yielded as `headerId` — which `<d.Header>` applies. **A drawer with no
+`Header` has a dangling label reference.** Render a `Header`, or put `headerId` on your own
+heading, so assistive technology has something to announce.
 
-The Drawer component includes built-in accessibility features:
+Behavior inherited from [Overlay](./overlay.md):
 
-- **ARIA Attributes**: Proper `role="dialog"` and `aria-labelledby` attributes
-- **Focus Management**: Inherits all focus management from Overlay component
-- **Keyboard Support**: Escape key to close (can be disabled)
-- **Screen Reader Support**: Proper semantic structure
+| Behavior       | Detail                                                 |
+| -------------- | ------------------------------------------------------ |
+| Focus on open  | Moves into the drawer, and a focus trap keeps it there |
+| Focus on close | Returns to whatever was focused before opening         |
+| `Escape`       | Closes, unless `@closeOnEscapeKey={{false}}`           |
+| Backdrop click | Closes, unless `@closeOnOutsideClick={{false}}`        |
+| Body scroll    | Blocked while open                                     |
 
-### Size Variants
+The drawer needs at least one focusable element inside it, or the focus trap has nowhere to
+put focus. `@allowClosing={{false}}` disables Escape, backdrop click and the close button at
+once, leaving a keyboard user no way out — the Non-Dismissible example above pairs it with
+explicit footer actions for that reason.
 
-Available size options:
-
-- **`xs`**: Extra small
-- **`sm`**: Small
-- **`md`**: Medium (default)
-- **`lg`**: Large
-- **`xl`**: Extra large
-- **`full`**: Full width/height
-
-### Placement Options
-
-Available placement options:
-
-- **`top`**: Slides down from top
-- **`bottom`**: Slides up from bottom
-- **`left`**: Slides in from left
-- **`right`**: Slides in from right (default)
-
-### Controlling Close Behavior
-
-- **`@allowClosing={{false}}`**: Disables all close methods (Escape, backdrop click, close button)
-- **`@allowCloseButton={{false}}`**: Hides the default close button
-- **`@closeOnOutsideClick={{false}}`**: Disables backdrop click to close
-- **`@closeOnEscapeKey={{false}}`**: Disables Escape key to close
+Note that `@placement` is purely visual: a drawer sliding in from the left is announced no
+differently from one on the right, and nothing about the placement reaches assistive
+technology. Frontile also does not set `aria-modal` or `aria-describedby`.
 
 ## API
 

--- a/packages/frontile/src/components/overlays/modal.md
+++ b/packages/frontile/src/components/overlays/modal.md
@@ -14,15 +14,6 @@ The Modal component is a centered dialog that appears over the main content. It'
 import { Modal } from 'frontile';
 ```
 
-## Key Features
-
-- **Centered Positioning**: Automatically centers content on screen
-- **Flexible Sizing**: Multiple size options from xs to full screen
-- **Built-in Components**: Header, Body, Footer, and CloseButton
-- **Accessible**: Proper ARIA attributes and focus management
-- **Customizable**: Control close button visibility and behavior
-- **All Overlay Features**: Focus trapping, keyboard support, portal rendering, etc.
-
 ## Usage
 
 ### Basic Modal
@@ -178,7 +169,8 @@ export default class ModalSizes extends Component {
 
 ### Centered vs Standard Positioning
 
-Control vertical centering with the `@isCentered` argument.
+By default the modal sits toward the top of the screen. `@isCentered={{true}}` centers it
+vertically.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -738,8 +730,8 @@ export default class NestedModals extends Component {
         <m.Body>
           <p class='mb-4'>This is the first modal. You can open another modal
             from here.</p>
-          <p class='text-sm text-neutral'>Notice how the backdrop becomes
-            darker with each modal layer.</p>
+          <p class='text-sm text-neutral'>Notice how the backdrop becomes darker
+            with each modal layer.</p>
 
           <!-- Second Modal -->
           <Modal
@@ -752,8 +744,8 @@ export default class NestedModals extends Component {
             <m.Body>
               <p class='mb-4'>This is the second modal, opened from the first
                 one.</p>
-              <p class='text-sm text-neutral'>You can continue nesting
-                modals as needed.</p>
+              <p class='text-sm text-neutral'>You can continue nesting modals as
+                needed.</p>
 
               <!-- Third Modal -->
               <Modal
@@ -766,8 +758,8 @@ export default class NestedModals extends Component {
                 <m.Body>
                   <p class='mb-4'>This is the third and final modal in this
                     example.</p>
-                  <p class='text-sm text-neutral'>Each modal maintains its
-                    own focus trap and can be closed independently.</p>
+                  <p class='text-sm text-neutral'>Each modal maintains its own
+                    focus trap and can be closed independently.</p>
                 </m.Body>
                 <m.Footer @class='flex gap-2'>
                   <Button @onPress={{this.toggleThird}}>
@@ -805,57 +797,43 @@ export default class NestedModals extends Component {
 }
 ```
 
-## Important Notes
+## Anatomy
 
-### Yielded Components
+Modal yields the pieces you assemble the dialog from:
 
-The Modal component yields several components for easy composition:
+| Yielded       | Purpose                                                         |
+| ------------- | --------------------------------------------------------------- |
+| `Header`      | Heading region; applies the id that `aria-labelledby` points at |
+| `Body`        | Main content area                                               |
+| `Footer`      | Action row                                                      |
+| `CloseButton` | Styled close button wired to `@onClose`                         |
+| `headerId`    | The id `Header` uses, for labelling your own heading instead    |
 
-- **`CloseButton`**: A close button with proper styling and onPress handler
-- **`Header`**: A header section with proper ID for accessibility
-- **`Body`**: The main content area
-- **`Footer`**: A footer section for actions or additional content
-- **`headerId`**: A unique ID string for the header (used for aria-labelledby)
+## Accessibility
 
-### Accessibility
+The dialog element renders as `role="dialog"` with `tabindex="0"`, labelled by
+`aria-labelledby` pointing at the id yielded as `headerId` — which is applied by
+`<m.Header>`. **A modal with no `Header` therefore has a dangling label reference.** Either
+render a `Header`, or put `headerId` on your own heading element, so assistive technology
+has something to announce.
 
-The Modal component includes built-in accessibility features:
+Behavior inherited from [Overlay](./overlay.md):
 
-- **ARIA Attributes**: Proper `role="dialog"` and `aria-labelledby` attributes
-- **Focus Management**: Inherits all focus management from Overlay component
-- **Keyboard Support**: Escape key to close (can be disabled)
-- **Screen Reader Support**: Proper semantic structure
+| Behavior       | Detail                                                |
+| -------------- | ----------------------------------------------------- |
+| Focus on open  | Moves into the modal, and a focus trap keeps it there |
+| Focus on close | Returns to whatever was focused before opening        |
+| `Escape`       | Closes, unless `@closeOnEscapeKey={{false}}`          |
+| Backdrop click | Closes, unless `@closeOnOutsideClick={{false}}`       |
+| Body scroll    | Blocked while open                                    |
 
-### Size Variants
+The modal needs at least one focusable element inside it, or the focus trap has nowhere to
+put focus. Note that `@allowClosing={{false}}` disables Escape, backdrop click and the close
+button together, which leaves a keyboard user no way out — reserve it for flows that provide
+their own explicit resolution.
 
-Available size options:
-
-- **`xs`**: Extra small
-- **`sm`**: Small
-- **`md`**: Medium
-- **`lg`**: Large (default)
-- **`xl`**: Extra large
-- **`full`**: Full screen
-
-### Positioning
-
-- **Standard**: Modal appears towards the top of the screen
-- **Centered**: Use `@isCentered={{true}}` to vertically center the modal
-
-### Controlling Close Behavior
-
-- **`@allowClosing={{false}}`**: Disables all close methods (Escape, backdrop click, close button)
-- **`@allowCloseButton={{false}}`**: Hides the default close button
-- **`@closeOnOutsideClick={{false}}`**: Disables backdrop click to close
-- **`@closeOnEscapeKey={{false}}`**: Disables Escape key to close
-
-### Best Practices
-
-- Use modals sparingly to avoid overwhelming users
-- Keep modal content focused and concise
-- Provide clear actions in the footer
-- Use appropriate sizes for the content
-- Consider using drawers for complex forms or navigation
+Frontile does not set `aria-modal` or `aria-describedby`. Add them yourself if your dialog
+needs them.
 
 ## API
 

--- a/packages/frontile/src/components/overlays/overlay.md
+++ b/packages/frontile/src/components/overlays/overlay.md
@@ -13,19 +13,6 @@ The Overlay component is the foundation for building overlay interactions like M
 import { Overlay } from 'frontile';
 ```
 
-## Key Features
-
-- **Auto-Focusing**: Automatically focuses the overlay when opened
-- **Focus Trapping**: Keeps focus within the overlay while open
-- **Portal Rendering**: Renders in a portal by default, with option to render in-place
-- **Keyboard Support**: Press `Esc` to dismiss
-- **Click Outside**: Click on the backdrop to dismiss
-- **Smooth Animations**: Built-in CSS transitions
-- **Scroll Management**: Prevents body scroll when overlay is open
-- **Focus Restoration**: Restores focus to the previously focused element when closed
-
-> **Important**: You must have at least one focusable element inside the Overlay for proper accessibility.
-
 ## Usage
 
 ### Basic Overlay
@@ -191,8 +178,8 @@ export default class RenderInPlace extends Component {
       <div
         class='relative border-2 border-dashed border-neutral-soft p-4 min-h-48'
       >
-        <p class='text-sm text-neutral mb-4'>This container shows the
-          difference between portal and in-place rendering.</p>
+        <p class='text-sm text-neutral mb-4'>This container shows the difference
+          between portal and in-place rendering.</p>
 
         <Overlay
           @isOpen={{this.inPlaceOpen}}
@@ -577,42 +564,42 @@ export default class OverlayElementClick extends Component {
 >
 > This option is set to `true` by default to make "outside click" functionality work intuitively. Most overlay content is wrapped with an inner element (like a card or dialog), which prevents accidental closure when clicking on the actual content. The overlay element itself acts as part of the "outside" area, allowing users to click anywhere around the content to dismiss the overlay.
 
-## Important Notes
+## Using Power Select inside an Overlay
 
-### Focus Requirements
+`FormSelect` uses Power Select, which defaults to `@renderInPlace={{false}}` and so inserts
+its dropdown outside the overlay. The focus trap then treats the dropdown as outside the
+overlay and blocks access to it, including its search input.
 
-> **Important**: You must have at least one focusable element inside the Overlay for proper accessibility and focus management.
+Pass `@renderInPlace={{true}}` on the `FormSelect` so the dropdown stays inside the trap:
 
-### Portal Elements and FormSelect
+```gts
+<FormSelect @renderInPlace={{true}} />
+```
 
-`FormSelect` uses Power Select under the hood and has `@renderInPlace={{false}}` set by default, which will insert the dropdown content outside of the Overlay. This can cause focus-trap to prevent accessing focusable elements (like search input) in the Power Select dropdown.
-
-**Solutions:**
-
-- Use `<FormSelect @renderInPlace={{true}} />` (recommended)
-- Use `<Overlay @disableFocusTrap={{true}} />` (not recommended for accessibility)
-
-### Backdrop Types
-
-- **`faded`** (default): Semi-transparent backdrop
-- **`blur`**: Backdrop with blur effect
-- **`none`**: No backdrop
-
-### Transition Options
-
-- **`transitionDuration`**: Duration in milliseconds (default: 200ms)
-- **`disableTransitions`**: Disable all animations (default: false)
-- **`transition`**: Custom transition configuration
+Disabling the overlay's focus trap with `@disableFocusTrap={{true}}` also works, but it
+removes the trap for everything else in the overlay too — prefer the first option.
 
 ## Accessibility
 
-The Overlay component follows accessibility best practices:
+Overlay is the primitive under Modal, Drawer and Popover, and supplies their shared focus
+and keyboard behavior. It sets `tabindex="0"` on the content element but no role — a
+semantic role is the consuming component's job, which is why Modal and Drawer add
+`role="dialog"` themselves. If you build directly on Overlay, give it a role and an
+accessible name.
 
-- **Focus Management**: Automatically focuses the overlay when opened and restores focus when closed
-- **Focus Trapping**: Keeps focus within the overlay (can be disabled)
-- **Keyboard Support**: Escape key to close (can be disabled)
-- **Screen Reader Support**: Proper ARIA roles and attributes
-- **Scroll Management**: Prevents body scroll when overlay is open
+| Behavior       | Detail                                                                     |
+| -------------- | -------------------------------------------------------------------------- |
+| Focus on open  | Moves into the overlay; `ember-focus-trap` keeps it there                  |
+| Focus trap     | Disable with `@disableFocusTrap={{true}}`, or tune via `@focusTrapOptions` |
+| Focus on close | Returns to the previously focused element, unless `@preventFocusRestore`   |
+| `Escape`       | Closes, unless `@closeOnEscapeKey={{false}}`                               |
+| Backdrop click | Closes, unless `@closeOnOutsideClick={{false}}`                            |
+| Body scroll    | Blocked while open, unless `@blockScroll={{false}}`                        |
+
+**The overlay needs at least one focusable element inside it.** A focus trap with nothing to
+focus leaves the keyboard stranded, and nothing warns you at runtime.
+
+Frontile does not set `aria-modal`, `aria-labelledby` or `aria-describedby` at this level.
 
 ## API
 

--- a/packages/frontile/src/components/overlays/popover.md
+++ b/packages/frontile/src/components/overlays/popover.md
@@ -323,6 +323,37 @@ import { Button } from 'frontile';
 </template>
 ```
 
+## Accessibility
+
+The `trigger` modifier sets three attributes on whatever element you attach it to, and keeps
+the last one in sync as the popover opens and closes:
+
+```
+aria-haspopup="true"
+aria-controls="<the content's id>"
+aria-expanded="true" | "false"
+```
+
+Because those go on your element, the trigger should be something natively focusable — a
+`<button>`. Attaching `trigger` to a `<div>` gives you the ARIA without the keyboard.
+
+With the default `click` trigger type, the trigger handles:
+
+| Key                     | Behavior                                                       |
+| ----------------------- | -------------------------------------------------------------- |
+| `Enter` / `Space`       | Toggles, via the element's native click                        |
+| `ArrowDown` / `ArrowUp` | Opens when closed                                              |
+| any letter key          | Opens when closed, for type-ahead into the content             |
+| `Escape`                | Closes when open                                               |
+| `Tab`                   | Closes and moves on, without pulling focus back to the trigger |
+
+Focus moves into the content when it opens and returns to the trigger when it closes.
+
+**`{{p.trigger "hover"}}` is mouse-only.** The hover branch attaches `mouseenter` and
+`mouseleave` and no key handling at all, so none of the keys above work and focus is not
+restored on close. A hover popover is fine for supplementary content that is also reachable
+another way; don't put anything a keyboard or screen-reader user needs behind one.
+
 ## API
 
 <Signature @component="Popover" />


### PR DESCRIPTION
First of the next batch. Overlays chosen to start because focus management is where getting it wrong hurts most.

Modal, Drawer and Popover had no top-level `## Accessibility` section. What existed elsewhere was unverifiable — *"Proper ARIA attributes"*, *"Screen Reader Support: Proper semantic structure"*. A component library gets chosen partly on whether its keyboard behavior can be trusted without reading the implementation, so these now state what the source actually does.

## What the source actually does

Read off the components and their integration tests:

- **Modal and Drawer** render `role="dialog"` with `tabindex="0"` and `aria-labelledby` pointing at `${guidFor(this)}-header` — the id that `Header` applies. **Without a `Header`, that reference dangles.** Documented nowhere before; now called out on both pages with the `headerId` escape hatch for labelling your own heading.
- **Overlay** sets `tabindex="0"` and *no* role, which is why Modal and Drawer add their own. Worth stating for anyone building directly on it.
- **`@allowClosing={{false}}`** disables Escape, backdrop click and the close button together, leaving a keyboard user no way out.
- **Popover's trigger** sets `aria-haspopup`, `aria-controls` and a synced `aria-expanded`, and handles `Escape`, `ArrowUp`/`ArrowDown`, `Tab`, and **any letter key** for type-ahead. None of that was documented.
- **`{{p.trigger "hover"}}` is mouse-only.** The hover branch attaches `mouseenter`/`mouseleave` and no `keydown` handler at all, so none of those keys work and focus isn't restored on close. That's a real gap for anyone putting functionality behind a hover popover — the page now says so plainly instead of implying parity with click.
- Frontile sets **no `aria-modal` or `aria-describedby`** anywhere. The pages say so rather than implying full dialog semantics.

## Structural cleanup, same pass

Each file gets touched once, so the heading vocabulary fixes ride along:

- `## Key Features` deleted — every bullet restated an argument the generated API table already carries.
- `## Important Notes` / `## Best Practices` dissolved, with load-bearing content moved to where it applies. The yielded-components lists became a real `## Anatomy` table on Modal and Drawer, and Overlay's Power Select footgun became a named section, since a focus trap swallowing Power Select's search input is genuinely surprising.
- Dropped as duplication: the **Size Variants** and **Placement Options** bullet lists. Both restate enums the API table already shows *with* their defaults (`@defaultValue 'lg'` for Modal, `'md'` for Drawer, `'right'` for placement), and both already have live demos directly above them. Generic Best Practices advice went too.

Net −151/+128 lines, and the pages gained content where it counts.

## Verification

- Linter: **0 errors, 0 warnings** across all four files, with `--since HEAD` on — **no demo was removed**
- `cd site && pnpm build` clean, so every demo still compiles
- Prettier clean

## What's left after this

From the linter on `main`: 14 more docs missing `## Accessibility` (buttons ×5, collections ×4, utilities ×4, forms/select, status/progress-bar), 11 discouraged headings across collections/forms/utilities, and **4 genuinely dead demos in `field.md`** where a `gts` fence is missing `preview`. I'll take those by category the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)