### PR TITLE
docs(theme): make the overlay-strong label legible in the surface showcase

### DIFF
--- a/site/app/components/theme-docs/surface-showcase.gts
+++ b/site/app/components/theme-docs/surface-showcase.gts
@@ -85,8 +85,26 @@ export default class SurfaceShowcase extends Component<SurfaceShowcaseSignature>
     strong: 'Heaviest step — the modal/drawer backdrop in light mode',
   };
 
+  // `strong` is the scrim step and inverts against the page — black 75% in
+  // light, white 95% in dark — so its ink has to invert too. There is no
+  // `on-surface-overlay-*` token: translucent veils are excluded from
+  // on-color generation, since contrast depends on what shows through.
+  private overlayInkClasses: Record<string, string> = {
+    strong: 'text-white dark:text-black',
+  };
+
   getOverlayClass = (level: string): string => {
     return this.overlayClasses[level] || '';
+  };
+
+  getOverlayInkClass = (level: string): string => {
+    return this.overlayInkClasses[level] || 'text-neutral-strong';
+  };
+
+  getOverlayMutedInkClass = (level: string): string => {
+    return this.overlayInkClasses[level]
+      ? `${this.overlayInkClasses[level]} opacity-70`
+      : 'text-neutral-firm';
   };
 
   getOverlayDescription = (level: string): string => {
@@ -127,10 +145,12 @@ export default class SurfaceShowcase extends Component<SurfaceShowcaseSignature>
             {{#each this.overlayLevels as |level|}}
               <div class="{{this.getOverlayClass level}} p-6 rounded">
                 <div class="flex items-center justify-between">
-                  <span class="font-mono text-sm text-neutral-strong">
+                  <span
+                    class="font-mono text-sm {{this.getOverlayInkClass level}}"
+                  >
                     surface-overlay-{{level}}
                   </span>
-                  <span class="text-xs text-neutral-firm">
+                  <span class="text-xs {{this.getOverlayMutedInkClass level}}">
                     {{this.getOverlayDescription level}}
                   </span>
                 </div>


### PR DESCRIPTION
Follow-up to the 20 Aug Beacon surface tokens (`e7807435`, already on `main`).

That change made dark `surface-overlay-strong` a white 95% veil, where it had
been black 75%. The surface showcase renders each overlay level with ink that
follows the page scheme, so in dark mode the `overlay-strong` row came out
white-on-white — the label was invisible.

`strong` is the scrim step, and it inverts against the page: black 75% in light,
white 95% in dark. Its ink therefore has to invert too, which is what this does.

| scheme | `overlay-strong` | label ink |
| ------ | ---------------- | --------- |
| light  | black @ 75%      | white     |
| dark   | white @ 95%      | black     |

### Why not a token

There is no `on-surface-overlay-strong` to lean on. `shouldGenerateOnColor` in
`plugin/resolve.ts` excludes the whole overlay *and* lift families, because for a
translucent veil the contrast depends on whatever shows through, and the
generator measures the raw RGBA rather than the composite over the page. That is
the same flaw that produced inverted `on-*-soft` values, which are now explicit
overrides in `semantic.ts`.

`strong` is arguably a fair exception — at 75–95% alpha a contrast calculation
*would* be meaningful, unlike `subtle`…`firm`. If we want a real token for it,
the shape would be explicit `on-surface-overlay-strong` / `on-surface-lift-strong`
overrides following the `on-*-soft` pattern, rather than switching the family
back on. Not done here; the showcase states the inversion in a comment instead.

### Verification

Computed styles in both schemes on `/docs/theming/design-tokens/surfaces`:

- light — background `oklch(0 0 0 / 0.749)`, ink `rgb(255,255,255)`
- dark — background `oklch(1 0 0 / 0.949)`, ink `rgb(0,0,0)`

Site-only change; no component or token behaviour is affected.
