### PR TITLE
feat(theme): adopt proposed modal and drawer size scale

### DIFF
--- a/docs/theming/configuration/css-variables.md
+++ b/docs/theming/configuration/css-variables.md
@@ -186,11 +186,11 @@ These variables are used by specific Frontile components and should be defined i
 
 ```css
 :root {
-  --modal-xs: 20rem;
-  --modal-sm: 24rem;
-  --modal-md: 28rem;
-  --modal-lg: 32rem;
-  --modal-xl: 36rem;
+  --modal-xs: 22rem;
+  --modal-sm: 30rem;
+  --modal-md: 35rem;
+  --modal-lg: 48rem;
+  --modal-xl: 60rem;
   --modal-full: 100%;
 }
 ```
@@ -199,11 +199,11 @@ These variables are used by specific Frontile components and should be defined i
 
 ```css
 :root {
-  --drawer-xs: 20rem;
-  --drawer-sm: 24rem;
-  --drawer-md: 28rem;
-  --drawer-lg: 32rem;
-  --drawer-xl: 36rem;
+  --drawer-xs: 22rem;
+  --drawer-sm: 30rem;
+  --drawer-md: 48rem;
+  --drawer-lg: 64rem;
+  --drawer-xl: 80rem;
   --drawer-full: 100%;
 }
 ```

--- a/packages/theme/src/index.css
+++ b/packages/theme/src/index.css
@@ -62,19 +62,19 @@
 /* Default theme values - can be overridden via CSS or JS config */
 :root {
   /* Drawer Sizes */
-  --drawer-xs: 20rem;
-  --drawer-sm: 24rem;
-  --drawer-md: 28rem;
-  --drawer-lg: 32rem;
-  --drawer-xl: 36rem;
+  --drawer-xs: 22rem;
+  --drawer-sm: 30rem;
+  --drawer-md: 48rem;
+  --drawer-lg: 64rem;
+  --drawer-xl: 80rem;
   --drawer-full: 100%;
 
   /* Modal Sizes */
-  --modal-xs: 20rem;
-  --modal-sm: 24rem;
-  --modal-md: 28rem;
-  --modal-lg: 32rem;
-  --modal-xl: 36rem;
+  --modal-xs: 22rem;
+  --modal-sm: 30rem;
+  --modal-md: 35rem;
+  --modal-lg: 48rem;
+  --modal-xl: 60rem;
   --modal-full: 100%;
 }
 


### PR DESCRIPTION
## Summary

Updates the default modal and drawer size CSS variables to the proposed design-system scale.

| size | modal | drawer |
|---|---|---|
| xs | 22rem (352px) | 22rem (352px) |
| sm | 30rem (480px) | 30rem (480px) |
| md | 35rem (560px) | 48rem (768px) |
| lg | 48rem (768px) | 64rem (1024px) |
| xl | 60rem (960px) | 80rem (1280px) |
| full | 100% | 100% |

All defaults live in a single place — `packages/theme/src/index.css` — which is shipped directly from `src` via the package's `style` export, so no generated output changes. The documented defaults in `docs/theming/configuration/css-variables.md` were updated to match. The override examples in `customization.md` and `theming/overview.md` were intentionally left alone: they are illustrative custom values, not defaults.

## Notes

- The plugin computes `min(var(--modal-*), calc(100vw - margin))`, so the larger sizes still clamp to the viewport on small screens.
- The proposed drawer `md` row was internally inconsistent (token `sizing/768-donut`, rem column `480`). This takes 48rem/768px, matching the token and giving a clean xs→xl progression.

## Test plan

- `pnpm --filter @frontile/theme build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)