### PR TITLE
fix(forms): match the `description` block name in FormControl's guard

### DIFF
--- a/packages/frontile/src/components/forms/form-control.gts
+++ b/packages/frontile/src/components/forms/form-control.gts
@@ -171,7 +171,7 @@ class FormControl extends Component<FormControlSignature> {
         </Label>
       {{/if}}
 
-      {{#if (or @description (has-block "Description"))}}
+      {{#if (or @description (has-block "description"))}}
         <Description @id={{this.descriptionId}} @size={{@size}}>
           {{@description}}
           {{yield to="description"}}

--- a/packages/frontile/src/components/forms/form-control.md
+++ b/packages/frontile/src/components/forms/form-control.md
@@ -127,6 +127,30 @@ import { FormControl } from 'frontile';
 </template>
 ```
 
+`:description` works the same way, for help text that needs a link or inline markup. It
+renders inside the same description element that `@description` would have produced, so
+`c.describedBy` still points the control at it.
+
+```gts preview
+import { FormControl } from 'frontile';
+
+<template>
+  <FormControl @label='Webhook URL'>
+    <:description>
+      Must be publicly reachable over HTTPS.
+      <a href='#docs' class='text-primary underline'>Read the requirements</a>
+    </:description>
+    <:default as |c|>
+      <input
+        id={{c.id}}
+        aria-describedby={{c.describedBy true false}}
+        class='bg-surface-input text-neutral-strong border-neutral-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
+      />
+    </:default>
+  </FormControl>
+</template>
+```
+
 ## Sizes
 
 `@size` scales the label, description and feedback text. It does not touch the control

--- a/test-app/tests/integration/components/forms/form-control-test.gts
+++ b/test-app/tests/integration/components/forms/form-control-test.gts
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+import { FormControl } from 'frontile';
+
+module(
+  'Integration | Component | @frontile/forms/FormControl',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders the :description named block without @description', async function (assert) {
+      await render(
+        <template>
+          <FormControl>
+            <:description>My description block</:description>
+          </FormControl>
+        </template>
+      );
+
+      assert
+        .dom('[data-component="form-description"]')
+        .exists('the description region renders from the named block alone');
+      assert
+        .dom('[data-component="form-description"]')
+        .hasText('My description block');
+    });
+
+    test('it renders the :label named block without @label', async function (assert) {
+      await render(
+        <template>
+          <FormControl>
+            <:label>My label block</:label>
+          </FormControl>
+        </template>
+      );
+
+      assert.dom('[data-component="label"]').exists();
+      assert.dom('[data-component="label"]').hasText('My label block');
+    });
+
+    test('it renders both named blocks together', async function (assert) {
+      await render(
+        <template>
+          <FormControl>
+            <:label>The label</:label>
+            <:description>The description</:description>
+          </FormControl>
+        </template>
+      );
+
+      assert.dom('[data-component="label"]').hasText('The label');
+      assert
+        .dom('[data-component="form-description"]')
+        .hasText('The description');
+    });
+
+    test('it still renders the @label and @description arguments', async function (assert) {
+      await render(
+        <template>
+          <FormControl @label="Arg label" @description="Arg description" />
+        </template>
+      );
+
+      assert.dom('[data-component="label"]').hasText('Arg label');
+      assert
+        .dom('[data-component="form-description"]')
+        .hasText('Arg description');
+    });
+
+    test('it renders neither region when no label or description is provided', async function (assert) {
+      await render(<template><FormControl /></template>);
+
+      assert.dom('[data-component="label"]').doesNotExist();
+      assert.dom('[data-component="form-description"]').doesNotExist();
+    });
+  }
+);


### PR DESCRIPTION
## Summary

`FormControl` guarded its description region with `(has-block "Description")`, but the block is declared as `description:` in the `Blocks` type and yielded as `{{yield to="description"}}`. Block names are case-sensitive, so that guard never matched.

The effect: a consumer who passed only a `:description` named block — without also passing the `@description` argument — got nothing rendered. The block was silently dropped. The `label` guard one line above already used the correct lowercase name.

```diff
-{{#if (or @description (has-block "Description"))}}
+{{#if (or @description (has-block "description"))}}
```

## Changes

- **Fix** the guard in `packages/frontile/src/components/forms/form-control.gts`.
- **Add** `test-app/tests/integration/components/forms/form-control-test.gts`. `FormControl` had no test file at all; this covers the `:description` block on its own, the `:label` block on its own, both together, the plain `@label`/`@description` arguments, and neither region rendering when nothing is passed.
- **Document** `:description` in `form-control.md`, which deliberately omitted it while the block was broken.

## Verification

Tests were written first and failed exactly as expected — the two `:description`-block tests reported `Element [data-component="form-description"] does not exist`, while the `:label` tests passed. After the fix all 5 pass.

- `pnpm --filter frontile build` — clean, glint declarations succeeded
- `ember test --filter="FormControl"` — 5/5 pass
- Full suite — **812 tests, 809 pass, 3 skip, 0 fail**. Worth running in full, since `FormControl` backs Input, Select, Checkbox, Switch, Autocomplete and NativeSelect; the change only makes the region render in the previously-dead case.
- `pnpm --filter frontile lint:types` — clean
- Docs linter (`lint-docs.mjs`) on `form-control.md` — 0 errors, 0 warnings

One note on where those runs happened: the suite was run at `f43b7714`, and this branch is based on `51ebbc8f` (12 commits newer). Between those two commits the diff to `form-control.gts`, `form-description.gts` and `label.gts` is JSDoc comments and blank lines only — the runtime code under test is unchanged — so the results carry over. The site build was not run, so the new demo is lint-clean but not render-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)