### PR TITLE
perf(site): declare what a prerendered page will fetch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,3 +16,16 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+# Everything Vite emits under /assets/ carries a content hash in its filename,
+# so a given URL can never change. Netlify's default for these is
+# `public,max-age=0,must-revalidate`, which makes a repeat visitor revalidate
+# every JS chunk, stylesheet and font on every navigation — several megabytes of
+# conditional requests for bytes that are immutable by construction. Fonts live
+# here too. The HTML keeps Netlify's default of `max-age=0, must-revalidate`,
+# which is what it needs — it names the hashed assets, so it has to revalidate
+# for a deploy to be picked up.
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"

--- a/site/app/ssr-entry.ts
+++ b/site/app/ssr-entry.ts
@@ -8,6 +8,11 @@ import config from './config/environment';
 export interface RenderResult {
   html: string;
   /**
+   * The route that was rendered, e.g. `docs.components.buttons.button`. The
+   * prerenderer maps it to the lazy route chunks the page will need.
+   */
+  routeName: string | undefined;
+  /**
    * Read before the instance is torn down — ember-page-title clears
    * `document.title` on teardown, so the caller cannot recover it afterwards.
    */
@@ -64,9 +69,14 @@ export async function render(
       instance.visit as (url: string, options: BootOptions) => Promise<unknown>
     )(url, bootOptions);
 
+    const router = instance.lookup('service:router') as {
+      currentRouteName?: string;
+    };
+
     const result = {
       html: `<!DOCTYPE html>\n${document.documentElement.outerHTML}`,
       title: document.title,
+      routeName: router.currentRouteName,
     };
 
     // Wait for work the transition did not await before the owner is destroyed.

--- a/site/index.html
+++ b/site/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Frontile - Modern, Accessible Component Library for Ember.js</title>

--- a/site/ssr/README.md
+++ b/site/ssr/README.md
@@ -195,6 +195,43 @@ Importing `@ember/test-helpers` for `settled()` costs ~376 KB in the Node bundle
 (never shipped) and one shim: it reads `document.location.search` at module
 scope, and linkedom supplies no location.
 
+## Preloads
+
+A prerendered page knows things Vite cannot. Vite emits `modulepreload` for what
+the _entry_ needs, but the lazily loaded route chunk is chosen at runtime by
+`@embroider/router`, and fonts are found only after the stylesheet is parsed and
+laid out. Both therefore arrive as later request waves, each costing a round trip.
+
+Measured on a docs page against a 6–25ms first wave: route chunks started at
+35ms, fonts at 41ms; on the homepage, fonts at 82ms. After declaring them in the
+HTML, all of it starts at 6–7ms.
+
+`ssr/preload.mjs` works out what to declare, and `prerender.mjs` injects it:
+
+- **Route chunks.** `render()` returns `router.currentRouteName`, which maps to
+  the `splitAtRoutes` bundles covering it — its own split point and every
+  ancestor, since visiting `docs.components.buttons.button` activates `docs` too.
+  Static `imports` are followed transitively, otherwise shared chunks (405 kB of
+  generated signature data among them) would just become a third wave. The split
+  point is read from the emitted filename, because the build manifest keys each
+  bundle by whichever route it happened to see first.
+- **Fonts.** The two used on every page, plus `domine` on the homepage only,
+  where it sets the `h1`. Preloading it everywhere would waste 39 kB a page and
+  earn an unused-preload warning. The italics are conditional and never above the
+  fold. URLs come from the built stylesheet, which is what actually references
+  them — the manifest does not expose emitted font filenames.
+
+Injected hrefs are deduped against what the shell already declares, so nothing is
+requested twice. Verified cold: one request per font, no double fetches, no
+unused-preload warnings.
+
+Two things deliberately left alone. The fonts are unsubset — Open Sans is 273 kB
+and its italic 305 kB, where a latin subset would be a fraction of that; worth
+doing, but it belongs in `@frontile/theme` rather than here. And
+`@embroider/virtual/vendor.js` is a 316-byte blocking classic script that is a
+separate request on the critical path; inlining it would need a build plugin, for
+one round trip.
+
 ## Prior art: vite-ember-ssr
 
 [evoactivity/vite-ember-ssr](https://github.com/evoactivity/vite-ember-ssr) (npm

--- a/site/ssr/preload.mjs
+++ b/site/ssr/preload.mjs
@@ -1,0 +1,123 @@
+/**
+ * Working out what a prerendered page should preload.
+ *
+ * Vite emits `<link rel="modulepreload">` for the chunks the *entry* needs, but
+ * it cannot know which lazily loaded route chunk any given prerendered page will
+ * ask for — that is decided at runtime by @embroider/router. The result is a
+ * second request wave that only starts once the app has booted and resolved its
+ * route. Since prerendering already knows the route, the chunks can be declared
+ * in the HTML instead and fetched alongside everything else.
+ */
+
+/** `assets/-embroider-route-entrypoint.js_route_docs.theming-Bf3x1y2z.js` */
+const ROUTE_BUNDLE_FILE = /_route_(.+?)-[A-Za-z0-9_-]+\.js$/;
+const ROUTE_ENTRYPOINT_KEY = /-embroider-route-entrypoint\.js:route=(.+)$/;
+
+/**
+ * Map each `splitAtRoutes` split point to the files a page under it needs.
+ *
+ * One bundle covers every route beneath its split point, and the manifest keys
+ * it by whichever route was encountered first — so the split point is read from
+ * the emitted filename rather than the key. The top-level `docs` bundle carries
+ * no `_route_` marker, and falls back to the key.
+ *
+ * Static `imports` are followed transitively: a section bundle pulls in shared
+ * chunks (the generated signature data is 405 kB of it) that would otherwise
+ * form a third wave.
+ */
+export function routeBundles(manifest) {
+  const fileFor = (key) => manifest[key]?.file;
+  const bundles = new Map();
+
+  const collect = (key, seen) => {
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+
+    for (const imported of manifest[key]?.imports ?? []) {
+      collect(imported, seen);
+    }
+  };
+
+  for (const key of Object.keys(manifest)) {
+    const keyMatch = ROUTE_ENTRYPOINT_KEY.exec(key);
+    if (!keyMatch) {
+      continue;
+    }
+
+    const file = fileFor(key);
+    const splitPoint = ROUTE_BUNDLE_FILE.exec(file ?? '')?.[1] ?? keyMatch[1];
+
+    const seen = new Set();
+    collect(key, seen);
+
+    bundles.set(splitPoint, [...seen].map(fileFor).filter(Boolean).sort());
+  }
+
+  return bundles;
+}
+
+/** True when `splitPoint` is `routeName` or one of its ancestors. */
+function covers(splitPoint, routeName) {
+  return routeName === splitPoint || routeName.startsWith(`${splitPoint}.`);
+}
+
+/**
+ * The files a page on `routeName` will load, newest split point last.
+ *
+ * Every ancestor split point contributes: visiting
+ * `docs.components.buttons.button` activates the `docs` route as well, so both
+ * bundles are fetched.
+ */
+export function routeChunksFor(bundles, routeName) {
+  if (!routeName) {
+    return [];
+  }
+
+  const files = new Set();
+
+  for (const [splitPoint, bundleFiles] of bundles) {
+    if (covers(splitPoint, routeName)) {
+      bundleFiles.forEach((file) => files.add(file));
+    }
+  }
+
+  return [...files].sort();
+}
+
+/**
+ * Hashed URLs for the given font families, read out of the built stylesheet.
+ *
+ * The build's own manifest does not expose the emitted font filenames at the
+ * point the HTML is generated, and the stylesheet is the thing that actually
+ * references them, so it is the honest source.
+ */
+export function fontUrls(css, families) {
+  return families
+    .map((family) => {
+      const match = new RegExp(
+        `url\\((/[^)"']*${family}[^)"']*\\.woff2)\\)`,
+      ).exec(css);
+
+      return match?.[1];
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Font families worth preloading for a page.
+ *
+ * `open-sans` (body) and `source-code-pro` (code) are used on every page.
+ * `domine` sets the headings on the homepage — including its `h1`, which is the
+ * largest text on the page — but is not fetched at all on a docs page, so
+ * preloading it everywhere would waste 39 kB per page and earn an unused-preload
+ * warning. The italics are conditional and never above the fold.
+ */
+export function fontFamiliesFor(routeName) {
+  const everywhere = ['open-sans-variable', 'source-code-pro-variable'];
+
+  return routeName === 'index'
+    ? [...everywhere, 'domine-variable']
+    : everywhere;
+}

--- a/site/ssr/preload.test.mjs
+++ b/site/ssr/preload.test.mjs
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fontUrls, routeBundles, routeChunksFor } from './preload.mjs';
+
+const ENTRY = 'app/-embroider-route-entrypoint.js:route=';
+
+/** Shaped like a real Vite manifest, trimmed to what these functions read. */
+const manifest = {
+  // The top-level `docs` bundle: no `_route_` marker in its filename.
+  [`${ENTRY}docs`]: {
+    file: 'assets/-embroider-route-entrypoint-aaaaaaaa.js',
+    imports: ['_shared-bbbbbbbb.js'],
+  },
+  // Keyed by whichever route was seen first, not by the split point.
+  [`${ENTRY}docs.components.buttons.button-group`]: {
+    file: 'assets/-embroider-route-entrypoint.js_route_docs.components.buttons-cccccccc.js',
+    imports: ['_shared-bbbbbbbb.js', '_signature-dddddddd.js'],
+  },
+  [`${ENTRY}docs.theming.component-styles`]: {
+    file: 'assets/-embroider-route-entrypoint.js_route_docs.theming-eeeeeeee.js',
+    imports: [],
+  },
+  '_shared-bbbbbbbb.js': { file: 'assets/shared-bbbbbbbb.js' },
+  '_signature-dddddddd.js': { file: 'assets/signature-dddddddd.js' },
+  'index.html': {
+    file: 'assets/main-ffffffff.js',
+    css: ['assets/main-11111111.css'],
+  },
+};
+
+test('split points come from the filename, not the manifest key', () => {
+  const bundles = routeBundles(manifest);
+
+  assert.deepEqual([...bundles.keys()].sort(), [
+    'docs',
+    'docs.components.buttons',
+    'docs.theming',
+  ]);
+});
+
+test('a page pulls its own bundle and every ancestor split point', () => {
+  const bundles = routeBundles(manifest);
+
+  // Visiting a buttons page activates the `docs` route too, so both load.
+  assert.deepEqual(routeChunksFor(bundles, 'docs.components.buttons.button'), [
+    'assets/-embroider-route-entrypoint-aaaaaaaa.js',
+    'assets/-embroider-route-entrypoint.js_route_docs.components.buttons-cccccccc.js',
+    'assets/shared-bbbbbbbb.js',
+    'assets/signature-dddddddd.js',
+  ]);
+});
+
+test('static imports are followed, so shared chunks are not a third wave', () => {
+  const bundles = routeBundles(manifest);
+
+  assert.ok(
+    routeChunksFor(bundles, 'docs.components.buttons.button').includes(
+      'assets/signature-dddddddd.js',
+    ),
+  );
+});
+
+test('a sibling section does not pull another section', () => {
+  const bundles = routeBundles(manifest);
+  const files = routeChunksFor(bundles, 'docs.theming.overview');
+
+  assert.ok(
+    !files.some((file) => file.includes('docs.components.buttons')),
+    'the buttons bundle is unrelated to a theming page',
+  );
+});
+
+test('a split point is matched on dot boundaries', () => {
+  const bundles = routeBundles(manifest);
+
+  // `docs.theming-extras` must not match the `docs.theming` split point.
+  assert.deepEqual(routeChunksFor(bundles, 'docs.theming-extras.index'), [
+    'assets/-embroider-route-entrypoint-aaaaaaaa.js',
+    'assets/shared-bbbbbbbb.js',
+  ]);
+});
+
+test('an unsplit route needs nothing extra', () => {
+  const bundles = routeBundles(manifest);
+
+  assert.deepEqual(routeChunksFor(bundles, 'index'), []);
+});
+
+test('a missing route name is not an error', () => {
+  assert.deepEqual(routeChunksFor(routeBundles(manifest), undefined), []);
+});
+
+test('font URLs are read out of the stylesheet, hash included', () => {
+  const css = `
+    @font-face{font-family:Open Sans;src:url(/assets/open-sans-variable-B73aTk82.woff2)format("woff2-variations")}
+    @font-face{font-family:Domine;src:url(/assets/domine-variable-B3iTxHSC.woff2)format("woff2-variations")}
+  `;
+
+  assert.deepEqual(fontUrls(css, ['open-sans-variable', 'domine-variable']), [
+    '/assets/open-sans-variable-B73aTk82.woff2',
+    '/assets/domine-variable-B3iTxHSC.woff2',
+  ]);
+});
+
+test('a font that is not in the stylesheet is skipped', () => {
+  assert.deepEqual(fontUrls('', ['open-sans-variable']), []);
+});

--- a/site/ssr/prerender.mjs
+++ b/site/ssr/prerender.mjs
@@ -12,6 +12,12 @@ import { fileURLToPath } from 'node:url';
 import { parseHTML } from 'linkedom';
 
 import { outputPathForUrl } from './output-path.mjs';
+import {
+  fontFamiliesFor,
+  fontUrls,
+  routeBundles,
+  routeChunksFor,
+} from './preload.mjs';
 
 // `import.meta.dirname` needs Node 20.11; package.json declares `node >= 18`.
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -34,6 +40,52 @@ try {
 // the template once rather than per document, and after the snapshot is written
 // so the file on disk stays a clean copy of the client build.
 shell = shell.replace('</head>', '<meta name="x-prerendered"></head>');
+
+// --- preloads ---------------------------------------------------------------
+const manifest = JSON.parse(
+  await readFile(join(distDir, '.vite', 'manifest.json'), 'utf8'),
+);
+const bundles = routeBundles(manifest);
+
+// Font URLs are read from the built stylesheet, which is the thing that actually
+// references them — the manifest does not expose the emitted filenames.
+const stylesheets = Object.values(manifest).flatMap((entry) => entry.css ?? []);
+const css = (
+  await Promise.all(
+    stylesheets.map((file) => readFile(join(distDir, file), 'utf8')),
+  )
+).join('\n');
+
+/** Hrefs the shell already declares, so preloads are not emitted twice. */
+const alreadyDeclared = new Set(
+  [...shell.matchAll(/(?:href|src)="(\/assets\/[^"]+)"/g)].map((m) => m[1]),
+);
+
+/**
+ * Declare what this page is about to fetch, so it does not have to be
+ * discovered.
+ *
+ * Route chunks otherwise form a second request wave that cannot start until the
+ * app has booted and resolved its route, and fonts a third, behind stylesheet
+ * parse and layout. Measured against a 6-25ms first wave: chunks at 35ms, fonts
+ * at 41ms on a docs page and 82ms on the homepage — and on a real connection
+ * each wave costs a full round trip.
+ */
+function withPreloads(html, routeName) {
+  const chunks = routeChunksFor(bundles, routeName)
+    .map((file) => `/${file}`)
+    .filter((href) => !alreadyDeclared.has(href))
+    .map((href) => `<link rel="modulepreload" crossorigin href="${href}">`);
+
+  const fonts = fontUrls(css, fontFamiliesFor(routeName)).map(
+    (href) =>
+      `<link rel="preload" as="font" type="font/woff2" href="${href}" crossorigin>`,
+  );
+
+  const links = [...fonts, ...chunks].join('');
+
+  return links ? html.replace('</head>', `${links}</head>`) : html;
+}
 
 /**
  * A document Glimmer can render into, paired with its own `window`.
@@ -145,15 +197,17 @@ for (const url of routes) {
   try {
     const { document } = installDocument();
 
-    const { html, title } = await render(url, document);
+    const { html, title, routeName } = await render(url, document);
+
+    const output = withPreloads(html, routeName);
 
     const outPath = outputPathForUrl(distDir, url);
     await mkdir(dirname(outPath), { recursive: true });
-    await writeFile(outPath, html, 'utf8');
+    await writeFile(outPath, output, 'utf8');
 
     const ms = Math.round(performance.now() - started);
     console.log(
-      `✓ ${url}  ${(html.length / 1024).toFixed(0)}kb  ${ms}ms  title=${JSON.stringify(title)}`,
+      `✓ ${url}  ${(output.length / 1024).toFixed(0)}kb  ${ms}ms  route=${routeName}  title=${JSON.stringify(title)}`,
     );
     ok++;
   } catch (error) {

--- a/site/vite.config.mjs
+++ b/site/vite.config.mjs
@@ -62,5 +62,11 @@ export default defineConfig(({ isSsrBuild }) => ({
           noExternal: true,
         },
       }
-    : {}),
+    : {
+        build: {
+          // ssr/prerender.mjs reads this to work out which lazy route chunks a
+          // page needs, so each prerendered page can preload its own.
+          manifest: true,
+        },
+      }),
 }));


### PR DESCRIPTION
Every change here is backed by a measurement on the built site, and nothing changes what renders.

## The problem

A prerendered page knows things Vite cannot, and wasn't saying them. Loading a docs page produced three request waves instead of one:

| wave | what | started |
|---|---|---|
| 1 | `main.js`, Vite's `modulepreload` chunks, CSS, `vendor.js` | 6–25ms |
| 2 | lazy route chunks (**646 kB**, the largest payload on the page) | **35ms** |
| 3 | fonts | **41ms** (82ms on the homepage) |

Wave 2 can't start until the app has booted and `@embroider/router` has resolved the route. Wave 3 can't start until the stylesheet is parsed *and* laid out — which on a prerendered page queues behind the JS the main thread is busy evaluating, even though the text is already in the HTML. On a real connection each wave is a full round trip.

## After

Everything starts in the first wave:

| | before | after |
|---|---|---|
| Route chunks (docs page) | 35ms | **6ms** |
| Fonts (docs page) | 41ms | **6ms** |
| Fonts (homepage, incl. the `h1` font) | 82–85ms | **7ms** |

## How

[`site/ssr/preload.mjs`](https://github.com/josemarluedke/frontile/blob/perf/index-html/site/ssr/preload.mjs) derives the set; `prerender.mjs` injects it per page.

**Route chunks.** `render()` now returns `router.currentRouteName`, which maps to the `splitAtRoutes` bundles covering it. Three details that took measuring to get right:

- Every *ancestor* split point counts — visiting `docs.components.buttons.button` activates the `docs` route too, so both bundles load.
- Static `imports` are followed transitively. Without that, shared chunks (405 kB of generated signature data among them) would simply become a third wave.
- The split point is read from the emitted **filename**, not the manifest key: the build keys each bundle by whichever route it happened to encounter first, so `docs.components.buttons` is keyed as `docs.components.buttons.button-group`.

**Fonts.** The two used on every page, plus `domine` on the homepage only, where it sets the `h1` — the largest text on the page. Preloading `domine` everywhere would waste 39 kB per page on the 67 docs pages and earn an unused-preload warning. The italics are conditional and never above the fold. URLs come from the built stylesheet, which is the thing that actually references them; the manifest doesn't expose emitted font filenames.

Injected hrefs are deduped against what the shell already declares. Verified on a cold origin: one request per font, no double fetches, **no unused-preload warnings**. (An earlier run did show warnings — that turned out to be a warm-cache artifact, `transferSize: 0` entries, not a real mismatch.)

## Also: hashed assets weren't cached

Measured against production:

```
$ curl -sI https://frontile.dev/assets/main-DGqS-7zY.js
cache-control: public,max-age=0,must-revalidate
```

Those filenames are content-hashed, so the URL can never change — yet every repeat visitor revalidates every chunk, stylesheet and font. `netlify.toml` now sets `max-age=31536000, immutable` for `/assets/*` (fonts live there too). The HTML keeps Netlify's default, which is correct: it names the hashed assets, so it must revalidate for a deploy to be picked up.

I dropped a `/*.html` rule I'd first written — our URLs are extensionless, so it would never have matched.

## Also: `<html lang="en">`

Was missing. Not a perf fix, but it's a one-character-class of bug that affects screen readers and translation.

## Deliberately not done

- **The fonts aren't subset.** Open Sans is 273 kB and its italic 305 kB; a latin subset would be a fraction. That's the biggest remaining win, but it belongs in `@frontile/theme`, not in the site's HTML.
- **`vendor.js` stays a separate blocking script.** 316 bytes, on the critical path, last of wave 1. Inlining it needs a build plugin to reach the emitted asset — one round trip for real machinery.

## Verification

- 68/68 routes prerender; running `prerender` twice is idempotent (no accumulating links).
- Preload counts stable: homepage 7 `modulepreload` + 3 fonts; docs page 10 + 2.
- Rehydration unaffected: one `h1`, zero leftover markers, zero console errors across homepage, table, theming, get-started.
- 9 new unit tests for the mapping (30 total via `pnpm --filter site test:node`), covering ancestor split points, transitive imports, dot-boundary matching so `docs.theming-extras` doesn't match `docs.theming`, and the unsplit-route case.
- glint 2837 errors before and after — all pre-existing. Lint clean.
- `site/index.html` is in `site/.prettierignore` (`*.html`), so the `lang` edit isn't reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
