### PR TITLE
fix(theme): keep selected ToggleButton readable on hover and active

### DIFF
--- a/packages/frontile/src/components/buttons/toggle-button.md
+++ b/packages/frontile/src/components/buttons/toggle-button.md
@@ -9,6 +9,11 @@ imports:
 A toggle button allows to toggle a selection on or off, for example switching
 between two states or modes.
 
+Unselected, it reads as an outlined button — ink and border only. Selected, it
+fills with its intent color and switches to the matching contrast ink; hovering
+and pressing deepen that fill one step at a time, the same ramp a filled
+`Button` uses, so the label stays readable in every state.
+
 ## Import
 
 ```js

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -327,48 +327,63 @@ const toggleButton = tv({
       true: ''
     }
   },
+  // Selected is a *filled* state, so every color has to be restated here —
+  // fill, border and ink, for the resting, hover and active steps. The
+  // unselected `outlined` rules in `baseButton` set their own
+  // `hover:text-*`/`active:*` colors, and anything we leave out keeps leaking
+  // through: an unselected ink color over a selected fill is what produced the
+  // unreadable label on hover. The ramp matches the filled button
+  // (`appearance: 'default'`) — one step deeper on hover, another on active —
+  // and pairs each fill with its generated `on-*` contrast ink.
   compoundVariants: [
     {
       appearance: 'outlined',
       intent: 'default',
       isSelected: true,
-      class: 'bg-neutral-bolder text-on-neutral-bolder hover:bg-neutral-bolder'
+      class:
+        'bg-neutral-bolder border-neutral-bolder text-on-neutral-bolder hover:bg-neutral-strong hover:border-neutral-strong hover:text-on-neutral-strong active:bg-neutral-firm active:border-neutral-firm active:text-on-neutral-firm'
     },
     {
       appearance: 'outlined',
       intent: 'primary',
       isSelected: true,
-      class: 'bg-primary text-on-primary hover:bg-primary-soft'
+      class:
+        'bg-primary border-primary text-on-primary hover:bg-primary-mild hover:border-primary-mild hover:text-on-primary-mild active:bg-primary-firm active:border-primary-firm active:text-on-primary-firm'
     },
     {
       appearance: 'outlined',
       intent: 'secondary',
       isSelected: true,
-      class: 'bg-secondary text-on-secondary hover:bg-secondary-soft'
+      class:
+        'bg-secondary border-secondary text-on-secondary hover:bg-secondary-mild hover:border-secondary-mild hover:text-on-secondary-mild active:bg-secondary-firm active:border-secondary-firm active:text-on-secondary-firm'
     },
     {
       appearance: 'outlined',
       intent: 'tertiary',
       isSelected: true,
-      class: 'bg-tertiary text-on-tertiary hover:bg-tertiary-soft'
+      class:
+        'bg-tertiary border-tertiary text-on-tertiary hover:bg-tertiary-mild hover:border-tertiary-mild hover:text-on-tertiary-mild active:bg-tertiary-firm active:border-tertiary-firm active:text-on-tertiary-firm'
     },
     {
       appearance: 'outlined',
       intent: 'success',
       isSelected: true,
-      class: 'bg-success text-on-success hover:bg-success-soft'
+      class:
+        'bg-success border-success text-on-success hover:bg-success-mild hover:border-success-mild hover:text-on-success-mild active:bg-success-firm active:border-success-firm active:text-on-success-firm'
     },
     {
       appearance: 'outlined',
       intent: 'warning',
       isSelected: true,
-      class: 'bg-warning text-on-warning hover:bg-warning-soft'
+      class:
+        'bg-warning border-warning text-on-warning hover:bg-warning-mild hover:border-warning-mild hover:text-on-warning-mild active:bg-warning-firm active:border-warning-firm active:text-on-warning-firm'
     },
     {
       appearance: 'outlined',
       intent: 'danger',
       isSelected: true,
-      class: 'bg-danger text-on-danger hover:bg-danger-soft'
+      class:
+        'bg-danger border-danger text-on-danger hover:bg-danger-mild hover:border-danger-mild hover:text-on-danger-mild active:bg-danger-firm active:border-danger-firm active:text-on-danger-firm'
     }
   ]
 });


### PR DESCRIPTION
## Problem

A selected `ToggleButton` lost its label on hover — mid-gray ink on a near-white fill in dark mode.

`toggleButton` extends `baseButton`, whose `appearance: 'outlined'` compound variants define the **unselected** look *including* their own `hover:` and `active:` colors. The selected variants only restated `bg-*`, `text-*` and one `hover:bg-*`, so everything they omitted leaked through. Class output before the fix (default intent, selected):

```
bg-neutral-bolder  text-on-neutral-bolder  hover:bg-neutral-bolder
hover:text-neutral-firm/80  hover:border-neutral-strong          ← leaked
active:bg-neutral-muted  active:text-neutral-firm                ← leaked
```

Three defects fell out of that:

1. **Unreadable label on hover.** The ink switched to `neutral-firm/80` while the fill stayed `neutral-bolder` — **2.08:1** measured against the live CSS variables. Same shape for the colored intents, where `hover:bg-*-soft` (a 10–25% translucent tint) paired with the leaked `hover:text-*-mild`: primary **1.96:1**, danger **1.90:1**.
2. **Active dropped the selected state entirely.** `active:bg-neutral-muted active:text-neutral-firm` came from the unselected rule, so pressing a selected toggle repainted it as an unselected one.
3. **No hover feedback on the default intent** (`hover:bg-neutral-bolder` is the resting fill), and borders were left on the unselected hover/active steps, disagreeing with the fill.

## Approach

Selected is a *filled* state, so it should behave like the filled `Button` (`appearance: 'default'`), not like an outlined one: deepen the fill one step on hover, another on active, carrying the generated `on-*` contrast ink along. That keeps the two components consistent, makes contrast a property of the generated contrast colors rather than of hand-picked pairs, and works in dark mode where the ramp inverts.

Every selected variant now restates fill, border and ink for all three steps, with a comment on why nothing may be omitted.

## Verification

Contrast for every selected intent × (rest, hover, active), in both schemes, measured from the real computed CSS variables on the running docs page:

| | light | dark |
|---|---|---|
| worst pair | 4.71:1 (danger, rest) | 4.61:1 (primary, hover) |

All 42 combinations clear WCAG AA. Live confirmation on the Intents demo — default toggle selected and actually hovered: black on `neutral-strong`, **15.35:1** (was 2.08:1); danger selected and hovered: white on `danger-mild`, **6.36:1** (was 1.90:1).

Full suite green: 832 tests, 0 failures, 3 pre-existing skips. Types clean. `lint:hbs` reports 50 errors, but they are identical on a clean checkout — unrelated to this change.

The docs carry no hardcoded classes, so the live demos pick the fix up automatically; added a short paragraph describing the unselected/selected/hover behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)