### PR TITLE
Fold reusable local Claude permissions into project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,19 +4,50 @@
     "allow": [
       "WebSearch",
       "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)",
+
+      "Bash(cat:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(xargs:*)",
+
+      "Bash(pnpm install:*)",
       "Bash(pnpm build)",
+      "Bash(pnpm start)",
       "Bash(pnpm ember test:*)",
-      "Bash(pnpm run lint:js:*)",
       "Bash(pnpm lint:js:*)",
+      "Bash(pnpm run lint:js:*)",
+
+      "Bash(pnpm --filter frontile build)",
+      "Bash(pnpm --filter frontile lint:types:*)",
       "Bash(pnpm --filter buttons build)",
       "Bash(pnpm --filter collections build)",
-      "Bash(pnpm --filter core build)",
       "Bash(pnpm --filter forms build)",
-      "Bash(pnpm --filter frontile build)",
       "Bash(pnpm --filter notifications build)",
       "Bash(pnpm --filter overlays build)",
       "Bash(pnpm --filter status build)",
-      "Bash(pnpm --filter theme build)"
+      "Bash(pnpm --filter theme build)",
+      "Bash(pnpm --filter theme lint:types:*)",
+      "Bash(pnpm --filter collections lint:types:*)",
+      "Bash(pnpm --filter forms-legacy build:*)",
+
+      "Bash(pnpm --filter @frontile/theme build:*)",
+      "Bash(pnpm --filter @frontile/theme lint:types:*)",
+      "Bash(pnpm --filter @frontile/buttons build:*)",
+      "Bash(pnpm --filter @frontile/collections build:*)",
+      "Bash(pnpm --filter @frontile/forms build:*)",
+      "Bash(pnpm --filter @frontile/notifications build:*)",
+      "Bash(pnpm --filter @frontile/overlays build:*)",
+      "Bash(pnpm --filter @frontile/status build:*)",
+      "Bash(pnpm --filter @frontile/utilities build:*)",
+
+      "Bash(pnpm --filter site build:*)",
+      "Bash(pnpm --filter site lint:types:*)",
+      "Bash(pnpm --filter site generate-signature-data:*)",
+      "Bash(pnpm --filter site test:node:*)",
+
+      "Bash(node .claude/skills/frontile-docs/scripts/lint-docs.mjs:*)",
+      "Bash(node scripts/migrate-semantic-colors.mjs:*)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
`.claude/settings.local.json` had accumulated a parallel permission set, so every contributor re-approves the same build and lint commands. This merges the entries that belong to the repo rather than to one machine.

## Added

- Read-only shell helpers: `cat`, `find`, `grep`, `xargs`
- `pnpm install`, `pnpm start`
- `lint:types` for the packages that have it
- Per-package build entries under their scoped `@frontile/*` names
- The site's `build`, `lint:types`, `generate-signature-data` and `test:node` scripts
- The docs linter from the `frontile-docs` skill
- `scripts/migrate-semantic-colors.mjs`

## Removed

`Bash(pnpm --filter core build)` — there is no `core` package, so it could never match.

## On the two filter spellings

Both `--filter theme` and `--filter @frontile/theme` are listed, which looks redundant. pnpm matches either (it strips the scope — I checked), but **permissions match the literal command string**, and both spellings appear in real use, so allowing only one still prompts.

I initially assumed the bare-name entries on `main` were dead and was going to replace them. They aren't — worth stating, since the commit would otherwise look like churn.

## Deliberately left local

These describe a developer's machine, not this project:

| Entry | Why |
| --- | --- |
| MCP grants (figma, playwright, puppeteer) | Whether those servers exist is per-developer setup |
| `playwright-cli` + its skill | Not part of this repo's tooling |
| `enabledPlugins` | A personal plugin choice |
| `git add` / `git commit` | Reusable, but auto-approving commits for everyone who clones should be each developer's own opt-in |
| `node fix-imports.mjs`, `migrate-imports.mjs`, `migrate-test.mjs` | These scripts no longer exist |

The `git` one is the judgment call — happy to add it if you'd rather it be a project default.

## No untracking needed

`settings.local.json` is already gitignored (`.gitignore:42`) and already untracked on `main`. The local checkout still showed it as tracked only because that branch predates the upstream cleanup.

## What I did *not* commit from the working tree

The branch had several other uncommitted changes. All were stale or regressions, so none are here:

| File | Why not |
| --- | --- |
| `.gitignore` | `main` already has all three patterns (`.eslintcache`, `.playwright-cli/`, `.playwright-mcp/`) |
| `pnpm-workspace.yaml` | Local had `allowBuilds: false`; `main` has `true`. Committing it would disable Tailwind oxide's native build |
| `site/public/docfy-urls.json` | Truncated to 14 URLs with every component page missing — a partial-build artifact |
| `pnpm-lock.yaml` | 13k-line diff from a branch base well behind `main` |
| `test-app/.../form-control-test.gts` | Byte-identical to the copy already on `main` |

They're preserved in `git stash` on the original branch rather than discarded, in case any of it was wanted.

## Unrelated, worth a look

`site/public/docfy-urls.json` on `main` is a committed generated file that's now stale — it's missing `/docs/components/forms/form-control` and `/docs/components/forms/native-select`, both added in recent PRs. Whatever consumes it is working from an incomplete list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)