### PR TITLE
fix(table): give sticky headers, rows and columns an opaque surface

### DIFF
--- a/docs/theming/design-tokens/surfaces.md
+++ b/docs/theming/design-tokens/surfaces.md
@@ -15,7 +15,7 @@ The Surface system provides a flexible way to create depth and hierarchy in your
 
 The Surface system consists of three types:
 
-- **Surface Roles** - Semantic, opaque surface tokens for specific UI contexts (app, canvas, card, modal, input)
+- **Surface Roles** - Semantic, opaque surface tokens for specific UI contexts (app, canvas, card, table, modal, input)
 - **Surface Overlay** (subtle, soft, mild, firm, strong) - Translucent layers that push an element _into_ its background
 - **Surface Lift** (subtle, soft, mild, firm, strong) - Translucent layers that pull an element _up off_ its background
 
@@ -76,9 +76,9 @@ Component contrast baseline (hierarchy level 1).
 
 Elevated card container surface (hierarchy level 1). Opaque white in light mode;
 in dark mode it is a translucent veil (white @ 7%, the same value as
-`overlay-subtle`), so whatever sits behind it shows through faintly. Reach for an
-opaque role such as `surface-canvas` when content must be fully hidden behind it
-— a sticky table header, for instance.
+`overlay-subtle`), so whatever sits behind it shows through faintly. Where a
+surface has to stay opaque, use `surface-table` — the same colour without the
+transparency.
 
 **When to use:**
 
@@ -96,6 +96,57 @@ opaque role such as `surface-canvas` when content must be fully hidden behind it
       <p class='text-neutral-strong'>This card is elevated off the canvas
         background</p>
     </article>
+  </div>
+</template>
+```
+
+#### Table (`bg-surface-table`)
+
+Data table surface (hierarchy level 1). The same colour as a card, guaranteed
+opaque: pure white in light mode, and in dark mode `gray-900` — what
+`surface-card` renders over `surface-canvas`.
+
+Tables need that guarantee. A sticky header, a frozen row, or a pinned column
+paints over the rows and columns scrolling beneath it, and anything translucent
+lets them show through.
+
+**When to use:**
+
+- Data table containers, and the sticky parts inside them
+- Any surface at card elevation that has to stay opaque
+
+Recolour it for the whole app the way you would any semantic colour:
+
+```js
+module.exports = frontile({
+  themes: {
+    dark: {
+      colors: {
+        surface: { table: '#1c1c1c' }
+      }
+    }
+  }
+});
+```
+
+For one table that sits on a different background, set `--color-surface-table` on
+it instead — it is a plain custom property, and it applies to everything below
+it. The Table component takes it as a wrapper class; see
+[Table](/docs/components/collections/table).
+
+```gts preview
+<template>
+  <div class='bg-surface-canvas p-6'>
+    <div class='bg-surface-table rounded-lg h-32 overflow-auto'>
+      <div class='bg-surface-table sticky top-0 px-4 py-2'>
+        <p class='text-neutral-bolder'>Sticky header — rows pass under it</p>
+      </div>
+      <div class='px-4 py-2 text-neutral-strong'>Row one</div>
+      <div class='px-4 py-2 text-neutral-strong'>Row two</div>
+      <div class='px-4 py-2 text-neutral-strong'>Row three</div>
+      <div class='px-4 py-2 text-neutral-strong'>Row four</div>
+      <div class='px-4 py-2 text-neutral-strong'>Row five</div>
+    </div>
   </div>
 </template>
 ```
@@ -160,12 +211,12 @@ Form control surface for inputs, checkboxes, radios, and similar controls (hiera
 
 Surface roles are designed to create visual depth through a hierarchy system:
 
-| Level | Role         | Purpose                                                  |
-| ----- | ------------ | -------------------------------------------------------- |
-| -1    | Input        | Recessed below canvas                                    |
-| 0     | App          | Root application background                              |
-| 1     | Canvas, Card | Component contrast baseline and first level of elevation |
-| 3     | Modal        | Highest elevation (modals, drawers, popovers, dropdowns) |
+| Level | Role                | Purpose                                                  |
+| ----- | ------------------- | -------------------------------------------------------- |
+| -1    | Input               | Recessed below canvas                                    |
+| 0     | App                 | Root application background                              |
+| 1     | Canvas, Card, Table | Component contrast baseline and first level of elevation |
+| 3     | Modal               | Highest elevation (modals, drawers, popovers, dropdowns) |
 
 In **light mode**, elevated surfaces appear brighter (white) against gray backgrounds following the elevation-luminance principle.
 In **dark mode**, elevated surfaces appear progressively lighter against near-black backgrounds.
@@ -325,7 +376,7 @@ The same nesting, one family each — overlay recedes, lift advances:
 Follow this decision flow:
 
 1. **Does this match a specific UI context?**
-   - If yes → Use `surface-{role}` (app, canvas, card, modal, input)
+   - If yes → Use `surface-{role}` (app, canvas, card, table, modal, input)
    - Surface roles provide semantic meaning and automatically adapt to themes.
 
 2. **Is this the base container and no role matches?**

--- a/docs/theming/design-tokens/surfaces.md
+++ b/docs/theming/design-tokens/surfaces.md
@@ -102,9 +102,7 @@ transparency.
 
 #### Table (`bg-surface-table`)
 
-Data table surface (hierarchy level 1). The same colour as a card, guaranteed
-opaque: pure white in light mode, and in dark mode `gray-900` — what
-`surface-card` renders over `surface-canvas`.
+Data table surface (hierarchy level 1). Usually the same color as a card, but must be opaque.
 
 Tables need that guarantee. A sticky header, a frozen row, or a pinned column
 paints over the rows and columns scrolling beneath it, and anything translucent
@@ -113,26 +111,6 @@ lets them show through.
 **When to use:**
 
 - Data table containers, and the sticky parts inside them
-- Any surface at card elevation that has to stay opaque
-
-Recolour it for the whole app the way you would any semantic colour:
-
-```js
-module.exports = frontile({
-  themes: {
-    dark: {
-      colors: {
-        surface: { table: '#1c1c1c' }
-      }
-    }
-  }
-});
-```
-
-For one table that sits on a different background, set `--color-surface-table` on
-it instead — it is a plain custom property, and it applies to everything below
-it. The Table component takes it as a wrapper class; see
-[Table](/docs/components/collections/table).
 
 ```gts preview
 <template>

--- a/packages/frontile/src/components/collections/table.md
+++ b/packages/frontile/src/components/collections/table.md
@@ -183,6 +183,26 @@ export default class DemoComponent extends Component {
 
 ## Sticky Elements
 
+Sticky parts of a table — a frozen header or footer, sticky rows, pinned columns
+— are painted with `surface-table`, the same opaque surface as the table itself,
+so they cover the rows and columns that scroll under them. Pinned columns keep
+their row's selection, hover, and striping.
+
+Tables assume they sit on a canvas-backed page. On any other background, point
+`--color-surface-table` at it — in CSS, or through `@classes`:
+
+```gts
+<Table
+  @columns={{this.columns}}
+  @items={{this.items}}
+  @isScrollable={{true}}
+  @classes={{hash wrapper='[--color-surface-table:var(--color-surface-app)]'}}
+/>
+```
+
+Whatever you point it at has to be opaque. See
+[Surfaces](/docs/theming/design-tokens/surfaces) for the role itself.
+
 ### Sticky Header
 
 Keep the header visible while scrolling:

--- a/packages/theme/src/colors/semantic.ts
+++ b/packages/theme/src/colors/semantic.ts
@@ -101,7 +101,7 @@ const themeColorsLight: ThemeColors = {
       soft: `${absolute.black}0d`, // absolute.black @ 5%
       mild: `${absolute.black}1a`, // absolute.black @ 10%
       firm: `${absolute.black}24`, // absolute.black @ 14%
-      strong: `${absolute.black}bf` // absolute.black @ 75% — the scrim in this scheme
+      strong: `${absolute.black}bf` // absolute.black @ 75%
     },
     lift: {
       subtle: `${absolute.white}4c`, // absolute.white @ 30%
@@ -113,7 +113,6 @@ const themeColorsLight: ThemeColors = {
     app: absolute.white,
     canvas: palette.gray['50'],
     card: absolute.white,
-    // `card` is already opaque in this scheme, so the table matches it exactly.
     table: absolute.white,
     input: absolute.white,
     modal: absolute.white
@@ -210,23 +209,16 @@ const themeColorsDark: ThemeColors = {
       firm: `${absolute.white}40`, // absolute.white @ 25%
       strong: `${absolute.white}f2` // absolute.white @ 95%
     },
-    // The two families are mirrored, so the black scrim lives in `lift` here
-    // rather than in `overlay`. Components wanting a backdrop in both schemes
-    // pair `overlay-strong` with `dark:lift-strong` — see the Overlay theme.
     lift: {
       subtle: `${absolute.black}1a`, // absolute.black @ 10%
       soft: `${absolute.black}33`, // absolute.black @ 20%
       mild: `${absolute.black}4c`, // absolute.black @ 30%
       firm: `${absolute.black}66`, // absolute.black @ 40%
-      strong: `${absolute.black}bf` // absolute.black @ 75% — the scrim in this scheme
+      strong: `${absolute.black}bf` // absolute.black @ 75%
     },
     app: absolute.black,
     canvas: palette.gray['950'],
-    // Beacon aliases dark `card` to `surface.overlay.subtle`, i.e. a
-    // translucent veil rather than an opaque step.
     card: `${absolute.white}12`, // absolute.white @ 7%
-    // What `card` renders: white @ 7% over `canvas` (gray-950) composites to
-    // exactly gray-900 — the same colour, opaque.
     table: palette.gray['900'],
     input: absolute.black,
     modal: palette.gray['950']

--- a/packages/theme/src/colors/semantic.ts
+++ b/packages/theme/src/colors/semantic.ts
@@ -113,6 +113,8 @@ const themeColorsLight: ThemeColors = {
     app: absolute.white,
     canvas: palette.gray['50'],
     card: absolute.white,
+    // `card` is already opaque in this scheme, so the table matches it exactly.
+    table: absolute.white,
     input: absolute.white,
     modal: absolute.white
   }
@@ -223,6 +225,9 @@ const themeColorsDark: ThemeColors = {
     // Beacon aliases dark `card` to `surface.overlay.subtle`, i.e. a
     // translucent veil rather than an opaque step.
     card: `${absolute.white}12`, // absolute.white @ 7%
+    // What `card` renders: white @ 7% over `canvas` (gray-950) composites to
+    // exactly gray-900 — the same colour, opaque.
+    table: palette.gray['900'],
     input: absolute.black,
     modal: palette.gray['950']
   }

--- a/packages/theme/src/colors/types.ts
+++ b/packages/theme/src/colors/types.ts
@@ -273,8 +273,8 @@ export interface SurfaceColors {
    *
    * Light: Pure white, creating lifted appearance against gray canvas
    * Dark: A translucent veil (white @ 7%, the same value as `overlay-subtle`),
-   * so content behind it shows through faintly. Use an opaque role such as
-   * `surface-canvas` where it must not — a sticky table header, for instance.
+   * so content behind it shows through faintly. Where a surface has to stay
+   * opaque, use {@link table} — the same color without the transparency.
    *
    * @example
    * // Product card
@@ -288,6 +288,28 @@ export interface SurfaceColors {
    * <div className="bg-surface-card hover:bg-surface-overlay-subtle">
    */
   card: string;
+
+  /**
+   * Data table surface (hierarchy level 1).
+   *
+   * The same color as {@link card}, guaranteed opaque. Tables need that
+   * guarantee: a sticky header, a frozen row, or a pinned column paints over the
+   * rows and columns scrolling beneath it, and anything translucent lets them
+   * show through.
+   *
+   * Light: Pure white, identical to `card`
+   * Dark: `gray-900` — the color `card` renders over `canvas`, so the two are
+   * indistinguishable on a canvas-backed page
+   *
+   * For one table on a different background, set `--color-surface-table` on it
+   * rather than recolouring the role — it is a plain custom property, and it
+   * applies to everything below it.
+   *
+   * @example
+   * // Sticky table header, which the rows scroll under
+   * <thead className="sticky top-0 bg-surface-table">
+   */
+  table: string;
 
   /**
    * Form control surface for inputs, checkboxes, radios, and similar controls

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -27,7 +27,10 @@ const table = tv({
       // inherit`. Row tints layer on top of this, and any tint that replaces it
       // has to be opaque too — see `striped` and the selection variants.
       '[&>tr]:bg-surface-table',
-      '[&>tr]:data-[selectable=true]:data-[selected=false]:hover:bg-neutral-subtle',
+      // `muted`, not `subtle`: in dark `neutral-subtle` is gray-900, the same
+      // value `surface-table` carries, so a `subtle` hover reads as no hover at
+      // all. This stays a background *colour* so `transition-colors` animates it.
+      '[&>tr]:data-[selectable=true]:data-[selected=false]:hover:bg-neutral-muted',
       '[&>tr]:data-[selectable=true]:transition-colors'
     ],
     // Footer rows take the surface for the same reason body rows do: a sticky
@@ -361,8 +364,13 @@ const table = tv({
         // Half-opacity, so it layers over the row's fill rather than replacing
         // it — a selected sticky row still has to occlude what scrolls under.
         // The other selection colours are opaque and can stay plain fills.
+        //
+        // `soft` rather than `subtle`, which in dark is the same value as
+        // `surface-table` and so tints nothing. At 50% this lands on the weight
+        // the colour variants carry (1.4:1 against the surface, against
+        // `primary-subtle`'s 1.38:1).
         tbody:
-          '[&>tr]:data-[selected=true]:[background-image:linear-gradient(color-mix(in_oklab,var(--color-neutral-subtle)_50%,transparent),color-mix(in_oklab,var(--color-neutral-subtle)_50%,transparent))]',
+          '[&>tr]:data-[selected=true]:[background-image:linear-gradient(color-mix(in_oklab,var(--color-neutral-soft)_50%,transparent),color-mix(in_oklab,var(--color-neutral-soft)_50%,transparent))]',
         tr: ['data-[selectable=true]:focus-visible:ring-default']
       }
     },

--- a/packages/theme/src/components/table.ts
+++ b/packages/theme/src/components/table.ts
@@ -8,17 +8,31 @@ const table = tv({
       'isolate',
       'overflow-auto',
       'rounded-default',
-      'bg-surface-card'
+      // `surface-table` rather than `surface-card`, which the table otherwise
+      // looks exactly like: every sticky part of the table paints over the rows
+      // and columns scrolling beneath it, and in dark `card` is a translucent
+      // veil that would let them read through. The role carries the colour that
+      // veil renders, with the alpha already resolved. Override
+      // `--color-surface-table` to sit a table on a different background.
+      'bg-surface-table'
     ],
     table: ['w-full', 'table-auto'],
     thead: ['relative', 'bg-surface-overlay-subtle'],
     tbody: [
       'divide-y',
       'divide-surface-overlay-subtle',
+      // Rows carry the surface themselves rather than letting the wrapper show
+      // through: a sticky row has to hide the rows sliding under it, and a
+      // sticky cell picks its fill up from its row via `background-color:
+      // inherit`. Row tints layer on top of this, and any tint that replaces it
+      // has to be opaque too — see `striped` and the selection variants.
+      '[&>tr]:bg-surface-table',
       '[&>tr]:data-[selectable=true]:data-[selected=false]:hover:bg-neutral-subtle',
       '[&>tr]:data-[selectable=true]:transition-colors'
     ],
-    tfoot: ['relative'],
+    // Footer rows take the surface for the same reason body rows do: a sticky
+    // column in the footer scrolls past the cells to its side.
+    tfoot: ['relative', '[&>tr]:bg-surface-table'],
     tr: [
       'data-[disabled=true]:opacity-50',
       'data-[disabled=true]:cursor-not-allowed',
@@ -148,7 +162,11 @@ const table = tv({
     },
     striped: {
       true: {
-        tbody: '[&_tr:nth-child(odd)]:bg-surface-overlay-subtle'
+        // A translucent tint, so it goes on as a background *image* layer over
+        // the row's opaque fill instead of replacing it. Painting it as the
+        // background colour would make every striped sticky row see-through.
+        tbody:
+          '[&_tr:nth-child(odd)]:[background-image:linear-gradient(var(--color-surface-overlay-subtle),var(--color-surface-overlay-subtle))]'
       }
     },
     isSticky: {
@@ -178,9 +196,16 @@ const table = tv({
       isSticky: true,
       stickyPosition: 'top',
       class: {
-        // `surface-card` is translucent in dark, which would let rows show
-        // through a stuck header; `surface-canvas` is opaque in both schemes.
-        thead: ['sticky', 'top-0', 'z-2', 'bg-surface-canvas']
+        // The opaque surface plus the header's own translucent tint as a layer
+        // above it, which is what a non-sticky `thead` composites to over the
+        // wrapper — so stuck and unstuck headers read as the same colour.
+        thead: [
+          'sticky',
+          'top-0',
+          'z-2',
+          'bg-surface-table',
+          '[background-image:linear-gradient(var(--color-surface-overlay-subtle),var(--color-surface-overlay-subtle))]'
+        ]
       }
     },
     // Sticky footer
@@ -188,10 +213,13 @@ const table = tv({
       isSticky: true,
       stickyPosition: 'bottom',
       class: {
-        tfoot: ['sticky', 'bottom-0', 'z-2', 'bg-surface-card']
+        tfoot: ['sticky', 'bottom-0', 'z-2', 'bg-surface-table']
       }
     },
-    // Sticky columns - medium priority, header cells get higher z-index
+    // Sticky columns - medium priority, header cells get higher z-index.
+    // Body and footer cells inherit their row's paint — fill, and any tint
+    // layered over it — so a pinned column tracks selection, hover and striping
+    // instead of masking them with a surface of its own.
     {
       isSticky: true,
       stickyPosition: 'left',
@@ -200,10 +228,16 @@ const table = tv({
           'sticky',
           'left-0',
           'z-3',
-          'bg-surface-card',
+          'bg-surface-table',
           '[background-image:linear-gradient(var(--color-surface-overlay-subtle),var(--color-surface-overlay-subtle))]'
         ],
-        td: ['sticky', 'left-0', 'z-1', 'bg-surface-card']
+        td: [
+          'sticky',
+          'left-0',
+          'z-1',
+          'bg-inherit',
+          '[background-image:inherit]'
+        ]
       }
     },
     {
@@ -214,10 +248,16 @@ const table = tv({
           'sticky',
           'right-0',
           'z-3',
-          'bg-surface-card',
+          'bg-surface-table',
           '[background-image:linear-gradient(var(--color-surface-overlay-subtle),var(--color-surface-overlay-subtle))]'
         ],
-        td: ['sticky', 'right-0', 'z-1', 'bg-surface-card']
+        td: [
+          'sticky',
+          'right-0',
+          'z-1',
+          'bg-inherit',
+          '[background-image:inherit]'
+        ]
       }
     },
     // Sticky rows - base layer
@@ -225,14 +265,14 @@ const table = tv({
       isSticky: true,
       stickyPosition: 'top',
       class: {
-        tr: ['sticky', 'top-0', 'z-1', 'bg-surface-card']
+        tr: ['sticky', 'top-0', 'z-1', 'bg-surface-table']
       }
     },
     {
       isSticky: true,
       stickyPosition: 'bottom',
       class: {
-        tr: ['sticky', 'bottom-0', 'z-1', 'bg-surface-card']
+        tr: ['sticky', 'bottom-0', 'z-1', 'bg-surface-table']
       }
     },
     // Sticky rows with sticky header - position after header
@@ -244,7 +284,7 @@ const table = tv({
         tr: [
           'sticky',
           'z-2',
-          'bg-surface-card',
+          'bg-surface-table',
           '[&.sticky]:[top:var(--table-header-height,48px)]'
         ]
       }
@@ -255,7 +295,13 @@ const table = tv({
       stickyPosition: 'left',
       isInStickyRow: true,
       class: {
-        td: ['sticky', 'left-0', 'z-2', 'bg-surface-card']
+        td: [
+          'sticky',
+          'left-0',
+          'z-2',
+          'bg-inherit',
+          '[background-image:inherit]'
+        ]
       }
     },
     {
@@ -263,7 +309,13 @@ const table = tv({
       stickyPosition: 'right',
       isInStickyRow: true,
       class: {
-        td: ['sticky', 'right-0', 'z-2', 'bg-surface-card']
+        td: [
+          'sticky',
+          'right-0',
+          'z-2',
+          'bg-inherit',
+          '[background-image:inherit]'
+        ]
       }
     },
     // Loading states with color variants
@@ -306,7 +358,11 @@ const table = tv({
     {
       selectionColor: 'default',
       class: {
-        tbody: '[&>tr]:data-[selected=true]:bg-neutral-subtle/50',
+        // Half-opacity, so it layers over the row's fill rather than replacing
+        // it — a selected sticky row still has to occlude what scrolls under.
+        // The other selection colours are opaque and can stay plain fills.
+        tbody:
+          '[&>tr]:data-[selected=true]:[background-image:linear-gradient(color-mix(in_oklab,var(--color-neutral-subtle)_50%,transparent),color-mix(in_oklab,var(--color-neutral-subtle)_50%,transparent))]',
         tr: ['data-[selectable=true]:focus-visible:ring-default']
       }
     },

--- a/site/app/components/homepage/app-specimen.gts
+++ b/site/app/components/homepage/app-specimen.gts
@@ -11,6 +11,7 @@ import {
   type ColumnConfig,
   type SortItem,
 } from 'frontile';
+import { hash } from '@ember/helper';
 import {
   SearchIcon,
   FilterIcon,
@@ -201,7 +202,12 @@ export default class AppSpecimen extends Component {
       {{! Table: selectable, pre-sorted, with an icon action group per row.
           Inset to the same 20px gutter as the header, toolbar, and footer, so
           the rows read as bands inside the panel rather than running into its
-          border. }}
+          border.
+          The table surface is pointed at the panel's own "app" surface: the
+          selection column is sticky because the table scrolls, and a sticky
+          column paints an opaque patch of that surface over whatever scrolls
+          past it. Left at the default it would carry a card's step of
+          elevation, which the panel already provides. }}
       <div class="px-5 py-2">
         <Table
           @columns={{this.columns}}
@@ -211,6 +217,9 @@ export default class AppSpecimen extends Component {
           @initialSort={{this.initialSort}}
           @onSort={{this.sortItems}}
           @isScrollable={{true}}
+          @classes={{hash
+            wrapper="[--color-surface-table:var(--color-surface-app)]"
+          }}
         >
           <:cell as |c|>
             <c.For @key="workerId">

--- a/site/app/components/theme-docs/surface-showcase.gts
+++ b/site/app/components/theme-docs/surface-showcase.gts
@@ -34,7 +34,7 @@ export default class SurfaceShowcase extends Component<SurfaceShowcaseSignature>
   }
 
   get surfaceRoles() {
-    return ['app', 'canvas', 'card', 'modal', 'input'];
+    return ['app', 'canvas', 'card', 'table', 'modal', 'input'];
   }
 
   private overlayClasses: Record<string, string> = {
@@ -57,6 +57,7 @@ export default class SurfaceShowcase extends Component<SurfaceShowcaseSignature>
     app: 'bg-surface-app',
     canvas: 'bg-surface-canvas',
     card: 'bg-surface-card',
+    table: 'bg-surface-table',
     modal: 'bg-surface-modal',
     input: 'bg-surface-input',
   };
@@ -65,6 +66,7 @@ export default class SurfaceShowcase extends Component<SurfaceShowcaseSignature>
     app: 'App',
     canvas: 'Canvas',
     card: 'Card',
+    table: 'Table',
     modal: 'Modal',
     input: 'Input',
   };
@@ -73,6 +75,7 @@ export default class SurfaceShowcase extends Component<SurfaceShowcaseSignature>
     app: 'Root application background, base layer',
     canvas: 'Component contrast baseline, may cover app',
     card: 'Elevated content containers, article cards',
+    table: 'Data tables — a card that must occlude, so never translucent',
     modal: 'Modals, drawers, popovers, dropdowns — highest elevation',
     input: 'Form controls: inputs, checkboxes, radios',
   };

--- a/test-app/tests/integration/components/collections/table-test.gts
+++ b/test-app/tests/integration/components/collections/table-test.gts
@@ -750,6 +750,134 @@ module(
       assert.dom('[data-test-id="table-row"][data-key="1"]').hasClass('sticky');
     });
 
+    test('sticky surfaces are opaque so scrolled content cannot show through', async function (assert) {
+      // A sticky cell paints over the rows and columns that scroll beneath it,
+      // so its background has to be fully opaque. In dark mode `surface-card`
+      // is a translucent veil, which used to let the scrolled content read
+      // straight through every sticky header, row, and column.
+      const columns = [
+        { key: 'id', name: 'ID', isSticky: true, stickyPosition: 'left' },
+        { key: 'name', name: 'Name' },
+        {
+          key: 'actions',
+          name: 'Actions',
+          isSticky: true,
+          stickyPosition: 'right'
+        }
+      ] as const satisfies ColumnConfig<TestItem>[];
+
+      const items: TestItem[] = [
+        { id: '1', name: 'John', email: 'john@example.com', role: 'admin' },
+        { id: '2', name: 'Jane', email: 'jane@example.com', role: 'user' }
+      ];
+
+      await render(
+        <template>
+          {{! the veil only exists in the dark theme }}
+          <div class="dark">
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @isScrollable={{true}}
+              @isStickyHeader={{true}}
+              @isStickyFooter={{true}}
+              @footerColumns={{columns}}
+              @stickyKeys={{array "1"}}
+            />
+          </div>
+        </template>
+      );
+
+      const alphaOf = (el: Element) => {
+        const color = getComputedStyle(el).backgroundColor;
+        const parts = color.match(/[\d.]+/g) ?? [];
+        // rgb()/oklch() without an alpha component is fully opaque
+        return parts.length > 3 ? Number(parts[3]) : 1;
+      };
+
+      const stickyElements = [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-component="table-wrapper"] .sticky'
+        )
+      ].filter((el) => el.tagName !== 'TR' || el.children.length > 0);
+
+      assert.ok(
+        stickyElements.length >= 4,
+        `found sticky elements to check (${stickyElements.length})`
+      );
+
+      for (const el of stickyElements) {
+        assert.strictEqual(
+          alphaOf(el),
+          1,
+          `sticky ${el.tagName.toLowerCase()}${
+            el.dataset.key ? `[data-key=${el.dataset.key}]` : ''
+          } has an opaque background`
+        );
+      }
+    });
+
+    test('row tints layer over the sticky fill instead of replacing it', async function (assert) {
+      // The translucent tints — striping, and the `default` selection colour —
+      // go on as a background image so the row keeps the opaque fill
+      // underneath. Painting them as the background colour instead is what let
+      // a striped or selected sticky row turn see-through.
+      const columns = [
+        { key: 'id', name: 'ID', isSticky: true, stickyPosition: 'left' },
+        { key: 'name', name: 'Name' }
+      ] as const satisfies ColumnConfig<TestItem>[];
+
+      const items: TestItem[] = [
+        { id: '1', name: 'John', email: 'john@example.com', role: 'admin' },
+        { id: '2', name: 'Jane', email: 'jane@example.com', role: 'user' }
+      ];
+
+      await render(
+        <template>
+          <div class="dark">
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @isStriped={{true}}
+              @isScrollable={{true}}
+              @selectionMode="multiple"
+              @selectionColor="default"
+              @selectedKeys={{array "1"}}
+              @stickyKeys={{array "1"}}
+            />
+          </div>
+        </template>
+      );
+
+      const row = document.querySelector<HTMLElement>(
+        '[data-test-id="table-row"][data-key="1"]'
+      )!;
+      const cell = row.querySelector<HTMLElement>('[data-column="id"]')!;
+
+      const rowStyle = getComputedStyle(row);
+      assert.notStrictEqual(
+        rowStyle.backgroundImage,
+        'none',
+        'the selected row carries its tint as a background image'
+      );
+      assert.notOk(
+        rowStyle.backgroundColor.includes('/'),
+        `the fill under that tint is opaque (${rowStyle.backgroundColor})`
+      );
+
+      const cellStyle = getComputedStyle(cell);
+      assert.strictEqual(
+        cellStyle.backgroundColor,
+        rowStyle.backgroundColor,
+        'the pinned cell takes its fill from the row'
+      );
+      assert.strictEqual(
+        cellStyle.backgroundImage,
+        rowStyle.backgroundImage,
+        'and the row tint with it, so selection is not masked'
+      );
+    });
+
     test('it renders footer with footerColumns', async function (assert) {
       const columns = [
         { key: 'id', name: 'ID' },


### PR DESCRIPTION
## The bug

In dark mode `surface-card` is a translucent veil (white @ 7% — the same value as `surface-overlay-subtle`), and the table painted every sticky part with it. A sticky cell paints *over* the rows and columns scrolling beneath it, so that 7% alpha let the scrolled content read straight through. Before this change, every sticky `thead`/`tr`/`th`/`td` computed to `oklch(1 0 0 / 0.0705882)`.

Three symptoms, one cause:

- **Sticky rows** — the row underneath showed through the frozen row.
- **Sticky columns** — text from the scrolled columns bled through the pinned ones. The sticky header had already been worked around with `surface-canvas`, which occludes but is a *different colour* from the card it interrupts, leaving a seam where the header meets the body.
- **Homepage specimen** — the sticky selection column re-applied the veil over its own row, so it sat a shade off the rest of the row.

## The fix

**A new `surface-table` role**, alongside `card` and `input`: the colour a card renders, guaranteed opaque — white in light, `gray-900` in dark (what white @ 7% composites to over `canvas`). A table still looks like a card, and its sticky parts can occlude. Retargeting it is plain CSS (`--color-surface-table`), with no component API involved; the homepage specimen points it at `app`, matching its panel.

**Tints layer instead of replacing.** The translucent row tints (striping, `default` selection) go on as a `background-image` layer over the opaque fill, so a striped or selected sticky row still occludes. Pinned body cells take `bg-inherit` plus `background-image: inherit`, so they follow their row's selection, hover and striping rather than masking them.

**Interaction tints moved off `neutral-subtle`.** In dark that token is `gray-900` — the same value `surface-table` carries — so hover and the `default` selection both rendered as no-ops. Verified with a real `:hover`: the hovered row and its neighbour computed identical. Hover now uses `neutral-muted` and the `default` selection `neutral-soft` at 50%.

## Colour audit

Contrast against the table surface, dark / light:

| | token | dark | light |
|---|---|---|---|
| header + striped tint | `overlay-subtle` layer | 1.22:1 | 1.07:1 |
| separator | `overlay-mild` layer | 1.71:1 | 1.25:1 |
| selection (primary etc.) | `*-subtle` | 1.38:1 | 1.05:1 |
| selection (`default`) | `neutral-soft` @50% | 1.40:1 *(was 1.00:1)* | 1.16:1 |
| hover | `neutral-muted` | 1.35:1 *(was 1.00:1)* | 1.18:1 |
| td / th text | `neutral-strong` / `bolder` | 12.2:1 / 14.2:1 | 12.5:1 / 16.8:1 |

## Verification

- Rendered every path in a real browser (dark and light): pinned columns cover the scrolled text instead of letting it through; the sticky row covers the row beneath it; hover and `default` selection are now distinct from the surface. Removing the header's gradient tint reproduces the seam it exists to prevent, which confirms it is doing work.
- Two new integration tests, written first and confirmed failing against the old styles (8 of 10 assertions, alpha `0.0705882`): sticky surfaces are opaque, and row tints layer over the fill without replacing it.
- Full suite: **834 tests, 831 pass, 0 fail** (3 pre-existing skips).
- `pnpm lint:js` clean; `frontile` and `@frontile/theme` type-check clean; the repo's docs linter reports no findings on the touched pages.

## Noted, not changed

The table's `empty` slot and `sortIcon` use `text-neutral-soft`: **2.08:1 in dark, 1.37:1 in light**. "No users available" is barely legible on white. Pre-existing and outside this change, but it fails WCAG AA for text and wants a follow-up.

Also unrelated: `Dropdown` and `Popover` panels paint `bg-surface-input` (pure black in dark), not the `surface-modal` role the docs prescribe for floating panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)