### PR TITLE
fix(theme): match the refreshed Facet button label sizes

### DIFF
--- a/packages/theme/src/styles/typography.css
+++ b/packages/theme/src/styles/typography.css
@@ -205,7 +205,9 @@
 
 
   /* strong text styles — Open Sans bold, emphasis for numerics/prices.
-     Shares the header size/tracking/leading matrix. */
+     Sizes follow the Facet button label ramp (sm..3xl map to typescale
+     11/13/16/18/22/25); the smaller steps are unused by Button and keep their
+     original mapping. */
   --text-strong-4xs: var(--font-size-3);
   --text-strong-4xs--font-weight: var(--font-weight-bold);
   --text-strong-4xs--letter-spacing: var(--letter-spacing-default);
@@ -226,32 +228,32 @@
   --text-strong-xs--letter-spacing: var(--letter-spacing-default);
   --text-strong-xs--line-height: var(--line-height-easy);
 
-  --text-strong-sm: var(--font-size-12);
+  --text-strong-sm: var(--font-size-11);
   --text-strong-sm--font-weight: var(--font-weight-bold);
   --text-strong-sm--letter-spacing: var(--letter-spacing-default);
   --text-strong-sm--line-height: var(--line-height-easy);
 
-  --text-strong-md: var(--font-size-14);
+  --text-strong-md: var(--font-size-13);
   --text-strong-md--font-weight: var(--font-weight-bold);
   --text-strong-md--letter-spacing: var(--letter-spacing-tight);
   --text-strong-md--line-height: var(--line-height-easy);
 
-  --text-strong-lg: var(--font-size-17);
+  --text-strong-lg: var(--font-size-16);
   --text-strong-lg--font-weight: var(--font-weight-bold);
   --text-strong-lg--letter-spacing: var(--letter-spacing-tight);
   --text-strong-lg--line-height: var(--line-height-default);
 
-  --text-strong-xl: var(--font-size-19);
+  --text-strong-xl: var(--font-size-18);
   --text-strong-xl--font-weight: var(--font-weight-bold);
   --text-strong-xl--letter-spacing: var(--letter-spacing-tight);
   --text-strong-xl--line-height: var(--line-height-default);
 
-  --text-strong-2xl: var(--font-size-23);
+  --text-strong-2xl: var(--font-size-22);
   --text-strong-2xl--font-weight: var(--font-weight-bold);
   --text-strong-2xl--letter-spacing: var(--letter-spacing-tight);
   --text-strong-2xl--line-height: var(--line-height-default);
 
-  --text-strong-3xl: var(--font-size-26);
+  --text-strong-3xl: var(--font-size-25);
   --text-strong-3xl--font-weight: var(--font-weight-bold);
   --text-strong-3xl--letter-spacing: var(--letter-spacing-tight);
   --text-strong-3xl--line-height: var(--line-height-default);


### PR DESCRIPTION
Refreshed the button type data from Figma (`msg58RSwg3YEC6CCUVOW9L`, nodes
`284:62`–`284:67`). Every button label moved down exactly one typescale step:

| `@size` | label was | label now | px |
| ------- | --------- | --------- | -- |
| `xs`    | typescale-12 | **typescale-11** | 14.995 |
| `sm`    | typescale-14 | **typescale-13** | 17.072 |
| `md`    | typescale-17 | **typescale-16** | 20.739 |
| `lg`    | typescale-19 | **typescale-18** | 23.611 |
| `xl`    | typescale-23 | **typescale-22** | 30.603 |
| `2xl`   | typescale-26 | **typescale-25** | 37.176 |

### How

None of the new steps are named in the `strong` ramp, so the button classes
could not simply be re-pointed at a different named step — the ramp itself had
to move. `text-strong-*` is consumed **only** by Button (plus its docs and the
tw-merge registration), so shifting it is contained: `button.ts` is untouched and
the size variants keep their existing classes.

Verified in the browser — rendered label sizes now match the comp to the
sub-pixel at every size, still at weight 700.

The four smaller steps (`4xs`–`xs`) are unused by Button and keep their original
mapping. That leaves `xs`→10 sitting next to `sm`→11 in the ramp; I did not
invent values for steps the design file says nothing about, but it is worth a
look if the whole scale was meant to shift.

Padding, gaps and the label↔unit gap are unchanged in the refreshed tokens.

### Noticed but not changed

- **The `/mo` unit also moved one step** (8→7, 10→9, 12→11, 14→13, 16→15,
  18→17). The unit uses the `body` ramp, which is shared with forms, listbox,
  table, progress-bar and notification-card, so shifting it is not contained the
  way `strong` is — and our ramp has no named steps at 11/13/15/17. The
  label+unit table in `button.md` is therefore ~1 step large on four rows. Needs
  a decision: add body steps, or accept the approximation.
- **Icon sizing is now its own token set** — at `md` the glyph is
  `sizing/16-sequin` (16px) inside an 18px box, rather than deriving from the
  label. We use `[&_svg]:size-[1em]`, which at `md` now yields 20.7px. Separate
  change if we want to follow it.
- **`typography/font/header` was renamed to `typography/font/strong`** for the
  label. Both resolve to Open Sans in our theme, so there is no visual
  difference; Button still applies `font-header`.
