### PR TITLE
feat(theme): derive radius scale from a single --radius knob

### DIFF
--- a/docs/migrations/v0.18/index.md
+++ b/docs/migrations/v0.18/index.md
@@ -22,6 +22,7 @@ them is optional for the whole 0.18 line.
 | `--frontile-*` variable references | The declaration is dropped | **Silently** |
 | Nested `LayoutTheme` config | Build or type error | Loudly, and only if you customize the theme |
 | `@frontile/*` package imports | Nothing — they still work in 0.18.x | Deprecation warning only |
+| Derived border-radius scale | Slightly rounder corners on menus and small marks | Visual only — nothing to fix |
 
 **The silent ones are the reason to take this in order.** A class Tailwind can't
 resolve produces no error, no warning, and no CSS — the element just renders

--- a/docs/migrations/v0.18/theme-configuration.md
+++ b/docs/migrations/v0.18/theme-configuration.md
@@ -149,6 +149,79 @@ module.exports = frontile({
 
 **Why:** The nested structure provides better organization for related theme properties and aligns with CSS custom property conventions.
 
+### 5. Border Radius Is Now a Derived Scale
+
+Every `rounded-*` step is now `calc(var(--radius) * n)` instead of a hardcoded
+value, so `--radius` is a single knob for how round the whole library looks.
+
+#### Before (v0.17)
+
+```css
+--radius-xs: 1px;
+--radius-sm: 2px;
+--radius-md: 4px;
+--radius: 8px;
+--radius-xl: 12px;
+--radius-2xl: 16px;
+--radius-default: 20px;
+```
+
+#### After (v0.18)
+
+```css
+--radius: 0.5rem;                            /* 8px — the base */
+--radius-xs: calc(var(--radius) * 0.25);     /* 2px */
+--radius-sm: calc(var(--radius) * 0.5);      /* 4px */
+--radius-md: calc(var(--radius) * 0.75);     /* 6px */
+--radius-lg: calc(var(--radius) * 1);        /* 8px */
+--radius-xl: calc(var(--radius) * 1.5);      /* 12px */
+--radius-2xl: calc(var(--radius) * 2);       /* 16px */
+--radius-3xl: calc(var(--radius) * 3);       /* 24px */
+--radius-4xl: calc(var(--radius) * 4);       /* 32px */
+--radius-default: calc(var(--radius) * 2.5); /* 20px */
+```
+
+**What actually changes visually.** Three steps got slightly larger, bringing the
+scale back in line with stock Tailwind v4:
+
+| Utility | v0.17 | v0.18 |
+| --- | --- | --- |
+| `rounded-xs` | 1px | 2px |
+| `rounded-sm` | 2px | 4px |
+| `rounded-md` | 4px | 6px |
+
+Everything from `rounded` upward keeps its value. If you relied on `rounded-sm`
+being 2px, use `rounded-xs`, or pin the step explicitly:
+
+```css
+@theme {
+  --radius-sm: 2px; /* opt this one step out of the derived scale */
+}
+```
+
+**Popover surfaces are rounder.** Dropdown and Popover panels moved from
+`rounded-sm` (2px) to `rounded-xl` (12px), Listbox and menu items to
+`rounded-lg` (8px), and NotificationCard to `rounded-xl`. Select and
+Autocomplete inherit the change through Popover. This is a visual change only —
+no API moved. To go back to square-ish menus, set `--radius: 0`, or override the
+component classes via `@classes`.
+
+**Why:** The old scale was smaller than stock Tailwind at every step, which made
+`rounded-sm` a surprise for anyone reading the class name, and left popover
+surfaces visibly sharper than the Modal and Drawer they sit alongside. Deriving
+the scale from one value fixes the inconsistency and makes overall roundness a
+one-line theme decision.
+
+**Dialing it from the plugin config**, including per theme:
+
+```typescript
+module.exports = frontile({
+  layout: {
+    radius: { DEFAULT: '0.75rem' }
+  }
+});
+```
+
 ## Migration Steps
 
 ### Step 1: Update CSS Imports

--- a/docs/theming/configuration/css-variables.md
+++ b/docs/theming/configuration/css-variables.md
@@ -85,20 +85,45 @@ See [Typography documentation](../design-tokens/typography.md) for detailed info
 
 ### Border Radius
 
+Every step is derived from a single `--radius` base, so you can dial the
+roundness of the whole library with one value:
+
 ```css
 @theme {
+  --radius: 0.5rem;                          /* 8px — the one knob */
   --radius-none: 0px;
-  --radius-sm: 2px;
-  --radius-md: 4px;
-  --radius: 8px;          /* Default */
-  --radius-xl: 12px;
-  --radius-2xl: 16px;
-  --radius-default: 20px;
+  --radius-xs: calc(var(--radius) * 0.25);   /* 2px */
+  --radius-sm: calc(var(--radius) * 0.5);    /* 4px */
+  --radius-md: calc(var(--radius) * 0.75);   /* 6px */
+  --radius-lg: calc(var(--radius) * 1);      /* 8px */
+  --radius-xl: calc(var(--radius) * 1.5);    /* 12px */
+  --radius-2xl: calc(var(--radius) * 2);     /* 16px */
+  --radius-3xl: calc(var(--radius) * 3);     /* 24px */
+  --radius-4xl: calc(var(--radius) * 4);     /* 32px */
+  --radius-default: calc(var(--radius) * 2.5); /* 20px */
   --radius-pill: 9999px;
 }
 ```
 
-**Generated utilities:** `rounded-none`, `rounded-sm`, `rounded-md`, `rounded`, `rounded-xl`, `rounded-2xl`, `rounded-default`, `rounded-pill`
+**Generated utilities:** `rounded-none`, `rounded-xs`, `rounded-sm`, `rounded-md`, `rounded`, `rounded-lg`, `rounded-xl`, `rounded-2xl`, `rounded-3xl`, `rounded-4xl`, `rounded-default`, `rounded-pill`
+
+To make every component softer or sharper, override `--radius` alone — the rest
+of the scale follows:
+
+```css
+@theme {
+  --radius: 0.75rem; /* menus 18px, list items 12px, modals 24px */
+}
+```
+
+```css
+@theme {
+  --radius: 0; /* square everything off */
+}
+```
+
+`--radius-none` and `--radius-pill` are absolutes and deliberately do not scale,
+so `rounded-full` buttons stay pills at any base value.
 
 ### Icon Sizes
 

--- a/docs/theming/configuration/overview.md
+++ b/docs/theming/configuration/overview.md
@@ -42,7 +42,7 @@ Add customizations after importing the theme in your `app/styles/app.css`:
 
 Use CSS variables to customize:
 
-- **Border radius** - `--radius`, `--radius-xl`, `--radius-pill`
+- **Border radius** - `--radius` (one knob; the whole `rounded-*` scale is derived from it), plus `--radius-pill` and individual steps as escape hatches
 - **Border widths** - `--border-width-thin`, `--border-width-heavy`
 - **Icon sizes** - `--size-icon-sm`, `--size-icon-md`, `--size-icon-lg`
 - **Shadows** - `--shadow-elevation-1`, `--shadow-elevation-2`
@@ -152,7 +152,7 @@ For minor adjustments to existing tokens, use CSS variables:
 
 ```css
 @theme {
-  --radius: 6px;
+  --radius: 6px; /* scales every rounded-* step down proportionally */
   --opacity-hover: .9;
 }
 ```

--- a/docs/theming/design-tokens/borders.md
+++ b/docs/theming/design-tokens/borders.md
@@ -76,6 +76,10 @@ Control border thickness with semantic width tokens. These tokens provide meanin
 
 Control corner rounding with radius tokens that range from sharp edges to fully rounded elements.
 
+Every step is a multiple of a single `--radius` base (`0.5rem` by default), so
+the scale is proportional rather than arbitrary. Changing `--radius` alone
+re-rounds the entire library — see [Scaling the whole system](#scaling-the-whole-system) below.
+
 ### Available Radii
 
 ```gts preview
@@ -83,6 +87,9 @@ Control corner rounding with radius tokens that range from sharp edges to fully 
   <div class='grid grid-cols-2 md:grid-cols-4 gap-4'>
     <div class='rounded-none bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
       <span class='text-label-sm'>None</span>
+    </div>
+    <div class='rounded-xs bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
+      <span class='text-label-sm'>XS</span>
     </div>
     <div class='rounded-sm bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
       <span class='text-label-sm'>SM</span>
@@ -93,11 +100,20 @@ Control corner rounding with radius tokens that range from sharp edges to fully 
     <div class='rounded bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
       <span class='text-label-sm'>Default</span>
     </div>
+    <div class='rounded-lg bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
+      <span class='text-label-sm'>LG</span>
+    </div>
     <div class='rounded-xl bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
       <span class='text-label-sm'>XL</span>
     </div>
     <div class='rounded-2xl bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
       <span class='text-label-sm'>2XL</span>
+    </div>
+    <div class='rounded-3xl bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
+      <span class='text-label-sm'>3XL</span>
+    </div>
+    <div class='rounded-4xl bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
+      <span class='text-label-sm'>4XL</span>
     </div>
     <div class='rounded-default bg-primary-subtle p-4 flex items-center justify-center min-h-24'>
       <span class='text-label-sm'>Default (Custom)</span>
@@ -109,16 +125,23 @@ Control corner rounding with radius tokens that range from sharp edges to fully 
 </template>
 ```
 
-| Radius | Utility | Common Uses |
-|--------|---------|-------------|
-| None | `rounded-none` | Sharp corners, technical interfaces, no rounding |
-| SM | `rounded-sm` | Subtle rounding, tight layouts |
-| MD | `rounded-md` | Medium rounding, cards with more visual softness |
-| Default | `rounded` | Standard UI elements, buttons, inputs |
-| XL | `rounded-xl` | Large cards, prominent panels |
-| 2XL | `rounded-2xl` | Hero sections, feature cards |
-| Default (Custom) | `rounded-default` | Custom default radius value, soft friendly corners |
-| Pill | `rounded-pill` | Pills, badges, fully rounded buttons |
+| Radius | Utility | Multiplier | Default | Common Uses |
+|--------|---------|-----------|---------|-------------|
+| None | `rounded-none` | — | 0px | Sharp corners, technical interfaces, no rounding |
+| XS | `rounded-xs` | 0.25x | 2px | Hairline rounding on very small marks |
+| SM | `rounded-sm` | 0.5x | 4px | Keyboard shortcuts, checkboxes, tight layouts |
+| MD | `rounded-md` | 0.75x | 6px | Compact controls, inline chips |
+| Default | `rounded` | 1x | 8px | The base unit itself |
+| LG | `rounded-lg` | 1x | 8px | Menu items nested inside a popover |
+| XL | `rounded-xl` | 1.5x | 12px | Inputs, selects, popovers, dropdowns, notifications |
+| 2XL | `rounded-2xl` | 2x | 16px | Modals, drawers |
+| Default (Custom) | `rounded-default` | 2.5x | 20px | Tables, skeletons, soft friendly corners |
+| 3XL | `rounded-3xl` | 3x | 24px | Oversized surfaces |
+| 4XL | `rounded-4xl` | 4x | 32px | Hero-scale surfaces |
+| Pill | `rounded-pill` | — | 9999px | Pills, badges, fully rounded buttons |
+
+`rounded-none` and `rounded-pill` are absolutes: they stay 0 and 9999px no
+matter what `--radius` is set to.
 
 ## Combining Borders and Radius
 
@@ -190,11 +213,42 @@ Override border widths and radius using CSS variables:
   --border-width-default: 1.5px;
   --border-width-heavy: 3px;
 
-  /* Customize border radius */
-  --radius: 6px;
-  --radius-xl: 16px;
-  --radius-default: 8px;
-  --radius-pill: 9999px;
+  /* Customize border radius — one knob for the whole scale */
+  --radius: 0.75rem;
+}
+```
+
+### Scaling the whole system
+
+Because every step is `calc(var(--radius) * n)`, one value controls how round
+the entire library looks. Nothing else has to change:
+
+| `--radius` | Menus / inputs | Menu items | Modals |
+|-----------|----------------|-----------|--------|
+| `0` | 0px | 0px | 0px |
+| `0.25rem` | 6px | 4px | 8px |
+| `0.5rem` (default) | 12px | 8px | 16px |
+| `0.75rem` | 18px | 12px | 24px |
+| `1rem` | 24px | 16px | 32px |
+
+The same knob is available from the JavaScript plugin config, where it can also
+differ per theme:
+
+```js
+frontile({
+  layout: {
+    radius: { DEFAULT: '0.75rem' }
+  }
+});
+```
+
+Individual steps remain overridable when you need to break one out of the
+proportional scale:
+
+```css
+@theme {
+  --radius: 0.5rem;
+  --radius-2xl: 28px; /* modals rounder than the scale would give */
 }
 ```
 

--- a/docs/theming/overview.md
+++ b/docs/theming/overview.md
@@ -313,8 +313,8 @@ Add your customizations in your `app/styles/app.css` after importing the theme:
 /* Override Tailwind theme utilities */
 @theme {
   /* Custom border radius values */
-  --radius: 0.75rem;        /* Change default radius */
-  --radius-pill: 2rem;      /* Custom pill radius */
+  --radius: 0.75rem;        /* One knob: scales the whole rounded-* scale */
+  --radius-pill: 2rem;      /* Custom pill radius (absolute, does not scale) */
 
   /* Custom opacity values */
   --opacity-hover: .9;

--- a/packages/theme/src/components/dropdown.ts
+++ b/packages/theme/src/components/dropdown.ts
@@ -1,7 +1,7 @@
 import { tv } from '../tw';
 
 const dropdownContent = tv({
-  base: 'bg-surface-input w-[260px] rounded-sm border border-neutral-subtle'
+  base: 'bg-surface-input w-[260px] rounded-xl border border-neutral-subtle'
 });
 
 export { dropdownContent };

--- a/packages/theme/src/components/listbox.ts
+++ b/packages/theme/src/components/listbox.ts
@@ -18,7 +18,7 @@ const listboxItem = tv({
       'w-full',
       'h-full',
       'box-border',
-      'rounded-sm',
+      'rounded-lg',
       'subpixel-antialiased',
       'outline-hidden',
       'cursor-pointer',

--- a/packages/theme/src/components/notification-card.ts
+++ b/packages/theme/src/components/notification-card.ts
@@ -5,12 +5,12 @@ const btn = ['transition transition-200', ...focusVisibleRing];
 
 const notificationCard = tv({
   slots: {
-    base: 'py-3 px-4 overflow-hidden flex items-center justify-between relative min-h-16 font-body text-body-2xs rounded-sm shadow-sm transition-all transition-200 ease-in-out',
+    base: 'py-3 px-4 overflow-hidden flex items-center justify-between relative min-h-16 font-body text-body-2xs rounded-xl shadow-sm transition-all transition-200 ease-in-out',
     message: 'grow',
     customActions: 'flex flex-nowrap',
     customActionButton: [
       ...btn,
-      'first:ml-4 last:-mr-2 font-label text-label-xs py-1 px-2 rounded-sm hover:bg-surface-overlay-soft'
+      'first:ml-4 last:-mr-2 font-label text-label-xs py-1 px-2 rounded-md hover:bg-surface-overlay-soft'
     ],
     closeButton: [
       ...btn,

--- a/packages/theme/src/components/popover.ts
+++ b/packages/theme/src/components/popover.ts
@@ -1,7 +1,7 @@
 import { tv } from '../tw';
 
 const popover = tv({
-  base: 'bg-surface-input rounded-sm border border-neutral-subtle',
+  base: 'bg-surface-input rounded-xl border border-neutral-subtle',
   variants: {
     size: {
       sm: 'w-40',

--- a/packages/theme/src/styles/theme.css
+++ b/packages/theme/src/styles/theme.css
@@ -28,15 +28,26 @@
   --border-width-aggressive: 4px; /* Default border width. */
 
   /* ==================== Border Radius ==================== */
+  /*
+    One knob for the whole system. Every step below is a multiple of `--radius`,
+    so overriding that single value (in CSS, or via `layout.radius.DEFAULT` in
+    the plugin config) dials the roundness of every component up or down
+    proportionally — `--radius: 0` squares everything off, `--radius: 0.75rem`
+    makes it noticeably softer. `none` and `pill` are absolutes by design and
+    deliberately do not scale.
+  */
+  --radius: 0.5rem; /* 8px — base unit the entire scale is derived from. */
   --radius-none: 0px; /* No border radius (sharp corners). */
-  --radius-xs: 1px; /* Extra small border radius for minimal rounding. */
-  --radius-sm: 2px; /* Small border radius for subtle rounding. */
-  --radius-md: 4px; /* Medium border radius for standard elements. */
-  --radius-xl: 12px; /* Extra large border radius for emphasized elements. */
-  --radius-2xl: 16px; /* Double extra large border radius for very soft corners. */
-  --radius-default: 20px; /* Default border radius for friendly, approachable UI elements. Aligns with TailwindCSS &#x27;rounded&#x27; class. */
+  --radius-xs: calc(var(--radius) * 0.25); /* 2px — hairline rounding. */
+  --radius-sm: calc(var(--radius) * 0.5); /* 4px — small inline elements. */
+  --radius-md: calc(var(--radius) * 0.75); /* 6px — compact controls. */
+  --radius-lg: calc(var(--radius) * 1); /* 8px — nested list items, cards. */
+  --radius-xl: calc(var(--radius) * 1.5); /* 12px — inputs, menus, popovers. */
+  --radius-2xl: calc(var(--radius) * 2); /* 16px — modals, drawers. */
+  --radius-3xl: calc(var(--radius) * 3); /* 24px — oversized surfaces. */
+  --radius-4xl: calc(var(--radius) * 4); /* 32px — hero-scale surfaces. */
+  --radius-default: calc(var(--radius) * 2.5); /* 20px — friendly, approachable UI elements. */
   --radius-pill: 9999px; /* Pill-shaped border radius (fully rounded sides) for buttons and tags. */
-  --radius: 8px; /* Large border radius for more prominent rounding. - DEFAULT */
 
   /* ==================== Elevation Shadows ==================== */
   --shadow-elevation-0: 0px 0px 0px 0px rgb(0 0 0 / 0.01);

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -21,15 +21,32 @@ export interface LayoutTheme {
   /**
    * Border radius configuration for components.
    * Values can be any valid CSS length unit (px, rem, em, etc.)
+   *
+   * `DEFAULT` is the single knob for the whole system: every other step is
+   * derived from it via `calc()`, so setting it alone scales all component
+   * radii proportionally.
+   *
+   * ```ts
+   * frontile({ layout: { radius: { DEFAULT: '0.75rem' } } }) // softer overall
+   * frontile({ layout: { radius: { DEFAULT: '0' } } })       // fully squared off
+   * ```
+   *
+   * The individual steps are escape hatches — set one only to break a single
+   * step out of the derived scale. `none` and `pill` are absolutes and are not
+   * affected by `DEFAULT`.
    */
   radius?: {
+    /** Base unit the scale is derived from. Defaults to `0.5rem` (8px). */
+    DEFAULT?: string;
+    none?: string;
     xs?: string;
     sm?: string;
     md?: string;
     lg?: string;
-    DEFAULT?: string;
     xl?: string;
     '2xl'?: string;
+    '3xl'?: string;
+    '4xl'?: string;
     full?: string;
     pill?: string;
   };


### PR DESCRIPTION
## The problem

Popover-family surfaces used `rounded-sm`, which Frontile had redefined as **2px**. That's visibly sharper than the Modal and Drawer sitting alongside them (`rounded-2xl`, 16px) and than the Input they're attached to (`rounded-xl`, 12px) — so the system was internally inconsistent, not just small.

The wider issue: the whole scale sat *below* stock Tailwind at every step, so a class name told you nothing reliable about what you'd get.

| token | before | stock TW v4 |
|---|---|---|
| `--radius-xs` | 1px | 2px |
| `--radius-sm` | **2px** | 4px |
| `--radius-md` | 4px | 6px |
| `--radius-lg` | *(undefined)* | 8px |
| `--radius-3xl` / `4xl` | *(undefined)* | 24 / 32px |

## The approach

Every step is now `calc(var(--radius) * n)` off a single `0.5rem` base — the multipliers land each utility exactly on stock Tailwind's value, and **one variable controls how round the whole library looks**:

```css
--radius: 0.5rem;                            /* the one knob */
--radius-xs: calc(var(--radius) * 0.25);     /* 2px */
--radius-sm: calc(var(--radius) * 0.5);      /* 4px */
--radius-md: calc(var(--radius) * 0.75);     /* 6px */
--radius-lg: calc(var(--radius) * 1);        /* 8px */
--radius-xl: calc(var(--radius) * 1.5);      /* 12px */
--radius-2xl: calc(var(--radius) * 2);       /* 16px */
--radius-3xl: calc(var(--radius) * 3);       /* 24px */
--radius-4xl: calc(var(--radius) * 4);       /* 32px */
--radius-default: calc(var(--radius) * 2.5); /* 20px */
--radius-pill: 9999px;
```

This is the same shape HeroUI uses, but expressed through Tailwind's own scale names rather than a parallel `rounded-small/medium/large` vocabulary — so no new token layer, and existing class names keep working.

`none` and `pill` are absolutes by design: `rounded-full` buttons stay pills at any base.

**Configurable two ways.** In CSS via `@theme { --radius: 0.75rem }`, or from the plugin config (per theme if wanted) — the existing `layout.radius` config already emitted `--radius`, it just had nothing to cascade into before:

```ts
frontile({ layout: { radius: { DEFAULT: '0.75rem' } } })
```

## Component changes

Retargeted using the nested-radius rule (inner = outer − padding), so items sit correctly inside their panel — listbox padding is `p-1` (4px), and 12 − 4 = 8:

| Component | Before | After |
|---|---|---|
| Popover panel | `rounded-sm` (2px) | `rounded-xl` (12px) |
| Dropdown panel | `rounded-sm` (2px) | `rounded-xl` (12px) |
| Listbox / menu item | `rounded-sm` (2px) | `rounded-lg` (8px) |
| Listbox kbd shortcut | `rounded-sm` (2px) | `rounded-sm` (4px, via scale) |
| NotificationCard | `rounded-sm` (2px) | `rounded-xl` (12px) |
| Modal / Drawer | `rounded-2xl` (16px) | unchanged |
| Input / Select trigger | `rounded-xl` (12px) | unchanged |

Select and Autocomplete inherit the change through Popover, so their trigger and panel now agree at 12px.

## Breaking surface

Small. Only `rounded-xs` (1→2px), `rounded-sm` (2→4px) and `rounded-md` (4→6px) change value; everything from `rounded` upward is identical. Documented in the v0.18 migration guide, along with how to pin a single step out of the derived scale.

## Verification

- **832 tests pass, 0 failures** (`pnpm --filter test-app test`)
- `glint` clean; `lint:js` clean (0 errors)
- Site builds clean
- **Tailwind tree-shaking checked directly** — this was the main risk, since v4 drops unused `@theme` vars and a dropped `--radius` would break every `calc()`. Compiled a minimal case using only `rounded-xl`: Tailwind follows the `var()` dependency and keeps `--radius`, while correctly dropping the unused steps.
- **Cascade checked in-browser** — an `@layer base` `:root` override (what the plugin emits) beats `@theme` and flows through the chain: `--radius: 1rem` → `rounded-xl` resolves to 24px.
- **Computed values verified live** on the real components: Dropdown panel 12px / item 8px / kbd 4px; Select trigger 12px / option 8px. Full scale resolves to 0 / 2 / 4 / 6 / 8 / 8 / 12 / 16 / 20 / 24 / 32 / 9999px.
- Checked in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
