### PR TITLE
feat(forms): render multi-select selections as removable chips

### DIFF
--- a/docs/migrations/v0.18/index.md
+++ b/docs/migrations/v0.18/index.md
@@ -23,6 +23,7 @@ them is optional for the whole 0.18 line.
 | Nested `LayoutTheme` config | Build or type error | Loudly, and only if you customize the theme |
 | `@frontile/*` package imports | Nothing — they still work in 0.18.x | Deprecation warning only |
 | Derived border-radius scale | Slightly rounder corners on menus and small marks | Visual only — nothing to fix |
+| Multi-select renders chips | Multi-selects look different — selections become removable chips | Visual only — nothing to fix |
 
 **The silent ones are the reason to take this in order.** A class Tailwind can't
 resolve produces no error, no warning, and no CSS — the element just renders
@@ -83,6 +84,35 @@ you can't read — which matters precisely because those changes fail silently.
 
 **See:** [Package Consolidation](./package-consolidation.md)
 
+### 4. Multi-select renders chips — visual only
+
+`Select` with `@selectionMode="multiple"` used to show its selections as a
+comma-joined string inside the trigger. It now renders each selection as a
+removable [Chip](https://frontile.dev/docs/buttons/chip), so users can drop one
+selection without reopening the dropdown. The control grows taller as chips
+wrap, and a chips field is deliberately the same height as a same-size single
+select (46px at `md`).
+
+Nothing breaks, but the field is taller and looks different. If a layout
+depends on the old fixed-height appearance, opt back out per-select:
+
+```gts
+<Select @selectionMode='multiple' @selectedItemsDisplay='text' />
+```
+
+Chips inherit the Select's `@intent` and default to the `faded` appearance;
+`@chip={{hash appearance='outlined' size='md'}}` tunes appearance, intent,
+size, radius and `withDot`. `@allowEmpty` defaults to `false`, so the final
+selection's chip renders with no close button; `@isClearable` clears
+everything and ignores `@allowEmpty`. Chip close buttons are deliberately not
+in the tab order — the combobox is the single tab stop, and `Backspace` on
+the field removes the last chip in both filterable and non-filterable modes.
+See the [Select docs](https://frontile.dev/docs/forms/select#multiple-selection)
+for the full section.
+
+**Impact:** visual only. **Time:** none required; a few minutes if you want to
+opt out.
+
 ## Checklist
 
 - [ ] `@import "@frontile/theme"` added to `app.css`
@@ -94,6 +124,7 @@ you can't read — which matters precisely because those changes fail silently.
 - [ ] `{color}-foreground` / `contrast-*` replaced with `on-{color}-{level}`
 - [ ] **Looked at the running app**, not just the diff
 - [ ] Imports moved to `frontile` (optional until 0.19)
+- [ ] Looked at any multi-selects — they now render chips and are taller
 
 ## New projects
 

--- a/packages/frontile/src/components/buttons/chip.gts
+++ b/packages/frontile/src/components/buttons/chip.gts
@@ -54,6 +54,18 @@ interface ChipSignature {
     closeButtonTitle?: string;
 
     /**
+     * `tabindex` for the close button.
+     *
+     * Set to `-1` when chips sit inside another control (a multi-select field,
+     * say) and the close button should stay a pointer affordance: every chip
+     * would otherwise cost a Tab stop before the control itself is reached.
+     * Whoever does this owes keyboard users another way to remove a chip.
+     *
+     * @defaultValue undefined (the close button is a normal tab stop)
+     */
+    closeButtonTabIndex?: number | string;
+
+    /**
      * Disables the clip and disables the close button if any.
      */
     isDisabled?: boolean;
@@ -102,6 +114,7 @@ class Chip extends Component<ChipSignature> {
           @class={{this.classNames.closeButton}}
           @title={{@closeButtonTitle}}
           @onPress={{@onClose}}
+          tabindex={{@closeButtonTabIndex}}
           disabled={{@isDisabled}}
         />
       {{/if}}

--- a/packages/frontile/src/components/buttons/chip.md
+++ b/packages/frontile/src/components/buttons/chip.md
@@ -235,6 +235,15 @@ export default class Example extends Component {
 }
 ```
 
+### Keeping the close button out of the tab order
+
+`@closeButtonTabIndex="-1"` makes a chip's close button a pointer-only affordance.
+Reach for it when chips sit _inside_ another control — a multi-select field, say —
+where each chip would otherwise cost a Tab stop before the control itself is
+reachable. `Select` does exactly this in chips mode. If you do it, you owe keyboard
+users another way to remove a chip (`Select` uses `Backspace` on the field); leaving
+them with no route at all is worse than the extra tab stops.
+
 ## Accessibility
 
 A `Chip` is a `<div>` holding text — it has no role of its own, because a chip is

--- a/packages/frontile/src/components/buttons/close-button.gts
+++ b/packages/frontile/src/components/buttons/close-button.gts
@@ -107,6 +107,7 @@ class CloseButton extends Component<CloseButtonSignature> {
       type="button"
       class={{this.classes.base}}
       data-pressed={{if this.isPressed "true"}}
+      title={{if @title @title "Close"}}
       ...attributes
       {{press this.handlePress onPressChange=this.handlePressChange}}
       {{on "click" this.handleClick}}

--- a/packages/frontile/src/components/buttons/close-button.gts
+++ b/packages/frontile/src/components/buttons/close-button.gts
@@ -107,7 +107,6 @@ class CloseButton extends Component<CloseButtonSignature> {
       type="button"
       class={{this.classes.base}}
       data-pressed={{if this.isPressed "true"}}
-      title={{if @title @title "Close"}}
       ...attributes
       {{press this.handlePress onPressChange=this.handlePressChange}}
       {{on "click" this.handleClick}}

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -957,7 +957,13 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                 {{yield to="startContent"}}
               </div>
             {{/if}}
+            {{! The wrapper, not the trigger, is the popover's width reference:
+            in chips mode the trigger is only as wide as the space left over
+            inside the field. The wrapper is a real full-width box in both
+            modes, so the dropdown matches the field either way. }}
             <div
+              {{p.anchor}}
+              {{p.measureWidth}}
               data-test-id={{if this.showChips "chips-field"}}
               data-has-chips={{this.showChips}}
               data-invalid={{c.isInvalid}}
@@ -990,7 +996,6 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                 <input
                   type="text"
                   {{p.trigger}}
-                  {{p.anchor}}
                   {{this.triggerRef.setup}}
                   data-test-id="trigger"
                   data-component="select-trigger"
@@ -1011,7 +1016,6 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                 <button
                   type="button"
                   {{p.trigger}}
-                  {{p.anchor}}
                   {{this.triggerRef.setup}}
                   data-test-id="trigger"
                   data-component="select-trigger"

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -661,7 +661,11 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
    * chip renders without a close button rather than with a dead one.
    */
   get chipsRemovable(): boolean {
-    return this.args.allowEmpty === true || this.selectedKeys.length > 1;
+    // Counts `selectedItems` — the same collection the chips render from —
+    // rather than `selectedKeys`, so this decision can never disagree with
+    // what is actually on screen (a selected key with no remembered item
+    // would otherwise be counted here but never render a chip at all).
+    return this.args.allowEmpty === true || this.selectedItems.length > 1;
   }
 
   /**

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -575,6 +575,25 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   };
 
   /**
+   * Backspace on an empty filter removes the last chip — the familiar tag-input
+   * gesture. With text in the filter, Backspace edits the text as usual.
+   */
+  handleFilterKeydown = (event: KeyboardEvent) => {
+    if (event.key !== 'Backspace' || !this.showChips) {
+      return;
+    }
+    const target = event.target as HTMLInputElement;
+    if (target.value !== '') {
+      return;
+    }
+    const items = this.selectedItems;
+    const last = items[items.length - 1];
+    if (last) {
+      this.removeSelectedKey(last.key);
+    }
+  };
+
+  /**
    * Returns current selection as an array for template rendering.
    *
    * Normalizes both single and multiple selection modes to a consistent array interface:
@@ -807,6 +826,11 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   get filterFieldValue() {
     if (this.filterValue !== undefined) {
       return this.filterValue;
+    }
+    // With chips, the selection is already visible beside the input. Echoing
+    // the joined text here would fill the box and block typing.
+    if (this.showChips) {
+      return '';
     }
     return this.selectedTextValue;
   }
@@ -1042,6 +1066,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                   }}
                   value={{this.filterFieldValue}}
                   {{on "input" this.onFilterChange}}
+                  {{on "keydown" this.handleFilterKeydown}}
                   {{on "blur" this.handleBlur}}
                 />
               {{else}}

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -50,10 +50,27 @@ interface SelectedItem {
  * two can never drift apart; see {@link MultipleSelectArgs.chip} for the
  * Select-specific defaults applied on top of Chip's own.
  */
-interface SelectChipOptions extends Pick<
-  ChipSignature['Args'],
-  'appearance' | 'intent' | 'size' | 'radius' | 'withDot'
-> {}
+interface SelectChipOptions
+  extends Pick<ChipSignature['Args'], 'radius' | 'withDot'> {
+  /**
+   * The chip appearance.
+   *
+   * @defaultValue 'faded'
+   */
+  appearance?: ChipSignature['Args']['appearance'];
+
+  /**
+   * The intent of the chip. Defaults to the Select's own `@intent`.
+   */
+  intent?: ChipSignature['Args']['intent'];
+
+  /**
+   * The size of the chip.
+   *
+   * @defaultValue 'sm'
+   */
+  size?: ChipSignature['Args']['size'];
+}
 
 // Base interface for shared properties
 interface BaseSelectArgs<T>

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -35,6 +35,14 @@ const and = (a: unknown, b: unknown) => Boolean(a) && Boolean(b);
 const valueUnless = <T,>(condition: unknown, value: T): T | undefined =>
   condition ? undefined : value;
 
+/**
+ * A selected option reduced to what a chip needs to render.
+ */
+interface SelectedItem {
+  key: string;
+  textValue: string;
+}
+
 // Base interface for shared properties
 interface BaseSelectArgs<T>
   extends
@@ -419,6 +427,19 @@ interface SelectSignature<T> {
  */
 class Select<T = unknown> extends Component<SelectSignature<T>> {
   @tracked nodes: ListItem[] = [];
+
+  /**
+   * Every item that has registered so far, in item order.
+   *
+   * `nodes` only ever holds the items currently rendered, which is the
+   * *filtered* set. Chips have to reflect the selection rather than the filter,
+   * so a selected item's label has to survive that item being filtered out.
+   */
+  @tracked knownItems: SelectedItem[] = [];
+
+  /** Untracked backing store for `knownItems`. See `onItemsChange`. */
+  private itemOrder: string[] = [];
+  private textValues = new Map<string, string>();
   @tracked isOpen = false;
   /**
    * Internal tracked state for single selection mode.
@@ -634,8 +655,45 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   };
 
   onItemsChange = (nodes: ListItem[], _: 'add' | 'remove') => {
+    // `rememberItems` and the two fields it maintains are deliberately
+    // untracked. `onItemsChange` runs while a modifier installs, i.e. inside a
+    // render pass, and reading a tracked field there and then writing it in the
+    // same computation trips Glimmer's read-then-write assertion. Keeping the
+    // bookkeeping untracked makes `knownItems` and `nodes` write-only here.
+    this.rememberItems(nodes);
+    this.knownItems = this.itemOrder.map((key) => ({
+      key,
+      textValue: this.textValues.get(key) ?? key
+    }));
     this.nodes = nodes;
   };
+
+  /**
+   * Records the label and the position of every item that registers.
+   *
+   * A batch that still covers every key we already knew about is an unfiltered
+   * registration, and is therefore the authoritative item order. A batch that
+   * covers only some of them is a filter narrowing the list, so the order we
+   * already have is kept and only genuinely new keys are appended.
+   */
+  private rememberItems(nodes: ListItem[]): void {
+    const incomingKeys = new Set<string>();
+    for (const node of nodes) {
+      incomingKeys.add(node.key);
+      this.textValues.set(node.key, node.textValue);
+    }
+
+    if (this.itemOrder.every((key) => incomingKeys.has(key))) {
+      this.itemOrder = nodes.map((node) => node.key);
+      return;
+    }
+
+    for (const node of nodes) {
+      if (!this.itemOrder.includes(node.key)) {
+        this.itemOrder.push(node.key);
+      }
+    }
+  }
 
   didClose = () => {
     this.filterValue = undefined;
@@ -665,14 +723,28 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   }
 
   /**
+   * The accessible name for the trigger while chips are shown.
+   *
+   * In every other mode the trigger names itself from its own text -- the
+   * selected label, or the placeholder. In chips mode it renders nothing (the
+   * chips are its siblings, so they are read separately), which would leave the
+   * combobox announced as an unnamed button. This names the *control*, never the
+   * selection.
+   */
+  get triggerAccessibleName(): string {
+    return this.args.label || this.args.placeholder || 'Select options';
+  }
+
+  /**
    * The selected options in item order (not click order) so chips do not
    * reorder underneath the user as they select.
+   *
+   * Resolved against `knownItems` rather than `nodes`, so a chip stays put while
+   * a filter hides the item it came from.
    */
-  get selectedItems(): { key: string; textValue: string }[] {
+  get selectedItems(): SelectedItem[] {
     const keys = this.selectedKeys;
-    return this.nodes
-      .filter((node) => keys.includes(node.key))
-      .map((node) => ({ key: node.key, textValue: node.textValue }));
+    return this.knownItems.filter((item) => keys.includes(item.key));
   }
 
   get selectedTextValue(): string {
@@ -890,7 +962,11 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
               data-has-chips={{this.showChips}}
               data-invalid={{c.isInvalid}}
               data-disabled={{if @isDisabled "true" "false"}}
-              class={{this.classes.chipsField class=@classes.chipsField}}
+              class={{this.classes.chipsField
+                class=@classes.chipsField
+                hasStartContent=(has-block "startContent")
+                hasEndContent=true
+              }}
             >
               {{#if (and this.showChips this.hasSelection)}}
                 <div
@@ -919,6 +995,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                   data-test-id="trigger"
                   data-component="select-trigger"
                   disabled={{@isDisabled}}
+                  aria-label={{if this.showChips this.triggerAccessibleName}}
                   placeholder={{valueUnless this.hasSelection @placeholder}}
                   class={{this.classes.input
                     class=@classes.input
@@ -939,6 +1016,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                   data-test-id="trigger"
                   data-component="select-trigger"
                   disabled={{@isDisabled}}
+                  aria-label={{if this.showChips this.triggerAccessibleName}}
                   class={{this.classes.input
                     class=@classes.input
                     hasStartContent=(has-block "startContent")

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -490,20 +490,16 @@ interface SelectSignature<T> {
  * `@onSelectionChange`, or left uncontrolled.
  */
 class Select<T = unknown> extends Component<SelectSignature<T>> {
+  /**
+   * Every item registered by the hidden native `<select>`, in item order.
+   *
+   * The hidden select is deliberately given the *unfiltered* `@items` — it
+   * carries the form value, which must not shrink to the filter — so this
+   * covers the whole list even while the listbox is filtered down. Chips and
+   * the joined text value can therefore be resolved straight from it.
+   */
   @tracked nodes: ListItem[] = [];
 
-  /**
-   * Every item that has registered so far, in item order.
-   *
-   * `nodes` only ever holds the items currently rendered, which is the
-   * *filtered* set. Chips have to reflect the selection rather than the filter,
-   * so a selected item's label has to survive that item being filtered out.
-   */
-  @tracked knownItems: SelectedItem[] = [];
-
-  /** Untracked backing store for `knownItems`. See `onItemsChange`. */
-  private itemOrder: string[] = [];
-  private textValues = new Map<string, string>();
   @tracked isOpen = false;
   /**
    * Internal tracked state for single selection mode.
@@ -847,45 +843,12 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   };
 
   onItemsChange = (nodes: ListItem[], _: 'add' | 'remove') => {
-    // `rememberItems` and the two fields it maintains are deliberately
-    // untracked. `onItemsChange` runs while a modifier installs, i.e. inside a
-    // render pass, and reading a tracked field there and then writing it in the
-    // same computation trips Glimmer's read-then-write assertion. Keeping the
-    // bookkeeping untracked makes `knownItems` and `nodes` write-only here.
-    this.rememberItems(nodes);
-    this.knownItems = this.itemOrder.map((key) => ({
-      key,
-      textValue: this.textValues.get(key) ?? key
-    }));
+    // `onItemsChange` runs while a modifier installs, i.e. inside a render
+    // pass. Reading a tracked field here and writing it in the same
+    // computation would trip Glimmer's read-then-write assertion, so `nodes`
+    // is only ever written, never read, in this callback.
     this.nodes = nodes;
   };
-
-  /**
-   * Records the label and the position of every item that registers.
-   *
-   * A batch that still covers every key we already knew about is an unfiltered
-   * registration, and is therefore the authoritative item order. A batch that
-   * covers only some of them is a filter narrowing the list, so the order we
-   * already have is kept and only genuinely new keys are appended.
-   */
-  private rememberItems(nodes: ListItem[]): void {
-    const incomingKeys = new Set<string>();
-    for (const node of nodes) {
-      incomingKeys.add(node.key);
-      this.textValues.set(node.key, node.textValue);
-    }
-
-    if (this.itemOrder.every((key) => incomingKeys.has(key))) {
-      this.itemOrder = nodes.map((node) => node.key);
-      return;
-    }
-
-    for (const node of nodes) {
-      if (!this.itemOrder.includes(node.key)) {
-        this.itemOrder.push(node.key);
-      }
-    }
-  }
 
   didClose = () => {
     this.filterValue = undefined;
@@ -931,12 +894,15 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
    * The selected options in item order (not click order) so chips do not
    * reorder underneath the user as they select.
    *
-   * Resolved against `knownItems` rather than `nodes`, so a chip stays put while
-   * a filter hides the item it came from.
+   * Resolved against `nodes`, which the hidden native `<select>` populates from
+   * the unfiltered `@items`, so a chip stays put while a filter hides the item
+   * it came from.
    */
   get selectedItems(): SelectedItem[] {
     const keys = this.selectedKeys;
-    return this.knownItems.filter((item) => keys.includes(item.key));
+    return this.nodes
+      .filter((node) => keys.includes(node.key))
+      .map((node) => ({ key: node.key, textValue: node.textValue }));
   }
 
   get selectedTextValue(): string {
@@ -1076,7 +1042,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
           <VisuallyHidden>
             {{#if (eq @selectionMode "multiple")}}
               <NativeSelect
-                @items={{this.filteredItems}}
+                @items={{@items}}
                 @allowEmpty={{@allowEmpty}}
                 @disabledKeys={{@disabledKeys}}
                 @onSelectionChange={{this.onSelectionChange}}
@@ -1107,7 +1073,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
               </NativeSelect>
             {{else}}
               <NativeSelect
-                @items={{this.filteredItems}}
+                @items={{@items}}
                 @allowEmpty={{@allowEmpty}}
                 @disabledKeys={{@disabledKeys}}
                 @onSelectionChange={{this.onSingleSelectionChange}}

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -1178,7 +1178,10 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                   data-component="select-trigger"
                   disabled={{@isDisabled}}
                   aria-label={{if this.showChips this.triggerAccessibleName}}
-                  placeholder={{valueUnless this.hasSelection @placeholder}}
+                  placeholder={{valueUnless
+                    (and this.showChips this.hasSelection)
+                    @placeholder
+                  }}
                   class={{this.classes.input
                     class=@classes.input
                     hasStartContent=(has-block "startContent")

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -72,8 +72,14 @@ interface SelectChipOptions {
    */
   size?: 'sm' | 'md' | 'lg';
 
+  /**
+   * The corner radius of the chip.
+   */
   radius?: 'none' | 'sm' | 'lg' | 'full';
 
+  /**
+   * Whether the chip renders a leading dot before its label.
+   */
   withDot?: boolean;
 }
 
@@ -732,11 +738,6 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   };
 
   /**
-   * Whether chips may be removed. Mirrors the listbox: with `@allowEmpty`
-   * false — the default — the final selection cannot be deselected, so its
-   * chip renders without a close button rather than with a dead one.
-   */
-  /**
    * Resolved chip appearance: `@chip` wins, then the Select's own `@intent`,
    * then chip defaults tuned for sitting inside a field.
    */
@@ -758,6 +759,11 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
     };
   }
 
+  /**
+   * Whether chips may be removed. Mirrors the listbox: with `@allowEmpty`
+   * false — the default — the final selection cannot be deselected, so its
+   * chip renders without a close button rather than with a dead one.
+   */
   get chipsRemovable(): boolean {
     // Counts `selectedItems` — the same collection the chips render from —
     // rather than `selectedKeys`, so this decision can never disagree with

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -695,7 +695,8 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   get classes() {
     const { select } = useStyles();
     return select({
-      size: this.args.inputSize
+      size: this.args.inputSize,
+      hasChips: this.showChips
     });
   }
 
@@ -889,11 +890,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
               data-has-chips={{this.showChips}}
               data-invalid={{c.isInvalid}}
               data-disabled={{if @isDisabled "true" "false"}}
-              class={{if
-                this.showChips
-                (this.classes.chipsField class=@classes.chipsField)
-                "contents"
-              }}
+              class={{this.classes.chipsField class=@classes.chipsField}}
             >
               {{#if (and this.showChips this.hasSelection)}}
                 <div

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -743,10 +743,17 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   /**
    * In chips mode the trigger is only as wide as the room left over beside the
    * chips, so the field's padding -- and the strip under the chevron -- are not
-   * part of it. Without this, clicking those areas would do nothing, while the
-   * same click anywhere on a non-chips field opens the dropdown (there the
-   * trigger *is* the whole field). Forwards such a click to the trigger, leaving
-   * clicks on a chip (its close button) and on the trigger itself alone.
+   * part of it, and with a single selection the trigger can be a narrow sliver.
+   * Without this, clicking anywhere else in the field would do nothing, while
+   * the same click anywhere on a non-chips field opens the dropdown (there the
+   * trigger *is* the whole field). Forwards such a click to the trigger,
+   * including clicks on a chip's own body, so the whole field is a click
+   * target. The one exception is a chip's close button: within the chips
+   * container the only `<button>` elements a chip ever renders are its close
+   * button (see chip.gts / close-button.gts), so `closest('button')` combined
+   * with containment against `chipsContainerRef` identifies it without relying
+   * on any test-only attribute. Clicks on the trigger itself are left alone
+   * too, since it already handles its own clicks.
    */
   handleFieldClick = (event: MouseEvent): void => {
     if (!this.showChips || this.args.isDisabled) {
@@ -768,7 +775,10 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
     const chipsContainer = this.chipsContainerRef.current;
 
     if (chipsContainer && chipsContainer.contains(target)) {
-      return;
+      const closeButton = target.closest('button');
+      if (closeButton && chipsContainer.contains(closeButton)) {
+        return;
+      }
     }
 
     trigger.focus();

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -22,7 +22,7 @@ import {
 import { FormControl, type FormControlSharedArgs } from './form-control';
 import { triggerFormInputEvent } from '../../utils/forms-utils-index';
 import { CloseButton } from '../buttons/close-button';
-import { Chip } from '../buttons/chip';
+import { Chip, type ChipSignature } from '../buttons/chip';
 import { IconChevronUpDown } from './icons';
 import { keyAndLabelForItem, defaultFilter } from '../../utils/listManager';
 import { action } from '@ember/object';
@@ -46,42 +46,14 @@ interface SelectedItem {
 
 /**
  * Appearance options forwarded to the {@link Chip} rendered for each selected
- * option in multiple selection mode.
+ * option in multiple selection mode. Derived from {@link ChipSignature} so the
+ * two can never drift apart; see {@link MultipleSelectArgs.chip} for the
+ * Select-specific defaults applied on top of Chip's own.
  */
-interface SelectChipOptions {
-  /**
-   * @defaultValue 'faded'
-   */
-  appearance?: 'default' | 'outlined' | 'faded';
-
-  /**
-   * Defaults to the Select's own `@intent`, so `@intent="primary"` colors the
-   * listbox items and the chips together.
-   */
-  intent?:
-    | 'default'
-    | 'primary'
-    | 'secondary'
-    | 'tertiary'
-    | 'success'
-    | 'warning'
-    | 'danger';
-
-  /**
-   * @defaultValue 'sm'
-   */
-  size?: 'sm' | 'md' | 'lg';
-
-  /**
-   * The corner radius of the chip.
-   */
-  radius?: 'none' | 'sm' | 'lg' | 'full';
-
-  /**
-   * Whether the chip renders a leading dot before its label.
-   */
-  withDot?: boolean;
-}
+interface SelectChipOptions extends Pick<
+  ChipSignature['Args'],
+  'appearance' | 'intent' | 'size' | 'radius' | 'withDot'
+> {}
 
 // Base interface for shared properties
 interface BaseSelectArgs<T>
@@ -228,6 +200,15 @@ interface MultipleSelectArgs<T> extends BaseSelectArgs<T> {
   /**
    * Appearance of the chips rendered for each selected option.
    * Only applies when `@selectedItemsDisplay` is `'chips'` (the default).
+   *
+   * Options are the same ones {@link Chip} itself accepts (`appearance`,
+   * `intent`, `size`, `radius`, `withDot`), but Select applies its own
+   * defaults tuned for sitting inside a field, rather than Chip's:
+   * - `appearance` defaults to `'faded'`
+   * - `intent` defaults to the Select's own `@intent`, so `@intent="primary"`
+   *   colors the listbox items and the chips together
+   * - `size` defaults to `'sm'`
+   * - `radius` and `withDot` fall back to Chip's own defaults
    *
    * @example
    * ```gts

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -44,6 +44,39 @@ interface SelectedItem {
   textValue: string;
 }
 
+/**
+ * Appearance options forwarded to the {@link Chip} rendered for each selected
+ * option in multiple selection mode.
+ */
+interface SelectChipOptions {
+  /**
+   * @defaultValue 'faded'
+   */
+  appearance?: 'default' | 'outlined' | 'faded';
+
+  /**
+   * Defaults to the Select's own `@intent`, so `@intent="primary"` colors the
+   * listbox items and the chips together.
+   */
+  intent?:
+    | 'default'
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'success'
+    | 'warning'
+    | 'danger';
+
+  /**
+   * @defaultValue 'sm'
+   */
+  size?: 'sm' | 'md' | 'lg';
+
+  radius?: 'none' | 'sm' | 'lg' | 'full';
+
+  withDot?: boolean;
+}
+
 // Base interface for shared properties
 interface BaseSelectArgs<T>
   extends
@@ -141,6 +174,11 @@ interface ExplicitSingleSelectArgs<T> extends BaseSingleSelectArgs<T> {
    * Not applicable in single selection mode.
    */
   selectedItemsDisplay?: never;
+
+  /**
+   * Not applicable in single selection mode.
+   */
+  chip?: never;
 }
 
 // Single selection mode interface (when selectionMode is omitted - default behavior)
@@ -156,6 +194,11 @@ interface DefaultSingleSelectArgs<T> extends BaseSingleSelectArgs<T> {
    * Not applicable in single selection mode.
    */
   selectedItemsDisplay?: never;
+
+  /**
+   * Not applicable in single selection mode.
+   */
+  chip?: never;
 }
 
 // Multiple selection mode interface
@@ -175,6 +218,20 @@ interface MultipleSelectArgs<T> extends BaseSelectArgs<T> {
    * @defaultValue 'chips'
    */
   selectedItemsDisplay?: 'chips' | 'text';
+
+  /**
+   * Appearance of the chips rendered for each selected option.
+   * Only applies when `@selectedItemsDisplay` is `'chips'` (the default).
+   *
+   * @example
+   * ```gts
+   * <Select
+   *   @selectionMode="multiple"
+   *   @chip={{hash appearance="outlined" size="md" radius="full"}}
+   * />
+   * ```
+   */
+  chip?: SelectChipOptions;
 
   /**
    * @deprecated Use selectedKeys for multiple selection mode
@@ -679,6 +736,28 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
    * false — the default — the final selection cannot be deselected, so its
    * chip renders without a close button rather than with a dead one.
    */
+  /**
+   * Resolved chip appearance: `@chip` wins, then the Select's own `@intent`,
+   * then chip defaults tuned for sitting inside a field.
+   */
+  get chipOptions(): {
+    appearance: NonNullable<SelectChipOptions['appearance']>;
+    intent: NonNullable<SelectChipOptions['intent']>;
+    size: NonNullable<SelectChipOptions['size']>;
+    radius: SelectChipOptions['radius'];
+    withDot: boolean;
+  } {
+    const chip =
+      this.args.selectionMode === 'multiple' ? this.args.chip : undefined;
+    return {
+      appearance: chip?.appearance ?? 'faded',
+      intent: chip?.intent ?? this.args.intent ?? 'default',
+      size: chip?.size ?? 'sm',
+      radius: chip?.radius,
+      withDot: chip?.withDot ?? false
+    };
+  }
+
   get chipsRemovable(): boolean {
     // Counts `selectedItems` — the same collection the chips render from —
     // rather than `selectedKeys`, so this decision can never disagree with
@@ -1036,6 +1115,11 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                       data-test-id="selected-chip"
                       data-key={{item.key}}
                       @class={{this.classes.chip class=@classes.chip}}
+                      @appearance={{this.chipOptions.appearance}}
+                      @intent={{this.chipOptions.intent}}
+                      @size={{this.chipOptions.size}}
+                      @radius={{this.chipOptions.radius}}
+                      @withDot={{this.chipOptions.withDot}}
                       @isDisabled={{@isDisabled}}
                       @closeButtonTitle={{concat "Remove " item.textValue}}
                       @onClose={{if
@@ -1207,5 +1291,5 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
 
 const isSm = (size: SelectVariants['size']) => size === 'sm';
 
-export { Select, type SelectSignature };
+export { Select, type SelectSignature, type SelectChipOptions };
 export default Select;

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -649,12 +649,41 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
     if (target.value !== '') {
       return;
     }
+    this.removeLastSelectedKey();
+  };
+
+  /**
+   * The non-filterable counterpart of {@link handleFilterKeydown}.
+   *
+   * Chip close buttons are deliberately outside the tab order (they would
+   * otherwise cost a Tab stop each before the combobox is reached), so
+   * Backspace/Delete on the trigger is the *only* keyboard route to removing a
+   * chip here. There is no text to edit on a button trigger, so both keys act
+   * immediately; `preventDefault` keeps Backspace from navigating back.
+   */
+  handleTriggerKeydown = (event: KeyboardEvent) => {
+    if (!this.showChips || this.args.isDisabled) {
+      return;
+    }
+    if (event.key !== 'Backspace' && event.key !== 'Delete') {
+      return;
+    }
+    event.preventDefault();
+    this.removeLastSelectedKey();
+  };
+
+  /**
+   * Removes the trailing chip. `removeSelectedKey` applies the same
+   * `@allowEmpty` rule the chip close buttons follow, so the last required
+   * selection stays put.
+   */
+  removeLastSelectedKey(): void {
     const items = this.selectedItems;
     const last = items[items.length - 1];
     if (last) {
       this.removeSelectedKey(last.key);
     }
-  };
+  }
 
   /**
    * Returns current selection as an array for template rendering.
@@ -1163,6 +1192,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                       @withDot={{this.chipOptions.withDot}}
                       @isDisabled={{@isDisabled}}
                       @closeButtonTitle={{concat "Remove " item.textValue}}
+                      @closeButtonTabIndex="-1"
                       @onClose={{if
                         this.chipsRemovable
                         (fn this.removeSelectedKey item.key)
@@ -1209,6 +1239,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                     hasEndContent=true
                     hasChips=this.showChips
                   }}
+                  {{on "keydown" this.handleTriggerKeydown}}
                   {{on "blur" this.handleBlur}}
                 >
                   {{#if this.hasSelection}}

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -50,8 +50,10 @@ interface SelectedItem {
  * two can never drift apart; see {@link MultipleSelectArgs.chip} for the
  * Select-specific defaults applied on top of Chip's own.
  */
-interface SelectChipOptions
-  extends Pick<ChipSignature['Args'], 'radius' | 'withDot'> {
+interface SelectChipOptions extends Pick<
+  ChipSignature['Args'],
+  'radius' | 'withDot'
+> {
   /**
    * The chip appearance.
    *

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
+import { concat, fn } from '@ember/helper';
 import type Owner from '@ember/owner';
 import { NativeSelect, type ListItem } from './native-select';
 import { Listbox, type ListboxSignature } from '../collections/listbox';
@@ -654,6 +655,27 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
     this.onSelectionChange([]);
   };
 
+  /**
+   * Whether chips may be removed. Mirrors the listbox: with `@allowEmpty`
+   * false — the default — the final selection cannot be deselected, so its
+   * chip renders without a close button rather than with a dead one.
+   */
+  get chipsRemovable(): boolean {
+    return this.args.allowEmpty === true || this.selectedKeys.length > 1;
+  }
+
+  /**
+   * Removes a single selection from a chip's close button. Routes through
+   * `onSelectionChange`, which already syncs internal state, notifies the
+   * parent and dispatches the form input event.
+   */
+  removeSelectedKey = (key: string) => {
+    if (this.args.isDisabled || !this.chipsRemovable) {
+      return;
+    }
+    this.onSelectionChange(this.selectedKeys.filter((k) => k !== key));
+  };
+
   onItemsChange = (nodes: ListItem[], _: 'add' | 'remove') => {
     // `rememberItems` and the two fields it maintains are deliberately
     // untracked. `onItemsChange` runs while a modifier installs, i.e. inside a
@@ -986,6 +1008,12 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                       data-test-id="selected-chip"
                       data-key={{item.key}}
                       @class={{this.classes.chip class=@classes.chip}}
+                      @isDisabled={{@isDisabled}}
+                      @closeButtonTitle={{concat "Remove " item.textValue}}
+                      @onClose={{if
+                        this.chipsRemovable
+                        (fn this.removeSelectedKey item.key)
+                      }}
                     >
                       {{item.textValue}}
                     </Chip>

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -21,6 +21,7 @@ import {
 import { FormControl, type FormControlSharedArgs } from './form-control';
 import { triggerFormInputEvent } from '../../utils/forms-utils-index';
 import { CloseButton } from '../buttons/close-button';
+import { Chip } from '../buttons/chip';
 import { IconChevronUpDown } from './icons';
 import { keyAndLabelForItem, defaultFilter } from '../../utils/listManager';
 import { action } from '@ember/object';
@@ -30,6 +31,9 @@ import { modifier } from 'ember-modifier';
 
 // Import helper function directly instead of using ember-truth-helpers
 const eq = (a: unknown, b: unknown) => a === b;
+const and = (a: unknown, b: unknown) => Boolean(a) && Boolean(b);
+const valueUnless = <T,>(condition: unknown, value: T): T | undefined =>
+  condition ? undefined : value;
 
 // Base interface for shared properties
 interface BaseSelectArgs<T>
@@ -123,6 +127,11 @@ interface ExplicitSingleSelectArgs<T> extends BaseSingleSelectArgs<T> {
    * - 'single': Only one item can be selected at a time.
    */
   selectionMode: 'single';
+
+  /**
+   * Not applicable in single selection mode.
+   */
+  selectedItemsDisplay?: never;
 }
 
 // Single selection mode interface (when selectionMode is omitted - default behavior)
@@ -133,6 +142,11 @@ interface DefaultSingleSelectArgs<T> extends BaseSingleSelectArgs<T> {
    * @defaultValue 'single'
    */
   selectionMode?: undefined;
+
+  /**
+   * Not applicable in single selection mode.
+   */
+  selectedItemsDisplay?: never;
 }
 
 // Multiple selection mode interface
@@ -142,6 +156,16 @@ interface MultipleSelectArgs<T> extends BaseSelectArgs<T> {
    * - 'multiple': Allows multiple selections.
    */
   selectionMode: 'multiple';
+
+  /**
+   * How the selected options are presented in the trigger.
+   *
+   * - `'chips'`: each selection renders as a removable {@link Chip}.
+   * - `'text'`: the selections render as a comma-joined string.
+   *
+   * @defaultValue 'chips'
+   */
+  selectedItemsDisplay?: 'chips' | 'text';
 
   /**
    * @deprecated Use selectedKeys for multiple selection mode
@@ -624,6 +648,33 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
     return this.selectedKeys?.join(', ');
   }
 
+  /**
+   * Whether selections render as chips. Chips are the default presentation for
+   * multiple selection mode; `@selectedItemsDisplay="text"` opts back out to the
+   * comma-joined string.
+   */
+  get showChips(): boolean {
+    return (
+      this.args.selectionMode === 'multiple' &&
+      this.args.selectedItemsDisplay !== 'text'
+    );
+  }
+
+  get hasSelection(): boolean {
+    return this.selectedKeys.length > 0;
+  }
+
+  /**
+   * The selected options in item order (not click order) so chips do not
+   * reorder underneath the user as they select.
+   */
+  get selectedItems(): { key: string; textValue: string }[] {
+    const keys = this.selectedKeys;
+    return this.nodes
+      .filter((node) => keys.includes(node.key))
+      .map((node) => ({ key: node.key, textValue: node.textValue }));
+  }
+
   get selectedTextValue(): string {
     let selectedTextValues: string[] = [];
     for (let node of this.nodes) {
@@ -833,56 +884,90 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                 {{yield to="startContent"}}
               </div>
             {{/if}}
-            {{#if @isFilterable}}
-              <input
-                type="text"
-                {{p.trigger}}
-                {{p.anchor}}
-                {{this.triggerRef.setup}}
-                data-test-id="trigger"
-                data-component="select-trigger"
-                disabled={{@isDisabled}}
-                placeholder={{@placeholder}}
-                class={{this.classes.input
-                  class=@classes.input
-                  hasStartContent=(has-block "startContent")
-                  hasEndContent=true
-                }}
-                value={{this.filterFieldValue}}
-                {{on "input" this.onFilterChange}}
-                {{on "blur" this.handleBlur}}
-              />
-            {{else}}
-              <button
-                type="button"
-                {{p.trigger}}
-                {{p.anchor}}
-                {{this.triggerRef.setup}}
-                data-test-id="trigger"
-                data-component="select-trigger"
-                disabled={{@isDisabled}}
-                class={{this.classes.input
-                  class=@classes.input
-                  hasStartContent=(has-block "startContent")
-                  hasEndContent=true
-                }}
-                {{on "blur" this.handleBlur}}
-              >
-                {{#if this.selectedText}}
-                  <span>
-                    {{this.selectedTextValue}}
-                  </span>
-                {{else}}
-                  <span
-                    class={{this.classes.placeholder
-                      class=@classes.placeholder
-                    }}
-                  >
-                    {{#if @placeholder}}{{@placeholder}}{{else}}&nbsp;{{/if}}
-                  </span>
-                {{/if}}
-              </button>
-            {{/if}}
+            <div
+              data-test-id={{if this.showChips "chips-field"}}
+              data-has-chips={{this.showChips}}
+              data-invalid={{c.isInvalid}}
+              data-disabled={{if @isDisabled "true" "false"}}
+              class={{if
+                this.showChips
+                (this.classes.chipsField class=@classes.chipsField)
+                "contents"
+              }}
+            >
+              {{#if (and this.showChips this.hasSelection)}}
+                <div
+                  data-test-id="selected-chips"
+                  class={{this.classes.chipsContainer
+                    class=@classes.chipsContainer
+                  }}
+                >
+                  {{#each this.selectedItems key="key" as |item|}}
+                    <Chip
+                      data-test-id="selected-chip"
+                      data-key={{item.key}}
+                      @class={{this.classes.chip class=@classes.chip}}
+                    >
+                      {{item.textValue}}
+                    </Chip>
+                  {{/each}}
+                </div>
+              {{/if}}
+              {{#if @isFilterable}}
+                <input
+                  type="text"
+                  {{p.trigger}}
+                  {{p.anchor}}
+                  {{this.triggerRef.setup}}
+                  data-test-id="trigger"
+                  data-component="select-trigger"
+                  disabled={{@isDisabled}}
+                  placeholder={{valueUnless this.hasSelection @placeholder}}
+                  class={{this.classes.input
+                    class=@classes.input
+                    hasStartContent=(has-block "startContent")
+                    hasEndContent=true
+                    hasChips=this.showChips
+                  }}
+                  value={{this.filterFieldValue}}
+                  {{on "input" this.onFilterChange}}
+                  {{on "blur" this.handleBlur}}
+                />
+              {{else}}
+                <button
+                  type="button"
+                  {{p.trigger}}
+                  {{p.anchor}}
+                  {{this.triggerRef.setup}}
+                  data-test-id="trigger"
+                  data-component="select-trigger"
+                  disabled={{@isDisabled}}
+                  class={{this.classes.input
+                    class=@classes.input
+                    hasStartContent=(has-block "startContent")
+                    hasEndContent=true
+                    hasChips=this.showChips
+                  }}
+                  {{on "blur" this.handleBlur}}
+                >
+                  {{#if this.hasSelection}}
+                    {{#unless this.showChips}}
+                      <span>
+                        {{this.selectedTextValue}}
+                      </span>
+                    {{/unless}}
+                  {{else}}
+                    <span
+                      class={{this.classes.placeholder
+                        class=@classes.placeholder
+                      }}
+                    >
+                      {{#if @placeholder}}{{@placeholder}}{{else}}&nbsp;{{/if}}
+                    </span>
+                  {{/if}}
+                </button>
+              {{/if}}
+            </div>
             <div
               data-test-id="input-end-content"
               class={{this.classes.endContent

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -733,6 +733,39 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
     }, 150);
   }
 
+  /**
+   * In chips mode the trigger is only as wide as the room left over beside the
+   * chips, so the field's padding -- and the strip under the chevron -- are not
+   * part of it. Without this, clicking those areas would do nothing, while the
+   * same click anywhere on a non-chips field opens the dropdown (there the
+   * trigger *is* the whole field). Forwards such a click to the trigger, leaving
+   * clicks on a chip (its close button) and on the trigger itself alone.
+   */
+  handleFieldClick = (event: MouseEvent): void => {
+    if (!this.showChips || this.args.isDisabled) {
+      return;
+    }
+
+    const trigger = this.triggerRef.current;
+    const target = event.target;
+
+    if (!trigger || !(target instanceof Element)) {
+      return;
+    }
+
+    // The trigger handles its own clicks; this listener also sees them bubble.
+    if (trigger === target || trigger.contains(target)) {
+      return;
+    }
+
+    if (target.closest('[data-test-id="selected-chip"]')) {
+      return;
+    }
+
+    trigger.focus();
+    trigger.click();
+  };
+
   clearSelectedKeys = () => {
     this.onSelectionChange([]);
   };
@@ -898,7 +931,8 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
     const { select } = useStyles();
     return select({
       size: this.args.inputSize,
-      hasChips: this.showChips
+      hasChips: this.showChips,
+      isFilterable: !!this.args.isFilterable
     });
   }
 
@@ -1099,6 +1133,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
             <div
               {{p.anchor}}
               {{p.measureWidth}}
+              {{on "click" this.handleFieldClick}}
               data-test-id={{if this.showChips "chips-field"}}
               data-has-chips={{this.showChips}}
               data-invalid={{c.isInvalid}}

--- a/packages/frontile/src/components/forms/select.gts
+++ b/packages/frontile/src/components/forms/select.gts
@@ -567,6 +567,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
 
   containerRef = ref<HTMLDivElement>();
   triggerRef = ref<HTMLInputElement | HTMLButtonElement>();
+  chipsContainerRef = ref<HTMLDivElement>();
 
   /**
    * Handles selection changes from the Listbox component.
@@ -783,7 +784,9 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
       return;
     }
 
-    if (target.closest('[data-test-id="selected-chip"]')) {
+    const chipsContainer = this.chipsContainerRef.current;
+
+    if (chipsContainer && chipsContainer.contains(target)) {
       return;
     }
 
@@ -1141,6 +1144,7 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
             >
               {{#if (and this.showChips this.hasSelection)}}
                 <div
+                  {{this.chipsContainerRef.setup}}
                   data-test-id="selected-chips"
                   class={{this.classes.chipsContainer
                     class=@classes.chipsContainer

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -6,7 +6,7 @@ imports:
 
 # Select
 
-The `Select` component is a powerful and flexible dropdown component. It supports both **single** and **multiple** selection modes, provides built‐in filtering capabilities, and renders a hidden native `<select>` element to ensure full accessibility. Under the hood, it leverages the [Listbox](https://frontile.dev/docs/collections/listbox) and [Popover](https://frontile.dev/docs/overlays/popover) components to power its interactive behavior.
+The `Select` component is a powerful and flexible dropdown component. It supports both **single** and **multiple** selection modes — multiple selections render as removable chips — provides built‐in filtering capabilities, and renders a hidden native `<select>` element to ensure full accessibility. Under the hood, it leverages the [Listbox](https://frontile.dev/docs/collections/listbox) and [Popover](https://frontile.dev/docs/overlays/popover) components to power its interactive behavior.
 
 ## Import
 
@@ -97,6 +97,8 @@ export default class DataBoundSingleSelect extends Component {
 ### Form Validation
 
 The Select component integrates seamlessly with form validation by automatically displaying error messages and updating ARIA attributes. This example demonstrates both single and multiple select validation using Valibot schemas with the Form component. The example uses `@validateOn` to trigger validation on both change and submit events, providing immediate feedback as users make selections.
+
+The multiple select here is shown in a validation context; see [Multiple Selection](#multiple-selection) for the full reference on chips, removal and the arguments that configure them.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -542,17 +544,305 @@ export default class NativeSelectExample extends Component {
 }
 ```
 
+## Multiple Selection
+
+Set `@selectionMode='multiple'` to let the user pick more than one option. The selection is
+an array: pass it as `@selectedKeys`, and `@onSelectionChange` hands you the new array back.
+
+Every selection renders as a removable [Chip](../buttons/chip) beside the trigger — that is the
+default, with no extra configuration. Use `@selectedItemsDisplay='text'` to opt back out to a
+comma-joined string.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Select } from 'frontile';
+
+const languages = [
+  { key: 'en', label: 'English' },
+  { key: 'pt', label: 'Portuguese' },
+  { key: 'es', label: 'Spanish' },
+  { key: 'de', label: 'German' },
+  { key: 'ja', label: 'Japanese' }
+];
+
+export default class BasicMultipleSelect extends Component {
+  @tracked selectedKeys: string[] = ['en', 'pt'];
+
+  onSelectionChange = (keys: string[]) => {
+    this.selectedKeys = keys;
+  };
+
+  <template>
+    <Select
+      @selectionMode='multiple'
+      @label='Languages'
+      @placeholder='Select languages'
+      @items={{languages}}
+      @selectedKeys={{this.selectedKeys}}
+      @onSelectionChange={{this.onSelectionChange}}
+    />
+    <p class='mt-4'>Selected: {{this.selectedKeys}}</p>
+  </template>
+}
+```
+
+Chips render in item order rather than click order, so they do not reorder underneath the
+user as the selection grows.
+
+### Removing Selections
+
+Each chip carries its own close button. `@allowEmpty` defaults to `false`, which means the
+last remaining selection cannot be removed — its chip renders with **no close button at all**
+rather than a dead one. Set `@allowEmpty={{true}}` to allow emptying the selection one chip
+at a time.
+
+`@isClearable` adds a clear button to the field that removes everything at once. It
+deliberately ignores `@allowEmpty`, so a clearable Select can always be emptied even though
+its last chip has no close button.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Select } from 'frontile';
+
+const toppings = ['Basil', 'Mushroom', 'Olive', 'Onion', 'Pepper'];
+
+export default class RemovableChipsSelect extends Component {
+  @tracked required: string[] = ['Basil', 'Olive'];
+  @tracked optional: string[] = ['Basil', 'Olive'];
+
+  onRequiredChange = (keys: string[]) => {
+    this.required = keys;
+  };
+
+  onOptionalChange = (keys: string[]) => {
+    this.optional = keys;
+  };
+
+  <template>
+    <div class='grid gap-4 md:grid-cols-2'>
+      <Select
+        @selectionMode='multiple'
+        @label='At least one topping'
+        @placeholder='Select toppings'
+        @items={{toppings}}
+        @selectedKeys={{this.required}}
+        @onSelectionChange={{this.onRequiredChange}}
+      />
+      <Select
+        @selectionMode='multiple'
+        @label='Any number of toppings'
+        @placeholder='Select toppings'
+        @items={{toppings}}
+        @selectedKeys={{this.optional}}
+        @onSelectionChange={{this.onOptionalChange}}
+        @allowEmpty={{true}}
+        @isClearable={{true}}
+      />
+    </div>
+  </template>
+}
+```
+
+### Customizing the Chips
+
+`@chip` forwards appearance options to every chip: `appearance` (defaults to `faded`),
+`intent`, `size` (defaults to `sm`), `radius` and `withDot`.
+
+`@chip.intent` defaults to the Select's own `@intent`, so `@intent='primary'` colors the
+listbox options and the chips together and you only set `@chip.intent` when you want them to
+differ.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { hash } from '@ember/helper';
+import { Select } from 'frontile';
+
+const tags = ['Accessibility', 'Design', 'Performance', 'Testing'];
+
+export default class ChipOptionsSelect extends Component {
+  @tracked inherited: string[] = ['Design', 'Testing'];
+  @tracked customized: string[] = ['Design', 'Testing'];
+
+  onInheritedChange = (keys: string[]) => {
+    this.inherited = keys;
+  };
+
+  onCustomizedChange = (keys: string[]) => {
+    this.customized = keys;
+  };
+
+  <template>
+    <div class='grid gap-4 md:grid-cols-2'>
+      <Select
+        @selectionMode='multiple'
+        @intent='primary'
+        @label='Inherits @intent'
+        @placeholder='Select tags'
+        @items={{tags}}
+        @selectedKeys={{this.inherited}}
+        @onSelectionChange={{this.onInheritedChange}}
+      />
+      <Select
+        @selectionMode='multiple'
+        @label='Custom @chip'
+        @placeholder='Select tags'
+        @items={{tags}}
+        @selectedKeys={{this.customized}}
+        @onSelectionChange={{this.onCustomizedChange}}
+        @chip={{hash
+          appearance='outlined'
+          intent='success'
+          size='md'
+          radius='full'
+          withDot=true
+        }}
+      />
+    </div>
+  </template>
+}
+```
+
+### Text Display
+
+`@selectedItemsDisplay='text'` renders the selection as a comma-joined string inside the
+trigger instead of as chips. This was the only presentation before `0.18`, and it is worth
+keeping for a dense field where a growing stack of chips would push the layout around.
+Nothing is individually removable in this mode — use `@isClearable` or reopen the dropdown.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Select } from 'frontile';
+
+const permissions = ['Read', 'Write', 'Deploy', 'Administer'];
+
+export default class TextDisplayMultipleSelect extends Component {
+  @tracked selectedKeys: string[] = ['Read', 'Write'];
+
+  onSelectionChange = (keys: string[]) => {
+    this.selectedKeys = keys;
+  };
+
+  <template>
+    <Select
+      @selectionMode='multiple'
+      @selectedItemsDisplay='text'
+      @label='Permissions'
+      @placeholder='Select permissions'
+      @items={{permissions}}
+      @selectedKeys={{this.selectedKeys}}
+      @onSelectionChange={{this.onSelectionChange}}
+    />
+  </template>
+}
+```
+
+### Filterable Multiple Selection
+
+`@isFilterable={{true}}` turns the trigger into a text input that sits alongside the chips,
+the familiar tag-input shape. The filter never echoes the selection, so there is always room
+to type, and the chips reflect the selection rather than the filter — a chip stays put even
+when its option is filtered out of the list.
+
+Pressing `Backspace` while the filter is empty removes the last chip. With text in the
+filter, `Backspace` edits the text as usual, and the final chip is still protected by
+`@allowEmpty`.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Select } from 'frontile';
+
+const countries = [
+  'Argentina',
+  'Brazil',
+  'Canada',
+  'Denmark',
+  'Egypt',
+  'France',
+  'Germany',
+  'Italy',
+  'Japan',
+  'Mexico'
+];
+
+export default class FilterableMultipleSelect extends Component {
+  @tracked selectedKeys: string[] = ['Brazil', 'Japan'];
+
+  onSelectionChange = (keys: string[]) => {
+    this.selectedKeys = keys;
+  };
+
+  <template>
+    <Select
+      @selectionMode='multiple'
+      @isFilterable={{true}}
+      @allowEmpty={{true}}
+      @label='Countries'
+      @placeholder='Search countries'
+      @items={{countries}}
+      @selectedKeys={{this.selectedKeys}}
+      @onSelectionChange={{this.onSelectionChange}}
+    />
+  </template>
+}
+```
+
+### Styling the Chips Area
+
+Three `@classes` keys cover the chips: `chipsField` is the field shell that wraps the chips
+and the trigger together, `chipsContainer` is the flex row holding the chips, and `chip` is
+merged onto every individual chip.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { hash } from '@ember/helper';
+import { Select } from 'frontile';
+
+const teams = ['Design', 'Engineering', 'Marketing', 'Support'];
+
+export default class StyledChipsSelect extends Component {
+  @tracked selectedKeys: string[] = ['Design', 'Engineering'];
+
+  onSelectionChange = (keys: string[]) => {
+    this.selectedKeys = keys;
+  };
+
+  <template>
+    <Select
+      @selectionMode='multiple'
+      @label='Teams'
+      @placeholder='Select teams'
+      @items={{teams}}
+      @selectedKeys={{this.selectedKeys}}
+      @onSelectionChange={{this.onSelectionChange}}
+      @allowEmpty={{true}}
+      @classes={{hash
+        chipsField='border-primary-soft'
+        chipsContainer='gap-2'
+        chip='bg-primary-subtle text-primary-strong'
+      }}
+    />
+  </template>
+}
+```
+
 ## Accessibility
 
 Select is a custom listbox, not a native `<select>`, so its semantics are assembled from
 several pieces:
 
-| Element    | What it exposes                                                                                                                               |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Trigger    | `aria-haspopup="true"`, `aria-controls` pointing at the dropdown, and `aria-expanded` kept in sync — supplied by Popover's `trigger` modifier |
-| Dropdown   | `role="listbox"`, plus `aria-multiselectable="true"` when `@selectionMode="multiple"`                                                         |
-| Options    | `role="option"` with `aria-labelledby`, `aria-selected` reflecting selection, and `aria-disabled="true"` on disabled keys                     |
-| Form value | A visually hidden native `<select>` mirrors the options, so `@name` submits normally                                                          |
+| Element    | What it exposes                                                                                                                                                                                                                    |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trigger    | `aria-haspopup="true"`, `aria-controls` pointing at the dropdown, and `aria-expanded` kept in sync — supplied by Popover's `trigger` modifier                                                                                      |
+| Dropdown   | `role="listbox"`, plus `aria-multiselectable="true"` when `@selectionMode="multiple"`                                                                                                                                              |
+| Options    | `role="option"` with `aria-labelledby`, `aria-selected` reflecting selection, and `aria-disabled="true"` on disabled keys                                                                                                          |
+| Form value | A visually hidden native `<select>` mirrors the options, so `@name` submits normally                                                                                                                                               |
+| Chips      | Each chip's close button is named `Remove <label>` with visually hidden text, so the buttons are announced distinctly. The chips sit beside the trigger rather than inside it, so no interactive element is nested in the combobox |
 
 Keyboard handling comes from the listbox:
 
@@ -562,6 +852,8 @@ Keyboard handling comes from the listbox:
 | `Home` / `PageUp`, `End` / `PageDown` | Jump to first / last option |
 | `Enter`, `Space`                      | Select the active option    |
 | `Escape`                              | Closes the dropdown         |
+
+With `@isFilterable` and chips, `Backspace` on an empty filter removes the last chip.
 
 ## API
 

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -590,6 +590,10 @@ export default class BasicMultipleSelect extends Component {
 Chips render in item order rather than click order, so they do not reorder underneath the
 user as the selection grows.
 
+Clicking anywhere in the field opens the dropdown, including a chip's own body — with a
+single selection the trigger next to the chips can be a narrow sliver, so the whole field is a
+click target. The one exception is a chip's close button, which removes that chip instead.
+
 ### Removing Selections
 
 Each chip carries its own close button. `@allowEmpty` defaults to `false`, which means the

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -842,7 +842,7 @@ several pieces:
 | Dropdown   | `role="listbox"`, plus `aria-multiselectable="true"` when `@selectionMode="multiple"`                                                                                                                                              |
 | Options    | `role="option"` with `aria-labelledby`, `aria-selected` reflecting selection, and `aria-disabled="true"` on disabled keys                                                                                                          |
 | Form value | A visually hidden native `<select>` mirrors the options, so `@name` submits normally                                                                                                                                               |
-| Chips      | Each chip's close button is named `Remove <label>` with visually hidden text, so the buttons are announced distinctly. The chips sit beside the trigger rather than inside it, so no interactive element is nested in the combobox |
+| Chips      | Each chip's close button is named `Remove <label>` with visually hidden text, so the buttons are announced distinctly. The chips sit beside the trigger rather than inside it, so no interactive element is nested in the combobox. The close buttons carry `tabindex="-1"` — see the keyboard model below |
 
 Keyboard handling comes from the listbox:
 
@@ -853,7 +853,28 @@ Keyboard handling comes from the listbox:
 | `Enter`, `Space`                      | Select the active option    |
 | `Escape`                              | Closes the dropdown         |
 
-With `@isFilterable` and chips, `Backspace` on an empty filter removes the last chip.
+### The chips keyboard model
+
+Chip close buttons are **pointer affordances**: they are set to `tabindex="-1"` and are not
+tab stops. This is deliberate. A field holding five selections would otherwise put five Tab
+stops in front of the combobox, so a keyboard user Tabbing into the control would land on
+"Remove ..." rather than on the field itself.
+
+Keyboard removal is on the field instead, in **both** modes:
+
+| Context                                 | Key                    | Behavior                                       |
+| --------------------------------------- | ---------------------- | ---------------------------------------------- |
+| Chips, `@isFilterable={{true}}`         | `Backspace`            | Removes the last chip **when the filter is empty**; with text in the filter it edits the text as usual |
+| Chips, non-filterable (button trigger)  | `Backspace` or `Delete`| Removes the last chip                          |
+| Either                                  | `Enter` / `Space` on an option | Toggles that selection off from the dropdown |
+
+The `@allowEmpty` rule applies throughout: with the default `@allowEmpty={{false}}` the final
+selection cannot be removed, so its chip renders without a close button and `Backspace` leaves
+it alone.
+
+If you set `@chip` or restyle the chips, do not re-enable the close buttons as tab stops
+without also removing this keyboard path — a visual order that disagrees with focus order is
+its own WCAG 2.4.3 problem.
 
 ## API
 

--- a/packages/frontile/src/components/overlays/popover.gts
+++ b/packages/frontile/src/components/overlays/popover.gts
@@ -82,6 +82,12 @@ interface PopoverSignature {
     default: [
       {
         anchor: ModifierLike<{ Element: HTMLElement }>;
+
+        /**
+         * Nominates the element it is placed on as the width reference for
+         * `@size="trigger"` content, instead of the element carrying `trigger`.
+         */
+        measureWidth: ModifierLike<{ Element: HTMLElement }>;
         isOpen: boolean;
         toggle: () => void;
         open: () => void;
@@ -108,6 +114,14 @@ interface PopoverSignature {
 
 class Popover extends Component<PopoverSignature> {
   triggerEl?: HTMLElement;
+
+  /**
+   * The element `measureWidth` is watching, when a consumer opts into measuring
+   * something other than the trigger. Its presence is what gives `measureWidth`
+   * precedence over `trigger` as the source of `triggerWidth`.
+   */
+  widthEl?: HTMLElement;
+
   menuId = guidFor(this);
   @tracked _isOpen = false;
   @tracked isClosing = false;
@@ -167,14 +181,23 @@ class Popover extends Component<PopoverSignature> {
   trigger = modifier(
     (el: HTMLElement, [eventType]: [eventType?: 'click' | 'hover']) => {
       this.triggerEl = el as HTMLLIElement;
+      // The trigger is only the width reference when nothing more specific was
+      // nominated. `widthEl` is checked when the measurement happens rather than
+      // when the modifier installs, so the two modifiers can install in either
+      // order.
       requestAnimationFrame(() => {
-        this.triggerWidth = Math.round(el.offsetWidth);
+        if (!this.widthEl) {
+          this.triggerWidth = Math.round(el.offsetWidth);
+        }
       });
 
       let observer: ResizeObserver;
       if (eventType !== 'hover') {
         observer = new ResizeObserver((entries) => {
           for (let entry of entries) {
+            if (this.widthEl) {
+              continue;
+            }
             this.triggerWidth = Math.round(
               (entry.target as HTMLElement).offsetWidth
             );
@@ -246,6 +269,48 @@ class Popover extends Component<PopoverSignature> {
     }
   );
 
+  /**
+   * Nominates the element it is placed on as the popover's width reference,
+   * instead of the element carrying `trigger`.
+   *
+   * `@size="trigger"` content is sized from `--trigger-width`, which is normally
+   * the trigger's own width. That is only right while the toggle and the box the
+   * content should line up with are the same element. When they are not -- a
+   * field whose trigger is one of several things inside it, say -- put this on
+   * the element the content should match.
+   *
+   * It takes precedence over `trigger`'s own measurement for as long as it is
+   * installed, so the two never race.
+   */
+  measureWidth = modifier((el: HTMLElement) => {
+    this.widthEl = el;
+
+    requestAnimationFrame(() => {
+      if (this.widthEl === el) {
+        this.triggerWidth = Math.round(el.offsetWidth);
+      }
+    });
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (this.widthEl !== el) {
+          continue;
+        }
+        this.triggerWidth = Math.round(
+          (entry.target as HTMLElement).offsetWidth
+        );
+      }
+    });
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      if (this.widthEl === el) {
+        this.widthEl = undefined;
+      }
+    };
+  });
+
   updateAriaExtanded = modifier((_: HTMLElement) => {
     if (this.triggerEl) {
       this.triggerEl.setAttribute('aria-expanded', this.isOpen.toString());
@@ -271,6 +336,7 @@ class Popover extends Component<PopoverSignature> {
       {{yield
         (hash
           anchor=velcro.hook
+          measureWidth=this.measureWidth
           isOpen=this.isOpen
           open=this.open
           close=this.close

--- a/packages/frontile/src/components/overlays/popover.md
+++ b/packages/frontile/src/components/overlays/popover.md
@@ -227,6 +227,17 @@ const sizes = ['sm', 'md', 'lg', 'xl'];
 </template>
 ```
 
+### Matching a different element's width
+
+`@size='trigger'` sizes the content from `--trigger-width`, which is the width of
+whatever element carries the `trigger` modifier. That is what you want while the
+toggle and the box the content should line up with are the same element. When
+they are not — a field where the toggle is one of several things sitting inside
+it, and the content should match the whole field — put the `measureWidth`
+modifier on the element to match. It takes precedence over the `trigger`
+element's own width for as long as it is installed, so the two never race, and
+you do not need it at all in the usual case.
+
 ## Controlled
 
 You can use the `isOpen` and `onOpenChange` arguments to control whether the

--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -406,6 +406,29 @@ class ListManager {
     let selectedKeys: string[] = [];
 
     const items = this.#orderedItems;
+
+    // A selection is not the rendered list's to discard. Rebuilding purely
+    // from `#orderedItems` drops every selected key whose item is not on
+    // screen right now -- filtered out, most obviously -- so toggling one
+    // option in a filtered multi-select used to wipe the rest of the
+    // selection. Carry those keys over from the authoritative list instead.
+    //
+    // They go first so the rebuilt array keeps the shape it always had: when
+    // nothing is hidden this set is empty and the result is exactly the DOM
+    // -ordered scan below, unchanged.
+    //
+    // `multiple` only. Single mode replaces the selection outright, so it
+    // never lost anything here, and carrying a key over would change what
+    // counts as "the last selection" for the `allowEmpty` rule below.
+    if (this.args.selectionMode === 'multiple') {
+      const renderedKeys = new Set(items.map((_item) => _item.key));
+      for (const key of this.args.selectedKeys || []) {
+        if (!renderedKeys.has(key)) {
+          selectedKeys.push(key);
+        }
+      }
+    }
+
     for (let i = 0; i < items.length; i++) {
       const _item = items[i] as ListItem;
       if (_item.isSelected) {

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -61,6 +61,17 @@ const formFeedback = tv({
   }
 });
 
+// The visual shell of a form field: background, border, radius, and the
+// invalid/disabled treatments. Shared by the `input` slot and by `select`'s
+// `chipsField`, which becomes the shell when chips render beside the trigger.
+const fieldShell = [
+  'bg-surface-input',
+  'border',
+  'border-neutral-soft',
+  'rounded-xl',
+  'selection:bg-surface-overlay-soft'
+];
+
 const input = tv({
   slots: {
     base: '',
@@ -71,20 +82,16 @@ const input = tv({
       'appearance-none',
       'flex-1',
       'w-full',
-      'bg-surface-input',
+      ...fieldShell,
       'text-neutral-strong',
       'placeholder-neutral',
       // body role family; single-line controls keep tight leading (not the body relaxed leading)
       'font-body text-base text-left',
-      'border',
-      'border-neutral-soft',
-      'rounded-xl',
       'leading-tight',
       'focus:ring-3',
       'focus:ring-focus',
       'focus:outline-hidden',
       'focus:border-primary-soft',
-      'selection:bg-surface-overlay-soft',
       'disabled:border-neutral-subtle disabled:text-neutral-soft',
       'aria-invalid:border-danger-soft',
       'aria-invalid:focus:ring-danger-soft'
@@ -101,6 +108,22 @@ const input = tv({
     },
     hasEndContent: {
       true: { input: 'pe-10' }
+    },
+    // When chips render beside the trigger, `chipsField` owns the field shell
+    // and the trigger itself must be visually bare.
+    hasChips: {
+      true: {
+        input: [
+          'border-0',
+          'bg-transparent',
+          'p-0',
+          'w-auto',
+          'flex-1',
+          'min-w-16',
+          'focus:ring-0',
+          'focus:border-transparent'
+        ]
+      }
     },
     startContentPointerEvents: {
       auto: { startContent: 'pointer-events-auto' },
@@ -244,13 +267,34 @@ const select = tv({
     icon: 'w-5 h-5',
     clearButton: 'pointer-events-auto',
     input: '[button]:cursor-default',
-    emptyContent: 'p-2'
+    emptyContent: 'p-2',
+    // Field shell used in place of the trigger's own border when chips render.
+    // `data-invalid` / `data-disabled` are set by the component because
+    // `aria-invalid:` and `disabled:` only match the element carrying them.
+    chipsField: [
+      ...fieldShell,
+      'flex',
+      'flex-wrap',
+      'items-center',
+      'gap-1',
+      'w-full',
+      'cursor-default',
+      'focus-within:ring-3',
+      'focus-within:ring-focus',
+      'focus-within:border-primary-soft',
+      'data-[invalid=true]:border-danger-soft',
+      'data-[invalid=true]:focus-within:ring-danger-soft',
+      'data-[disabled=true]:border-neutral-subtle',
+      'data-[disabled=true]:text-neutral-soft'
+    ],
+    chipsContainer: 'flex flex-wrap items-center gap-1 min-w-0',
+    chip: ''
   },
   variants: {
     size: {
-      sm: {},
-      md: {},
-      lg: {}
+      sm: { chipsField: 'p-1 gap-1' },
+      md: { chipsField: 'p-1.5 gap-1' },
+      lg: { chipsField: 'p-2 gap-1.5' }
     }
   },
   defaultVariants: {

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -119,7 +119,16 @@ const input = tv({
           'p-0',
           'w-auto',
           'flex-1',
-          'min-w-16',
+          // Once chips show the selection the trigger renders nothing at all, so
+          // it has no content to give it a height -- it collapsed to a 0px box
+          // that could not be clicked. Stretching makes it as tall as the chips
+          // sitting next to it, which is the box a pointer needs to hit.
+          'self-stretch',
+          // No horizontal floor by default: a bare (non-filterable) trigger has
+          // no content of its own, so a floor would only push it onto a second
+          // flex line. `select` puts the floor back for the filterable trigger,
+          // which does need room to type.
+          'min-w-0',
           'focus:ring-0',
           'focus:border-transparent'
         ]
@@ -311,15 +320,41 @@ const select = tv({
         ]
       },
       false: { chipsField: 'flex w-full min-w-0' }
+    },
+    // Whether the trigger is a filterable text input rather than a bare button.
+    // Only affects how much horizontal room the trigger reserves in chips mode.
+    isFilterable: {
+      true: {},
+      false: {}
     }
   },
   compoundVariants: [
     // Padding belongs to whichever element is the field shell, so it is applied
     // to `chipsField` only in chips mode -- in passthrough mode the wrapper has
     // to add no geometry of its own.
-    { hasChips: true, size: 'sm', class: { chipsField: 'p-1 gap-1' } },
-    { hasChips: true, size: 'md', class: { chipsField: 'p-1.5 gap-1' } },
-    { hasChips: true, size: 'lg', class: { chipsField: 'p-2 gap-1.5' } },
+    // The `min-h-*` values are the height of the same-size text field
+    // (padding + line box + border), so a chips field is exactly as tall as a
+    // single-select one, does not change height as the first chip arrives, and
+    // absorbs the flex gap when the trigger wraps below the chips.
+    // No gap between the chips and the trigger: the chips carry their own gap,
+    // and a gap here is space the trigger has to fit into before it is allowed
+    // to stay on the chips' line. With `gap-0` a trigger that does have to wrap
+    // (the chips already fill the row) costs no vertical space at all.
+    {
+      hasChips: true,
+      size: 'sm',
+      class: { chipsField: 'p-1 gap-0 min-h-9.5' }
+    },
+    {
+      hasChips: true,
+      size: 'md',
+      class: { chipsField: 'p-1.5 gap-0 min-h-11.5' }
+    },
+    {
+      hasChips: true,
+      size: 'lg',
+      class: { chipsField: 'p-2 gap-0 min-h-13.5' }
+    },
     // Chips have to clear the absolutely-positioned start/end content the same
     // way a bare `input` does, otherwise they run underneath the chevron and the
     // clear button.
@@ -328,7 +363,15 @@ const select = tv({
     // ...and once `chipsField` reserves that room, the bare trigger inside it
     // must not reserve it a second time.
     { hasChips: true, hasStartContent: true, class: { input: 'ps-0' } },
-    { hasChips: true, hasEndContent: true, class: { input: 'pe-0' } }
+    { hasChips: true, hasEndContent: true, class: { input: 'pe-0' } },
+    // Only the filterable trigger needs typing room -- and, since the field
+    // itself no longer sets a gap, its own separation from the last chip.
+    // See `min-w-0` and `gap-0` above.
+    {
+      hasChips: true,
+      isFilterable: true,
+      class: { input: 'min-w-16 ms-1' }
+    }
   ],
   defaultVariants: {
     size: 'md'

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -269,24 +269,25 @@ const select = tv({
     input: '[button]:cursor-default',
     emptyContent: 'p-2',
     // The wrapper around the trigger. It is rendered in every mode; the
-    // `hasChips` variant below decides whether it is the field shell or is
-    // layout-transparent. Authored here rather than as a literal class in the
-    // component template because Tailwind does not scan `packages/frontile/src`.
+    // `hasChips` variant below decides whether it is the field shell or a
+    // transparent passthrough. Authored here rather than as literal classes in
+    // the component template because Tailwind does not scan
+    // `packages/frontile/src`.
     chipsField: '',
     chipsContainer: 'flex flex-wrap items-center gap-1 min-w-0',
     chip: ''
   },
   variants: {
     size: {
-      // Inert under `display: contents`, so it is safe to apply unconditionally.
-      sm: { chipsField: 'p-1 gap-1' },
-      md: { chipsField: 'p-1.5 gap-1' },
-      lg: { chipsField: 'p-2 gap-1.5' }
+      sm: {},
+      md: {},
+      lg: {}
     },
     // When chips render, `chipsField` becomes the field shell in place of the
-    // trigger's own border (see the `hasChips` variant on `input`). Otherwise it
-    // is `display: contents`, so the trigger lays out exactly as it did before
-    // the wrapper existed.
+    // trigger's own border (see the `hasChips` variant on `input`), and owns the
+    // padding. Otherwise it is a transparent, full-width flex passthrough: the
+    // shell stays on the trigger, but the wrapper is still a real box, so it can
+    // be measured as the popover's width reference in both modes.
     //
     // `data-invalid` / `data-disabled` are set by the component because
     // `aria-invalid:` and `disabled:` only match the element carrying them.
@@ -309,18 +310,26 @@ const select = tv({
           'data-[disabled=true]:text-neutral-soft'
         ]
       },
-      false: { chipsField: 'contents' }
-    },
-    // `chipsField` is the padding box in chips mode, so it has to clear the
-    // absolutely-positioned start/end content the same way the bare `input`
-    // does -- otherwise chips run underneath the chevron and clear button.
-    hasStartContent: {
-      true: { chipsField: 'ps-8' }
-    },
-    hasEndContent: {
-      true: { chipsField: 'pe-10' }
+      false: { chipsField: 'flex w-full min-w-0' }
     }
   },
+  compoundVariants: [
+    // Padding belongs to whichever element is the field shell, so it is applied
+    // to `chipsField` only in chips mode -- in passthrough mode the wrapper has
+    // to add no geometry of its own.
+    { hasChips: true, size: 'sm', class: { chipsField: 'p-1 gap-1' } },
+    { hasChips: true, size: 'md', class: { chipsField: 'p-1.5 gap-1' } },
+    { hasChips: true, size: 'lg', class: { chipsField: 'p-2 gap-1.5' } },
+    // Chips have to clear the absolutely-positioned start/end content the same
+    // way a bare `input` does, otherwise they run underneath the chevron and the
+    // clear button.
+    { hasChips: true, hasStartContent: true, class: { chipsField: 'ps-8' } },
+    { hasChips: true, hasEndContent: true, class: { chipsField: 'pe-10' } },
+    // ...and once `chipsField` reserves that room, the bare trigger inside it
+    // must not reserve it a second time.
+    { hasChips: true, hasStartContent: true, class: { input: 'ps-0' } },
+    { hasChips: true, hasEndContent: true, class: { input: 'pe-0' } }
+  ],
   defaultVariants: {
     size: 'md'
   }

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -268,33 +268,48 @@ const select = tv({
     clearButton: 'pointer-events-auto',
     input: '[button]:cursor-default',
     emptyContent: 'p-2',
-    // Field shell used in place of the trigger's own border when chips render.
-    // `data-invalid` / `data-disabled` are set by the component because
-    // `aria-invalid:` and `disabled:` only match the element carrying them.
-    chipsField: [
-      ...fieldShell,
-      'flex',
-      'flex-wrap',
-      'items-center',
-      'gap-1',
-      'w-full',
-      'cursor-default',
-      'focus-within:ring-3',
-      'focus-within:ring-focus',
-      'focus-within:border-primary-soft',
-      'data-[invalid=true]:border-danger-soft',
-      'data-[invalid=true]:focus-within:ring-danger-soft',
-      'data-[disabled=true]:border-neutral-subtle',
-      'data-[disabled=true]:text-neutral-soft'
-    ],
+    // The wrapper around the trigger. It is rendered in every mode; the
+    // `hasChips` variant below decides whether it is the field shell or is
+    // layout-transparent. Authored here rather than as a literal class in the
+    // component template because Tailwind does not scan `packages/frontile/src`.
+    chipsField: '',
     chipsContainer: 'flex flex-wrap items-center gap-1 min-w-0',
     chip: ''
   },
   variants: {
     size: {
+      // Inert under `display: contents`, so it is safe to apply unconditionally.
       sm: { chipsField: 'p-1 gap-1' },
       md: { chipsField: 'p-1.5 gap-1' },
       lg: { chipsField: 'p-2 gap-1.5' }
+    },
+    // When chips render, `chipsField` becomes the field shell in place of the
+    // trigger's own border (see the `hasChips` variant on `input`). Otherwise it
+    // is `display: contents`, so the trigger lays out exactly as it did before
+    // the wrapper existed.
+    //
+    // `data-invalid` / `data-disabled` are set by the component because
+    // `aria-invalid:` and `disabled:` only match the element carrying them.
+    hasChips: {
+      true: {
+        chipsField: [
+          ...fieldShell,
+          'flex',
+          'flex-wrap',
+          'items-center',
+          'gap-1',
+          'w-full',
+          'cursor-default',
+          'focus-within:ring-3',
+          'focus-within:ring-focus',
+          'focus-within:border-primary-soft',
+          'data-[invalid=true]:border-danger-soft',
+          'data-[invalid=true]:focus-within:ring-danger-soft',
+          'data-[disabled=true]:border-neutral-subtle',
+          'data-[disabled=true]:text-neutral-soft'
+        ]
+      },
+      false: { chipsField: 'contents' }
     }
   },
   defaultVariants: {

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -310,6 +310,15 @@ const select = tv({
         ]
       },
       false: { chipsField: 'contents' }
+    },
+    // `chipsField` is the padding box in chips mode, so it has to clear the
+    // absolutely-positioned start/end content the same way the bare `input`
+    // does -- otherwise chips run underneath the chevron and clear button.
+    hasStartContent: {
+      true: { chipsField: 'ps-8' }
+    },
+    hasEndContent: {
+      true: { chipsField: 'pe-10' }
     }
   },
   defaultVariants: {

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -8097,18 +8097,6 @@ const data: ComponentDoc[] = [
           type: '<span class="hljs-title class_">Object</span>',
           items: [
             {
-              identifier: 'size',
-              type: {
-                type: '<span class="hljs-keyword">enum</span>',
-                raw: '<span class="hljs-string">\'sm\'</span> | <span class="hljs-string">\'md\'</span> | <span class="hljs-string">\'lg\'</span>',
-                items: ["'sm'", "'md'", "'lg'"],
-              },
-              isRequired: false,
-              isInternal: false,
-              description: 'The size of the chip',
-              tags: {},
-            },
-            {
               identifier: 'appearance',
               type: {
                 type: '<span class="hljs-keyword">enum</span>',
@@ -8117,11 +8105,11 @@ const data: ComponentDoc[] = [
               },
               isRequired: false,
               isInternal: false,
-              description: 'The chip appearance',
+              description: 'The chip appearance.',
               tags: {
-                defaultValue: { name: 'defaultValue', value: "'default'" },
+                defaultValue: { name: 'defaultValue', value: "'faded'" },
               },
-              defaultValue: '<span class="hljs-string">\'default\'</span>',
+              defaultValue: '<span class="hljs-string">\'faded\'</span>',
             },
             {
               identifier: 'intent',
@@ -8140,8 +8128,22 @@ const data: ComponentDoc[] = [
               },
               isRequired: false,
               isInternal: false,
-              description: 'The intent of the chip',
+              description:
+                "The intent of the chip. Defaults to the Select's own `@intent`.",
               tags: {},
+            },
+            {
+              identifier: 'size',
+              type: {
+                type: '<span class="hljs-keyword">enum</span>',
+                raw: '<span class="hljs-string">\'sm\'</span> | <span class="hljs-string">\'md\'</span> | <span class="hljs-string">\'lg\'</span>',
+                items: ["'sm'", "'md'", "'lg'"],
+              },
+              isRequired: false,
+              isInternal: false,
+              description: 'The size of the chip.',
+              tags: { defaultValue: { name: 'defaultValue', value: "'sm'" } },
+              defaultValue: '<span class="hljs-string">\'sm\'</span>',
             },
             {
               identifier: 'radius',

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -8072,9 +8072,100 @@ const data: ComponentDoc[] = [
         defaultValue: '<span class="hljs-literal">true</span>',
       },
       {
+        identifier: 'chip',
+        type: {
+          type: '<span class="hljs-title class_">Object</span>',
+          items: [
+            {
+              identifier: 'appearance',
+              type: {
+                type: '<span class="hljs-keyword">enum</span>',
+                raw: '<span class="hljs-string">\'default\'</span> | <span class="hljs-string">\'outlined\'</span> | <span class="hljs-string">\'faded\'</span>',
+                items: ["'default'", "'outlined'", "'faded'"],
+              },
+              isRequired: false,
+              isInternal: false,
+              description: '',
+              tags: {
+                defaultValue: { name: 'defaultValue', value: "'faded'" },
+              },
+              defaultValue: '<span class="hljs-string">\'faded\'</span>',
+            },
+            {
+              identifier: 'intent',
+              type: {
+                type: '<span class="hljs-keyword">enum</span>',
+                raw: '<span class="hljs-string">\'default\'</span> | <span class="hljs-string">\'primary\'</span> | <span class="hljs-string">\'secondary\'</span> | <span class="hljs-string">\'tertiary\'</span> | <span class="hljs-string">\'success\'</span> | <span class="hljs-string">\'warning\'</span> | <span class="hljs-string">\'danger\'</span>',
+                items: [
+                  "'default'",
+                  "'primary'",
+                  "'secondary'",
+                  "'tertiary'",
+                  "'success'",
+                  "'warning'",
+                  "'danger'",
+                ],
+              },
+              isRequired: false,
+              isInternal: false,
+              description:
+                'Defaults to the Select\'s own `@intent`, so `@intent="primary"` colors the\nlistbox items and the chips together.',
+              tags: {},
+            },
+            {
+              identifier: 'size',
+              type: {
+                type: '<span class="hljs-keyword">enum</span>',
+                raw: '<span class="hljs-string">\'sm\'</span> | <span class="hljs-string">\'md\'</span> | <span class="hljs-string">\'lg\'</span>',
+                items: ["'sm'", "'md'", "'lg'"],
+              },
+              isRequired: false,
+              isInternal: false,
+              description: '',
+              tags: { defaultValue: { name: 'defaultValue', value: "'sm'" } },
+              defaultValue: '<span class="hljs-string">\'sm\'</span>',
+            },
+            {
+              identifier: 'radius',
+              type: {
+                type: '<span class="hljs-keyword">enum</span>',
+                raw: '<span class="hljs-string">\'sm\'</span> | <span class="hljs-string">\'lg\'</span> | <span class="hljs-string">\'none\'</span> | <span class="hljs-string">\'full\'</span>',
+                items: ["'sm'", "'lg'", "'none'", "'full'"],
+              },
+              isRequired: false,
+              isInternal: false,
+              description: 'The corner radius of the chip.',
+              tags: {},
+            },
+            {
+              identifier: 'withDot',
+              type: { type: '<span class="hljs-built_in">boolean</span>' },
+              isRequired: false,
+              isInternal: false,
+              description:
+                'Whether the chip renders a leading dot before its label.',
+              tags: {},
+            },
+          ],
+        },
+        isRequired: false,
+        isInternal: false,
+        description:
+          "Not applicable in single selection mode.\nAppearance of the chips rendered for each selected option.\nOnly applies when <code>@selectedItemsDisplay</code> is <code>'chips'</code> (the default).",
+        tags: {
+          example: { name: 'example', value: '```gts\n<Select' },
+          selectionMode: { name: 'selectionMode', value: '="multiple"' },
+          chip: {
+            name: 'chip',
+            value:
+              '={{hash appearance="outlined" size="md" radius="full"}}\n/>\n```',
+          },
+        },
+      },
+      {
         identifier: 'classes',
         type: {
-          type: '<span class="hljs-title class_">SlotsToClasses</span>&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span> | <span class="hljs-string">\'innerContainer\'</span> | <span class="hljs-string">\'startContent\'</span> | <span class="hljs-string">\'endContent\'</span> | <span class="hljs-string">\'listbox\'</span> | <span class="hljs-string">\'icon\'</span> | <span class="hljs-string">\'clearButton\'</span> | <span class="hljs-string">\'emptyContent\'</span> | <span class="hljs-string">\'placeholder\'</span>>',
+          type: '<span class="hljs-title class_">SlotsToClasses</span>&#x3C;<span class="hljs-string">\'base\'</span> | <span class="hljs-string">\'input\'</span> | <span class="hljs-string">\'innerContainer\'</span> | <span class="hljs-string">\'startContent\'</span> | <span class="hljs-string">\'endContent\'</span> | <span class="hljs-string">\'listbox\'</span> | <span class="hljs-string">\'icon\'</span> | <span class="hljs-string">\'clearButton\'</span> | <span class="hljs-string">\'emptyContent\'</span> | <span class="hljs-string">\'placeholder\'</span> | <span class="hljs-string">\'chipsField\'</span> | <span class="hljs-string">\'chipsContainer\'</span> | <span class="hljs-string">\'chip\'</span>>',
         },
         isRequired: false,
         isInternal: false,
@@ -8503,6 +8594,20 @@ const data: ComponentDoc[] = [
           'Whether to render in place or in the specified/default destination',
         tags: { defaultValue: { name: 'defaultValue', value: 'false' } },
         defaultValue: '<span class="hljs-literal">false</span>',
+      },
+      {
+        identifier: 'selectedItemsDisplay',
+        type: {
+          type: '<span class="hljs-keyword">enum</span>',
+          raw: '<span class="hljs-string">\'chips\'</span> | <span class="hljs-string">\'text\'</span>',
+          items: ["'chips'", "'text'"],
+        },
+        isRequired: false,
+        isInternal: false,
+        description:
+          "<p>Not applicable in single selection mode.\nHow the selected options are presented in the trigger.</p>\n<ul>\n<li><code>'chips'</code>: each selection renders as a removable {@link Chip }.</li>\n<li><code>'text'</code>: the selections render as a comma-joined string.</li>\n</ul>",
+        tags: { defaultValue: { name: 'defaultValue', value: "'chips'" } },
+        defaultValue: '<span class="hljs-string">\'chips\'</span>',
       },
       {
         identifier: 'selectedKey',
@@ -11230,7 +11335,7 @@ const data: ComponentDoc[] = [
         identifier: 'default',
         type: {
           type: '<span class="hljs-title class_">Array</span>',
-          raw: '[{ <span class="hljs-attr">anchor</span>: <span class="hljs-title class_">ModifierLike</span>&#x3C;{ <span class="hljs-title class_">Element</span>: <span class="hljs-title class_">HTMLElement</span>; }>; <span class="hljs-attr">isOpen</span>: <span class="hljs-built_in">boolean</span>; <span class="hljs-attr">toggle</span>: <span class="hljs-function">() =></span> <span class="hljs-built_in">void</span>; <span class="hljs-attr">open</span>: <span class="hljs-function">() =></span> <span class="hljs-built_in">void</span>; <span class="hljs-attr">close</span>: <span class="hljs-function">() =></span> <span class="hljs-built_in">void</span>; <span class="hljs-attr">trigger</span>: <span class="hljs-title class_">ModifierLike</span>&#x3C;{ <span class="hljs-title class_">Element</span>: <span class="hljs-title class_">HTMLElement</span>; <span class="hljs-title class_">Args</span>: { <span class="hljs-title class_">Positional</span>: [<span class="hljs-attr">eventType</span>?: <span class="hljs-string">\'click\'</span> | <span class="hljs-string">\'hover\'</span>]; }; }>; <span class="hljs-title class_">Content</span>: <span class="hljs-title class_">Content</span> (loop, isOpen, id, toggle, internalDidClose, blockScroll, backdrop, triggerWidth bound); }]',
+          raw: '[{ <span class="hljs-attr">anchor</span>: <span class="hljs-title class_">ModifierLike</span>&#x3C;{ <span class="hljs-title class_">Element</span>: <span class="hljs-title class_">HTMLElement</span>; }>; <span class="hljs-attr">measureWidth</span>: <span class="hljs-title class_">ModifierLike</span>&#x3C;{ <span class="hljs-title class_">Element</span>: <span class="hljs-title class_">HTMLElement</span>; }>; <span class="hljs-attr">isOpen</span>: <span class="hljs-built_in">boolean</span>; <span class="hljs-attr">toggle</span>: <span class="hljs-function">() =></span> <span class="hljs-built_in">void</span>; <span class="hljs-attr">open</span>: <span class="hljs-function">() =></span> <span class="hljs-built_in">void</span>; <span class="hljs-attr">close</span>: <span class="hljs-function">() =></span> <span class="hljs-built_in">void</span>; <span class="hljs-attr">trigger</span>: <span class="hljs-title class_">ModifierLike</span>&#x3C;{ <span class="hljs-title class_">Element</span>: <span class="hljs-title class_">HTMLElement</span>; <span class="hljs-title class_">Args</span>: { <span class="hljs-title class_">Positional</span>: [<span class="hljs-attr">eventType</span>?: <span class="hljs-string">\'click\'</span> | <span class="hljs-string">\'hover\'</span>]; }; }>; <span class="hljs-title class_">Content</span>: <span class="hljs-title class_">Content</span> (loop, isOpen, id, toggle, internalDidClose, blockScroll, backdrop, triggerWidth bound); }]',
           items: [
             {
               identifier: '0',
@@ -11245,6 +11350,17 @@ const data: ComponentDoc[] = [
                     isRequired: true,
                     isInternal: false,
                     description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'measureWidth',
+                    type: {
+                      type: '<span class="hljs-title class_">ModifierLike</span>&#x3C;{ <span class="hljs-title class_">Element</span>: <span class="hljs-title class_">HTMLElement</span>; }>',
+                    },
+                    isRequired: true,
+                    isInternal: false,
+                    description:
+                      'Nominates the element it is placed on as the width reference for\n`@size="trigger"` content, instead of the element carrying `trigger`.',
                     tags: {},
                   },
                   {
@@ -12401,8 +12517,8 @@ const data: ComponentDoc[] = [
         identifier: 'shape',
         type: {
           type: '<span class="hljs-keyword">enum</span>',
-          raw: '<span class="hljs-string">\'rounded\'</span> | <span class="hljs-string">\'square\'</span> | <span class="hljs-string">\'circle\'</span> | <span class="hljs-string">\'text\'</span> | <span class="hljs-string">\'rect\'</span>',
-          items: ["'rounded'", "'square'", "'circle'", "'text'", "'rect'"],
+          raw: '<span class="hljs-string">\'rounded\'</span> | <span class="hljs-string">\'text\'</span> | <span class="hljs-string">\'square\'</span> | <span class="hljs-string">\'circle\'</span> | <span class="hljs-string">\'rect\'</span>',
+          items: ["'rounded'", "'text'", "'square'", "'circle'", "'rect'"],
         },
         isRequired: false,
         isInternal: false,

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -8097,6 +8097,18 @@ const data: ComponentDoc[] = [
           type: '<span class="hljs-title class_">Object</span>',
           items: [
             {
+              identifier: 'size',
+              type: {
+                type: '<span class="hljs-keyword">enum</span>',
+                raw: '<span class="hljs-string">\'sm\'</span> | <span class="hljs-string">\'md\'</span> | <span class="hljs-string">\'lg\'</span>',
+                items: ["'sm'", "'md'", "'lg'"],
+              },
+              isRequired: false,
+              isInternal: false,
+              description: 'The size of the chip',
+              tags: {},
+            },
+            {
               identifier: 'appearance',
               type: {
                 type: '<span class="hljs-keyword">enum</span>',
@@ -8105,11 +8117,11 @@ const data: ComponentDoc[] = [
               },
               isRequired: false,
               isInternal: false,
-              description: '',
+              description: 'The chip appearance',
               tags: {
-                defaultValue: { name: 'defaultValue', value: "'faded'" },
+                defaultValue: { name: 'defaultValue', value: "'default'" },
               },
-              defaultValue: '<span class="hljs-string">\'faded\'</span>',
+              defaultValue: '<span class="hljs-string">\'default\'</span>',
             },
             {
               identifier: 'intent',
@@ -8128,22 +8140,8 @@ const data: ComponentDoc[] = [
               },
               isRequired: false,
               isInternal: false,
-              description:
-                'Defaults to the Select\'s own `@intent`, so `@intent="primary"` colors the\nlistbox items and the chips together.',
+              description: 'The intent of the chip',
               tags: {},
-            },
-            {
-              identifier: 'size',
-              type: {
-                type: '<span class="hljs-keyword">enum</span>',
-                raw: '<span class="hljs-string">\'sm\'</span> | <span class="hljs-string">\'md\'</span> | <span class="hljs-string">\'lg\'</span>',
-                items: ["'sm'", "'md'", "'lg'"],
-              },
-              isRequired: false,
-              isInternal: false,
-              description: '',
-              tags: { defaultValue: { name: 'defaultValue', value: "'sm'" } },
-              defaultValue: '<span class="hljs-string">\'sm\'</span>',
             },
             {
               identifier: 'radius',
@@ -8154,7 +8152,7 @@ const data: ComponentDoc[] = [
               },
               isRequired: false,
               isInternal: false,
-              description: 'The corner radius of the chip.',
+              description: 'The radius the chip',
               tags: {},
             },
             {
@@ -8162,8 +8160,7 @@ const data: ComponentDoc[] = [
               type: { type: '<span class="hljs-built_in">boolean</span>' },
               isRequired: false,
               isInternal: false,
-              description:
-                'Whether the chip renders a leading dot before its label.',
+              description: 'Option to add dot to the chip',
               tags: {},
             },
           ],
@@ -8171,7 +8168,7 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          "Not applicable in single selection mode.\nAppearance of the chips rendered for each selected option.\nOnly applies when <code>@selectedItemsDisplay</code> is <code>'chips'</code> (the default).",
+          "<p>Not applicable in single selection mode.\nAppearance of the chips rendered for each selected option.\nOnly applies when <code>@selectedItemsDisplay</code> is <code>'chips'</code> (the default).</p>\n<p>Options are the same ones {@link Chip } itself accepts (<code>appearance</code>,\n<code>intent</code>, <code>size</code>, <code>radius</code>, <code>withDot</code>), but Select applies its own\ndefaults tuned for sitting inside a field, rather than Chip's:</p>\n<ul>\n<li><code>appearance</code> defaults to <code>'faded'</code></li>\n<li><code>intent</code> defaults to the Select's own <code>@intent</code>, so <code>@intent=\"primary\"</code>\ncolors the listbox items and the chips together</li>\n<li><code>size</code> defaults to <code>'sm'</code></li>\n<li><code>radius</code> and <code>withDot</code> fall back to Chip's own defaults</li>\n</ul>",
         tags: {
           example: { name: 'example', value: '```gts\n<Select' },
           selectionMode: { name: 'selectionMode', value: '="multiple"' },

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -3457,6 +3457,26 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'closeButtonTabIndex',
+        type: {
+          type: '<span class="hljs-keyword">enum</span>',
+          raw: '<span class="hljs-built_in">string</span> | <span class="hljs-built_in">number</span>',
+          items: ['string', 'number'],
+        },
+        isRequired: false,
+        isInternal: false,
+        description:
+          '<p><code>tabindex</code> for the close button.</p>\n<p>Set to <code>-1</code> when chips sit inside another control (a multi-select field,\nsay) and the close button should stay a pointer affordance: every chip\nwould otherwise cost a Tab stop before the control itself is reached.\nWhoever does this owes keyboard users another way to remove a chip.</p>',
+        tags: {
+          defaultValue: {
+            name: 'defaultValue',
+            value: 'undefined (the close button is a normal tab stop)',
+          },
+        },
+        defaultValue:
+          '<span class="hljs-title function_">undefined</span> (the close button is a normal tab stop)',
+      },
+      {
         identifier: 'closeButtonTitle',
         type: { type: '<span class="hljs-built_in">string</span>' },
         isRequired: false,

--- a/site/docfy.config.mjs
+++ b/site/docfy.config.mjs
@@ -74,6 +74,10 @@ export default {
     {
       root: path.resolve(__dirname, '../docs'),
       pattern: '**/*.md',
+      // `docs/superpowers/` holds working documents for in-flight work (plans
+      // and design specs), not published documentation. Ignored as a directory
+      // so anything added there later stays unpublished too.
+      ignore: ['superpowers/**'],
       urlPrefix: 'docs',
     },
     ...[

--- a/test-app/tests/integration/components/collections/listbox-test.gts
+++ b/test-app/tests/integration/components/collections/listbox-test.gts
@@ -788,5 +788,152 @@ module(
           .doesNotHaveAttribute('aria-multiselectable');
       });
     });
+
+    /**
+     * Regression coverage for a pre-existing ListManager bug: the new
+     * selection was rebuilt purely from the *rendered* items, so any selected
+     * key whose item was not currently in the list — filtered out, paginated
+     * away, or simply never passed in @items — was silently dropped on the
+     * next toggle.
+     *
+     * Driven by plain clicks: the defect is in selection, not in key handling.
+     */
+    module('selections outside the rendered item set', function () {
+      test('toggling keeps selected keys whose items are not rendered', async function (assert) {
+        const animals = ['crocodile', 'elephant'];
+        // 'cheetah' is selected but deliberately absent from @items.
+        const selectedKeys = cell<string[]>(['cheetah', 'crocodile']);
+        const onSelectionChange = (keys: string[]) => {
+          selectedKeys.current = keys;
+        };
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="multiple"
+              @items={{animals}}
+              @selectedKeys={{selectedKeys.current}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </template>
+        );
+
+        assert
+          .dom('[data-key="cheetah"]')
+          .doesNotExist('the selected item is not in the rendered list');
+
+        await click('[data-key="elephant"]');
+
+        assert.deepEqual(
+          [...selectedKeys.current].sort(),
+          ['cheetah', 'crocodile', 'elephant'],
+          'selecting a rendered item does not drop the unrendered selection'
+        );
+      });
+
+      test('deselecting a rendered item keeps unrendered selections', async function (assert) {
+        const animals = ['crocodile', 'elephant'];
+        const selectedKeys = cell<string[]>(['cheetah', 'crocodile']);
+        const onSelectionChange = (keys: string[]) => {
+          selectedKeys.current = keys;
+        };
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="multiple"
+              @items={{animals}}
+              @selectedKeys={{selectedKeys.current}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </template>
+        );
+
+        await click('[data-key="crocodile"]');
+
+        assert.deepEqual(
+          [...selectedKeys.current].sort(),
+          ['cheetah'],
+          'deselecting removes only the clicked key'
+        );
+      });
+
+      /**
+       * The no-op guarantee. With every selected item rendered there is
+       * nothing to union back in, so the emitted array must be byte-for-byte
+       * what the unfixed code produced — including its quirk of appending a
+       * newly selected key last rather than in DOM order.
+       *
+       * Unlike its three neighbours this test is green BEFORE the fix as well
+       * as after: staying green across the change is precisely what it
+       * asserts. It was written against the unfixed code's real output.
+       */
+      test('is a no-op when every selected item is rendered', async function (assert) {
+        const animals = ['cheetah', 'crocodile', 'elephant'];
+        const selectedKeys = cell<string[]>(['crocodile']);
+        const onSelectionChange = (keys: string[]) => {
+          selectedKeys.current = keys;
+        };
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="multiple"
+              @items={{animals}}
+              @selectedKeys={{selectedKeys.current}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </template>
+        );
+
+        await click('[data-key="elephant"]');
+        assert.deepEqual(
+          selectedKeys.current,
+          ['crocodile', 'elephant'],
+          'DOM order preserved, no duplicates'
+        );
+
+        await click('[data-key="cheetah"]');
+        assert.deepEqual(
+          selectedKeys.current,
+          ['crocodile', 'elephant', 'cheetah'],
+          'a newly selected key is appended last, exactly as before the fix'
+        );
+
+        await click('[data-key="crocodile"]');
+        assert.deepEqual(
+          selectedKeys.current,
+          ['cheetah', 'elephant'],
+          'the array is re-derived in DOM order on each toggle, as before the fix'
+        );
+      });
+
+      test('single mode is unaffected by unrendered selections', async function (assert) {
+        const animals = ['crocodile', 'elephant'];
+        const selectedKeys = cell<string[]>(['cheetah']);
+        const onSelectionChange = (keys: string[]) => {
+          selectedKeys.current = keys;
+        };
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="single"
+              @items={{animals}}
+              @selectedKeys={{selectedKeys.current}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </template>
+        );
+
+        await click('[data-key="elephant"]');
+
+        assert.deepEqual(
+          selectedKeys.current,
+          ['elephant'],
+          'single selection still replaces, it does not accumulate'
+        );
+      });
+    });
   }
 );

--- a/test-app/tests/integration/components/forms/autocomplete-test.gts
+++ b/test-app/tests/integration/components/forms/autocomplete-test.gts
@@ -680,5 +680,46 @@ module(
 
       assert.dom('[data-test-id="loading-spinner"]').exists();
     });
+
+    /**
+     * Guard, not a regression repro. Autocomplete pins the listbox to
+     * `@selectionMode="single"`, and single mode replaces the selection
+     * outright rather than rebuilding it from the rendered items, so it never
+     * hit the ListManager bug that Select and Listbox did. This test exists to
+     * keep the shared fix from changing Autocomplete's behaviour: selecting a
+     * filtered option must still yield exactly that one key.
+     */
+    test('selecting a filtered option replaces the selection, filtered-out items and all', async function (assert) {
+      const items = ['Apple', 'Banana', 'Cherry'];
+      const selectedKey = cell<string | null>('Apple');
+      const onSelectionChange = (key: string | null) => {
+        selectedKey.current = key;
+      };
+
+      await render(
+        <template>
+          <Autocomplete
+            @items={{items}}
+            @selectedKey={{selectedKey.current}}
+            @onSelectionChange={{onSelectionChange}}
+          />
+        </template>
+      );
+
+      await click('[data-component="autocomplete-trigger"]');
+      await fillIn('[data-component="autocomplete-trigger"]', 'Cherry');
+
+      assert
+        .dom('[data-component="listbox"] [data-key="Apple"]')
+        .doesNotExist('the previously selected option is filtered out');
+
+      await click('[data-component="listbox"] [data-key="Cherry"]');
+
+      assert.strictEqual(
+        selectedKey.current,
+        'Cherry',
+        'single selection still replaces, it does not accumulate the filtered-out key'
+      );
+    });
   }
 );

--- a/test-app/tests/integration/components/forms/field-test.gts
+++ b/test-app/tests/integration/components/forms/field-test.gts
@@ -380,6 +380,7 @@ module('Integration | Component | @frontile/forms/Field', function (hooks) {
             @label="Choose Fruits"
             @items={{items}}
             @selectionMode="multiple"
+            @selectedItemsDisplay="text"
             data-test-multi-select
           />
         </Field>
@@ -444,6 +445,7 @@ module('Integration | Component | @frontile/forms/Field', function (hooks) {
             @label="Choose Fruits"
             @items={{items}}
             @selectionMode="multiple"
+            @selectedItemsDisplay="text"
             data-test-multi-select
           />
         </Field>
@@ -538,6 +540,7 @@ module('Integration | Component | @frontile/forms/Field', function (hooks) {
             @label="Choose Fruits"
             @items={{items}}
             @selectionMode="multiple"
+            @selectedItemsDisplay="text"
             @onSelectionChange={{onChange}}
             data-test-multi-select
           />
@@ -602,6 +605,7 @@ module('Integration | Component | @frontile/forms/Field', function (hooks) {
             @label="Choose Fruits"
             @items={{items}}
             @selectionMode="multiple"
+            @selectedItemsDisplay="text"
             @onSelectionChange={{onChange}}
             data-test-multi-select
           />

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1402,12 +1402,16 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       </template>
     );
 
+    // @closeButtonTitle feeds CloseButton's visually-hidden text, which is
+    // the button's accessible name — not a `title` attribute (CloseButton
+    // deliberately has none, to avoid a duplicate accessible description
+    // and an unwanted native tooltip).
     assert
       .dom('[data-test-id="selected-chip"][data-key="apple"] button')
-      .hasAttribute('title', 'Remove apple');
+      .hasText('Remove apple');
     assert
       .dom('[data-test-id="selected-chip"][data-key="banana"] button')
-      .hasAttribute('title', 'Remove banana');
+      .hasText('Remove banana');
   });
 
   test('Multiple mode: the last chip has no close button unless @allowEmpty', async function (assert) {
@@ -1468,30 +1472,23 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       </template>
     );
 
+    // A chip's close button carries a real `disabled` attribute when the
+    // select is disabled, so a user has no way to activate it — browsers
+    // do not deliver pointer/keyboard events to a natively disabled
+    // button, and `@ember/test-helpers`' `click()` itself refuses to
+    // simulate a click on one. That native semantics is the actual
+    // guarantee here, so it is what this test asserts.
+    //
+    // `removeSelectedKey`'s own `@isDisabled` check is defense-in-depth
+    // with no reachable UI path to exercise it from a test — there is no
+    // way to fire a "real" click on a disabled button, so that branch is
+    // intentionally left uncovered rather than faked with a synthetic
+    // event dispatch that would never occur from user interaction.
     assert
       .dom('[data-test-id="selected-chip"][data-key="apple"] button')
       .isDisabled();
     assert
       .dom('[data-test-id="chips-field"]')
       .hasAttribute('data-disabled', 'true');
-
-    // The close button carries a real `disabled` attribute, so
-    // `@ember/test-helpers`' `click()` refuses to simulate the interaction
-    // (it throws for any genuinely-disabled form control). Dispatch the
-    // click event directly to prove the removal is also guarded in JS, as
-    // defense-in-depth alongside the native disabled semantics.
-    const button = document.querySelector(
-      '[data-test-id="selected-chip"][data-key="apple"] button'
-    );
-    button?.dispatchEvent(
-      new MouseEvent('click', { bubbles: true, cancelable: true })
-    );
-    await settled();
-
-    assert.deepEqual(
-      selectedKeys.current,
-      ['apple', 'banana'],
-      'a disabled chip cannot remove its selection'
-    );
   });
 });

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -826,6 +826,7 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       <template>
         <Select
           @selectionMode="multiple"
+          @selectedItemsDisplay="text"
           @items={{items}}
           @selectedKeys={{selectedKeys.current}}
           @onSelectionChange={{onSelectionChange}}
@@ -961,6 +962,7 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       <template>
         <Select
           @selectionMode="multiple"
+          @selectedItemsDisplay="text"
           @items={{items}}
           @selectedKeys={{selectedKeys.current}}
           @onSelectionChange={{onSelectionChange}}
@@ -1036,6 +1038,7 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       <template>
         <Select
           @selectionMode="multiple"
+          @selectedItemsDisplay="text"
           @items={{items}}
           @selectedKeys={{selectedKeys.current}}
           @onSelectionChange={{onSelectionChange}}
@@ -1114,6 +1117,7 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       <template>
         <Select
           @selectionMode="multiple"
+          @selectedItemsDisplay="text"
           @items={{items}}
           @selectedKeys={{selectedKeys.current}}
           @onSelectionChange={{onSelectionChange}}
@@ -1174,5 +1178,108 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       3,
       'callback should only be called for user clicks'
     );
+  });
+  test('Multiple mode: renders a chip per selected option by default', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'cherry']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Select fruits"
+        />
+      </template>
+    );
+
+    assert.dom('[data-test-id="chips-field"]').exists('chips wrapper renders');
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 2 });
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"]')
+      .hasTextContaining('apple');
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="cherry"]')
+      .hasTextContaining('cherry');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .doesNotIncludeText('apple, cherry', 'joined text is not rendered');
+    assert
+      .dom('[data-component="select-trigger"] [data-test-id="selected-chip"]')
+      .doesNotExist('chips must not be nested inside the trigger');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute('data-component', 'select-trigger');
+  });
+
+  test('Multiple mode: chips replace the placeholder only once something is selected', async function (assert) {
+    const selectedKeys = cell<string[]>([]);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Select fruits"
+        />
+      </template>
+    );
+
+    assert.dom('[data-component="select-trigger"]').hasText('Select fruits');
+    assert.dom('[data-test-id="selected-chip"]').doesNotExist();
+
+    await click('[data-component="select-trigger"]');
+    await click('[data-component="listbox"] [data-key="apple"]');
+
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 1 });
+    assert
+      .dom('[data-component="select-trigger"]')
+      .doesNotIncludeText('Select fruits', 'placeholder hides once chips show');
+  });
+
+  test('Multiple mode: @selectedItemsDisplay="text" keeps the joined text', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'cherry']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @selectedItemsDisplay="text"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Select fruits"
+        />
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').doesNotExist();
+    assert.dom('[data-test-id="chips-field"]').doesNotExist();
+    assert.dom('[data-component="select-trigger"]').hasText('apple, cherry');
+  });
+
+  test('Single mode: is unaffected and renders no chips', async function (assert) {
+    const selectedKey = cell<string | null>('apple');
+    const onChange = (key: string | null) => (selectedKey.current = key);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectedKey={{selectedKey.current}}
+          @onSelectionChange={{onChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').doesNotExist();
+    assert.dom('[data-test-id="chips-field"]').doesNotExist();
+    assert.dom('[data-component="select-trigger"]').hasText('apple');
   });
 });

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1875,6 +1875,124 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     assert.dom('[data-test-id="selected-chip"]').exists({ count: 3 });
   });
 
+  /**
+   * The second of the two layout bugs the user reported: "larger spacing below
+   * the chip to the input bottom when in one line".
+   *
+   * The `min-w-16` floor the chips-mode trigger used to carry pushed it onto a
+   * second flex line whenever the room left beside the chips was tighter than
+   * the floor. That line was zero-height, but the field's `gap` still paid for
+   * it, so a single row of chips sat with dead space underneath.
+   *
+   * `triggerRect.height >= chipRect.height` — asserted by the hittable-box test
+   * above — does NOT catch this: a wrapped trigger that has since gained a
+   * `min-h` satisfies it while the dead space is back, and worse than before,
+   * because the wrapped line is now tall rather than empty. What has to be
+   * pinned is that the trigger *shares the chips' line*.
+   *
+   * The fixture is sized so the chips very nearly fill the row (~26px of real
+   * room left beside them, well under the old 64px floor). That is the case the
+   * user hit, and the case the old floor got wrong.
+   */
+  test('Multiple mode: the trigger shares the chips line instead of wrapping below them', async function (assert) {
+    const selectedKeys = cell<string[]>([
+      'strawberry',
+      'blackberry',
+      'raspberry'
+    ]);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    // Explicit widths: the assertion is about how much room is left beside the
+    // chips, so it must not depend on the harness viewport.
+    await render(
+      <template>
+        <div style="width: 320px">
+          <Select
+            @items={{array "strawberry" "blackberry" "raspberry"}}
+            @selectionMode="multiple"
+            @selectedKeys={{selectedKeys.current}}
+            @onSelectionChange={{onChange}}
+          />
+        </div>
+        <div style="width: 320px">
+          <Select
+            @items={{array "strawberry" "blackberry" "raspberry"}}
+            @placeholder="Pick one"
+          />
+        </div>
+      </template>
+    );
+
+    const field = document.querySelector(
+      '[data-test-id="chips-field"]'
+    ) as HTMLElement;
+    const trigger = field.querySelector(
+      '[data-component="select-trigger"]'
+    ) as HTMLElement;
+    const chips = [
+      ...field.querySelectorAll('[data-test-id="selected-chip"]')
+    ] as HTMLElement[];
+
+    assert.strictEqual(chips.length, 3, 'all three chips render');
+
+    const fieldRect = field.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+
+    // Every chip is on one row: this is the "in one line" case, not a field
+    // that is legitimately wrapping.
+    const firstChipRect = (chips[0] as HTMLElement).getBoundingClientRect();
+    chips.forEach((chip, i) => {
+      const rect = chip.getBoundingClientRect();
+      assert.ok(
+        Math.abs(rect.top - firstChipRect.top) < 1,
+        `chip ${i} shares the first chip's row (top ${rect.top} vs ${firstChipRect.top})`
+      );
+    });
+
+    const lastChipRect = (
+      chips[chips.length - 1] as HTMLElement
+    ).getBoundingClientRect();
+
+    assert.ok(
+      triggerRect.top < lastChipRect.bottom &&
+        triggerRect.bottom > lastChipRect.top,
+      `the trigger must share the chips' line, not wrap below them: trigger ` +
+        `[${triggerRect.top}, ${triggerRect.bottom}] vs last chip ` +
+        `[${lastChipRect.top}, ${lastChipRect.bottom}]`
+    );
+
+    assert.ok(
+      triggerRect.left >= lastChipRect.right - 1,
+      `the trigger sits after the last chip on that line (trigger left ` +
+        `${triggerRect.left}, last chip right ${lastChipRect.right})`
+    );
+
+    // ...and the field is no taller than a single-select field of the same
+    // @inputSize. That equivalence is what the geometry fix established, and it
+    // is what "extra spacing below the chip" violates: unexplained height in
+    // the field beyond one row of chips.
+    const singleTrigger = document.querySelectorAll(
+      '[data-component="select-trigger"]'
+    )[1] as HTMLElement;
+    const singleRect = singleTrigger.getBoundingClientRect();
+
+    assert.ok(
+      Math.abs(fieldRect.height - singleRect.height) <= 1,
+      `a chips field must be the same height as a same-size single select: ` +
+        `chips ${fieldRect.height} vs single ${singleRect.height}`
+    );
+
+    // The chips must be centred in that height rather than pinned to the top
+    // with the slack underneath, which is what the user actually saw.
+    const spaceAbove = firstChipRect.top - fieldRect.top;
+    const spaceBelow = fieldRect.bottom - firstChipRect.bottom;
+    assert.ok(
+      Math.abs(spaceAbove - spaceBelow) <= 1,
+      `the row of chips must sit centred in the field, not with the slack ` +
+        `below it: ${spaceAbove} above vs ${spaceBelow} below`
+    );
+  });
+
   test('Multiple mode: chips default to the faded appearance and inherit @intent', async function (assert) {
     const selectedKeys = cell<string[]>(['apple', 'banana']);
     const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1491,4 +1491,102 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       .dom('[data-test-id="chips-field"]')
       .hasAttribute('data-disabled', 'true');
   });
+
+  test('Filterable multiple mode: the filter input stays empty so it can be typed in', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'cherry']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 2 });
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasValue('', 'the joined selection does not fill the filter input');
+
+    await click('[data-component="select-trigger"]');
+    await fillIn('[data-component="select-trigger"]', 'ban');
+    assert.dom('[data-component="listbox"] [data-key="banana"]').exists();
+    assert
+      .dom('[data-component="listbox"] [data-key="apple"]')
+      .doesNotExist('filtering still works with chips present');
+  });
+
+  test('Filterable multiple mode: Backspace on an empty filter removes the last chip', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana', 'cherry']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Backspace'
+    );
+
+    assert.deepEqual(selectedKeys.current, ['apple', 'banana']);
+
+    // Backspace with text in the filter edits the text, it does not remove a chip
+    await fillIn('[data-component="select-trigger"]', 'ap');
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Backspace'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple', 'banana'],
+      'Backspace while filtering leaves the selection alone'
+    );
+  });
+
+  test('Filterable multiple mode: Backspace does not remove the final chip unless @allowEmpty', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Backspace'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple'],
+      'the last required selection is not removed by Backspace, matching the chip close-button rule'
+    );
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 1 });
+  });
 });

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -10,7 +10,7 @@ import {
 } from '@ember/test-helpers';
 import { cell } from 'ember-resources';
 import { Select } from 'frontile';
-import { array } from '@ember/helper';
+import { array, hash } from '@ember/helper';
 import { selectOptionByKey } from 'frontile/test-support';
 
 // Simple equality helper
@@ -1588,5 +1588,92 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       'the last required selection is not removed by Backspace, matching the chip close-button rule'
     );
     assert.dom('[data-test-id="selected-chip"]').exists({ count: 1 });
+  });
+
+  test('Multiple mode: chips default to the faded appearance and inherit @intent', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @intent="primary"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    // The chip theme's real 'faded' + 'primary' compound variant resolves to
+    // `bg-primary-subtle` (see packages/theme/src/components/chip.ts), but the
+    // test suite globally overrides the `chip` theme via `registerCustomStyles`
+    // in chip-test.gts with stub classnames per variant (no compound
+    // resolution), so `hasClass('bg-primary-subtle')` can never pass here.
+    // Assert against the variant stubs instead, matching the convention used
+    // by chip-test.gts / buttons-test.gts elsewhere in this suite.
+    const chip = '[data-test-id="selected-chip"][data-key="apple"]';
+    assert.dom(chip).hasClass('chip-faded', 'defaults to appearance faded');
+    assert.dom(chip).hasClass('intent-primary', 'inherits @intent="primary"');
+  });
+
+  test('Multiple mode: @chip overrides appearance, intent, size and dot', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @intent="primary"
+          @chip={{hash
+            appearance="outlined"
+            intent="danger"
+            size="lg"
+            radius="full"
+            withDot=true
+          }}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    const chip = '[data-test-id="selected-chip"][data-key="apple"]';
+    assert.dom(chip).hasClass('radius-full', '@chip.radius applies');
+    assert
+      .dom(chip)
+      .doesNotHaveClass(
+        'intent-primary',
+        '@chip.intent overrides the inherited @intent'
+      );
+    assert.dom(chip).hasClass('intent-danger', '@chip.intent applies');
+    assert.dom(`${chip} span:first-child`).exists('withDot renders the dot');
+  });
+
+  test('Multiple mode: @classes.chip is merged onto every chip', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @classes={{hash chip="test-chip-class" chipsField="test-field-class"}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 2 });
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"]')
+      .hasClass('test-chip-class');
+    assert.dom('[data-test-id="chips-field"]').hasClass('test-field-class');
   });
 });

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1214,6 +1214,77 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       .hasAttribute('data-component', 'select-trigger');
   });
 
+  test('Multiple mode: the chips-mode trigger keeps a hittable box beside the chips', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'cherry']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Select fruits"
+        />
+      </template>
+    );
+
+    const trigger = document.querySelector(
+      '[data-component="select-trigger"]'
+    ) as HTMLElement;
+    const chip = document.querySelector(
+      '[data-test-id="selected-chip"]'
+    ) as HTMLElement;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const chipRect = chip.getBoundingClientRect();
+
+    assert.ok(
+      triggerRect.height > 0,
+      `the trigger must have a box to click, height was ${triggerRect.height}`
+    );
+    assert.ok(
+      triggerRect.width > 0,
+      `the trigger must have a box to click, width was ${triggerRect.width}`
+    );
+    assert.ok(
+      triggerRect.height >= chipRect.height,
+      `trigger height (${triggerRect.height}) should be at least the chip height (${chipRect.height})`
+    );
+
+    // Hit test rather than `click(trigger)`: `@ember/test-helpers` dispatches at
+    // the element whether or not it occupies any space, which is exactly how a
+    // zero-height trigger passed the suite while being unusable in a browser.
+    const x = triggerRect.left + triggerRect.width / 2;
+    const y = triggerRect.top + triggerRect.height / 2;
+    const hit = document.elementFromPoint(x, y);
+
+    assert.ok(
+      !!hit && (hit === trigger || trigger.contains(hit)),
+      `the empty area of the field must hit the trigger, got ${
+        hit
+          ? (hit as HTMLElement).tagName + '.' + (hit as HTMLElement).className
+          : 'null'
+      }`
+    );
+
+    hit?.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y
+      })
+    );
+    await settled();
+
+    assert
+      .dom('[data-component="listbox"]')
+      .exists('clicking the empty area of the field opens the listbox');
+    assert.dom(trigger).hasAttribute('aria-expanded', 'true');
+  });
+
   test('Multiple mode: chips replace the placeholder only once something is selected', async function (assert) {
     const selectedKeys = cell<string[]>([]);
     const onChange = (keys: string[]) => (selectedKeys.current = keys);

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1661,6 +1661,142 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     assert.dom('[data-test-id="selected-chip"]').exists({ count: 1 });
   });
 
+  /**
+   * Tab order, not merely "is there a button". A keyboard user reaching a
+   * chips field expects the combobox first; per-chip close buttons are pointer
+   * affordances and must not each cost a Tab stop on the way in.
+   */
+  test('Multiple mode: the trigger is reached before any chip close button', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana', 'cherry']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    const field = document.querySelector(
+      '[data-test-id="chips-field"]'
+    ) as HTMLElement;
+    assert.ok(field, 'the chips field renders');
+
+    const isTabbable = (el: Element) => {
+      const tabindex = el.getAttribute('tabindex');
+      if (tabindex !== null && Number(tabindex) < 0) return false;
+      return !(el as HTMLButtonElement).disabled;
+    };
+
+    const tabbable = [
+      ...field.querySelectorAll('button, input, [tabindex]')
+    ].filter(isTabbable);
+
+    assert.deepEqual(
+      tabbable.map((el) => el.getAttribute('data-component')),
+      ['select-trigger'],
+      'the trigger is the only tab stop inside the chips field'
+    );
+
+    assert
+      .dom('[data-test-id="selected-chip"] button')
+      .exists({ count: 3 }, 'chips still have pointer-reachable close buttons');
+
+    document
+      .querySelectorAll('[data-test-id="selected-chip"] button')
+      .forEach((button) => {
+        assert.strictEqual(
+          button.getAttribute('tabindex'),
+          '-1',
+          'each chip close button is out of the tab order'
+        );
+      });
+  });
+
+  /**
+   * Taking the close buttons out of the tab order is only acceptable because
+   * Backspace removes the last chip. That has to hold for the non-filterable
+   * trigger too, otherwise keyboard users lose chip removal entirely.
+   */
+  test('Multiple mode: Backspace on the non-filterable trigger removes the last chip', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana', 'cherry']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert
+      .dom('button[data-component="select-trigger"]')
+      .exists('this select uses the button trigger, not a filter input');
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Backspace'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple', 'banana'],
+      'Backspace removes the last chip from a non-filterable chips field'
+    );
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 2 });
+    checkSelected(assert, '[data-key="cherry"]', false);
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Delete'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple'],
+      'Delete removes the last chip too'
+    );
+  });
+
+  test('Multiple mode: Backspace does not remove the final chip unless @allowEmpty', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Backspace'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple'],
+      'the final required selection survives Backspace on the button trigger'
+    );
+  });
+
   test('Multiple mode: chips default to the faded appearance and inherit @intent', async function (assert) {
     const selectedKeys = cell<string[]>(['apple', 'banana']);
     const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1358,4 +1358,140 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       .dom('[data-component="select-trigger"]')
       .doesNotHaveAttribute('aria-label');
   });
+
+  test('Multiple mode: a chip close button removes just that selection', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana', 'cherry']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 3 });
+
+    await click('[data-test-id="selected-chip"][data-key="banana"] button');
+
+    assert.deepEqual(selectedKeys.current, ['apple', 'cherry']);
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 2 });
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="banana"]')
+      .doesNotExist();
+    isNotSelected(assert, '[value="banana"]');
+    isSelected(assert, '[value="apple"]');
+  });
+
+  test('Multiple mode: chip close buttons are individually labelled', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"] button')
+      .hasAttribute('title', 'Remove apple');
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="banana"] button')
+      .hasAttribute('title', 'Remove banana');
+  });
+
+  test('Multiple mode: the last chip has no close button unless @allowEmpty', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"] button')
+      .doesNotExist('no dead close button on the last required selection');
+  });
+
+  test('Multiple mode: @allowEmpty lets the last chip be removed', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    await click('[data-test-id="selected-chip"][data-key="apple"] button');
+
+    assert.deepEqual(selectedKeys.current, []);
+    assert.dom('[data-test-id="selected-chip"]').doesNotExist();
+  });
+
+  test('Multiple mode: chips are disabled when the select is disabled', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @isDisabled={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"] button')
+      .isDisabled();
+    assert
+      .dom('[data-test-id="chips-field"]')
+      .hasAttribute('data-disabled', 'true');
+
+    // The close button carries a real `disabled` attribute, so
+    // `@ember/test-helpers`' `click()` refuses to simulate the interaction
+    // (it throws for any genuinely-disabled form control). Dispatch the
+    // click event directly to prove the removal is also guarded in JS, as
+    // defense-in-depth alongside the native disabled semantics.
+    const button = document.querySelector(
+      '[data-test-id="selected-chip"][data-key="apple"] button'
+    );
+    button?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+    await settled();
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple', 'banana'],
+      'a disabled chip cannot remove its selection'
+    );
+  });
 });

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1282,4 +1282,80 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     assert.dom('[data-test-id="chips-field"]').doesNotExist();
     assert.dom('[data-component="select-trigger"]').hasText('apple');
   });
+  test('Multiple mode: a selected chip survives a filter that excludes its item', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Select fruits"
+        />
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"]')
+      .exists('the chip renders before filtering');
+
+    await fillIn('[data-component="select-trigger"]', 'ban');
+
+    assert
+      .dom('[data-component="listbox"] [data-key="apple"]')
+      .doesNotExist('apple is filtered out of the listbox');
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"]')
+      .exists('the chip for the filtered-out selection is still rendered');
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"]')
+      .hasTextContaining('apple', 'and it keeps its label');
+  });
+
+  test('Multiple mode: the trigger has an accessible name while chips are shown', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @label="Fruits"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-component="select-trigger"]').hasText('');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute('aria-label', 'Fruits');
+  });
+
+  test('Single mode: the trigger is named by its own text, not an aria-label', async function (assert) {
+    const selectedKey = cell<string | null>('apple');
+    const onChange = (key: string | null) => (selectedKey.current = key);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @label="Fruit"
+          @selectedKey={{selectedKey.current}}
+          @onSelectionChange={{onChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-component="select-trigger"]').hasText('apple');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .doesNotHaveAttribute('aria-label');
+  });
 });

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -456,14 +456,16 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     assert.dom('[data-component="listbox"]').exists();
 
     await fillIn('[data-test-id="trigger"]', 'App');
-    assert.dom('[data-key="Apple"]').exists();
-    assert.dom('[data-key="Banana"]').doesNotExist();
-    assert.dom('[data-key="Cherry"]').doesNotExist();
+    // Scoped to the listbox: the hidden native <select> deliberately keeps
+    // every option so the submitted value is never truncated by the filter.
+    assert.dom('[data-component="listbox"] [data-key="Apple"]').exists();
+    assert.dom('[data-component="listbox"] [data-key="Banana"]').doesNotExist();
+    assert.dom('[data-component="listbox"] [data-key="Cherry"]').doesNotExist();
 
     await fillIn('[data-test-id="trigger"]', 'a');
-    assert.dom('[data-key="Apple"]').exists();
-    assert.dom('[data-key="Banana"]').exists();
-    assert.dom('[data-key="Cherry"]').doesNotExist();
+    assert.dom('[data-component="listbox"] [data-key="Apple"]').exists();
+    assert.dom('[data-component="listbox"] [data-key="Banana"]').exists();
+    assert.dom('[data-component="listbox"] [data-key="Cherry"]').doesNotExist();
   });
 
   test('it shows empty content when no options match the filter', async function (assert) {

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1389,6 +1389,49 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       .hasTextContaining('apple', 'and it keeps its label');
   });
 
+  test('Multiple mode: the hidden native select keeps the whole selection while a filter is active', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'cherry']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @name="fruits"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Select fruits"
+        />
+      </template>
+    );
+
+    // The hidden native <select> is what a form submit reads, so its
+    // selectedOptions are the submitted value.
+    const submittedValues = () =>
+      Array.from((getNativeSelect() as HTMLSelectElement).selectedOptions).map(
+        (option) => option.value
+      );
+
+    assert.deepEqual(
+      submittedValues(),
+      ['apple', 'cherry'],
+      'both selections submit before filtering'
+    );
+
+    await fillIn('[data-component="select-trigger"]', 'ban');
+
+    assert
+      .dom('[data-component="listbox"] [data-key="apple"]')
+      .doesNotExist('the filter really is narrowing the listbox');
+    assert.deepEqual(
+      submittedValues(),
+      ['apple', 'cherry'],
+      'an active filter must not truncate the submitted value'
+    );
+  });
+
   test('Multiple mode: the trigger has an accessible name while chips are shown', async function (assert) {
     const selectedKeys = cell<string[]>(['apple']);
     const onChange = (keys: string[]) => (selectedKeys.current = keys);

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1212,8 +1212,8 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       .dom('[data-component="select-trigger"] [data-test-id="selected-chip"]')
       .doesNotExist('chips must not be nested inside the trigger');
     assert
-      .dom('[data-component="select-trigger"]')
-      .hasAttribute('data-component', 'select-trigger');
+      .dom('[data-test-id="chips-field"] [data-component="select-trigger"]')
+      .exists('the trigger is a sibling of the chips inside the chips field');
   });
 
   test('Multiple mode: the chips-mode trigger keeps a hittable box beside the chips', async function (assert) {
@@ -1430,6 +1430,112 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       ['apple', 'cherry'],
       'an active filter must not truncate the submitted value'
     );
+  });
+
+  test('Single mode: the filterable trigger keeps its placeholder once the filter is cleared', async function (assert) {
+    const selectedKey = cell<string | null>('apple');
+    const onChange = (key: string | null) => (selectedKey.current = key);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @isFilterable={{true}}
+          @selectedKey={{selectedKey.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Search fruits"
+        />
+      </template>
+    );
+
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute(
+        'placeholder',
+        'Search fruits',
+        'single mode keeps its placeholder with a selection'
+      );
+
+    await fillIn('[data-component="select-trigger"]', '');
+
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasValue('', 'the filter box is empty');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute(
+        'placeholder',
+        'Search fruits',
+        'so the placeholder is what the user sees'
+      );
+  });
+
+  test('Multiple mode: @selectedItemsDisplay="text" keeps the filterable placeholder', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @selectedItemsDisplay="text"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Search fruits"
+        />
+      </template>
+    );
+
+    await fillIn('[data-component="select-trigger"]', '');
+
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute(
+        'placeholder',
+        'Search fruits',
+        'text mode is not chips mode, so the placeholder stays'
+      );
+  });
+
+  test('Multiple mode: chips mode drops the filterable placeholder once something is selected', async function (assert) {
+    const selectedKeys = cell<string[]>([]);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+          @placeholder="Search fruits"
+        />
+      </template>
+    );
+
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute(
+        'placeholder',
+        'Search fruits',
+        'with nothing selected the placeholder is the only prompt'
+      );
+
+    await click('[data-component="select-trigger"]');
+    await click('[data-component="listbox"] [data-key="apple"]');
+
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="apple"]')
+      .exists('a chip now occupies the field');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .doesNotHaveAttribute(
+        'placeholder',
+        'so the placeholder is suppressed beside it'
+      );
   });
 
   test('Multiple mode: the trigger has an accessible name while chips are shown', async function (assert) {
@@ -1935,9 +2041,16 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
    * because the wrapped line is now tall rather than empty. What has to be
    * pinned is that the trigger *shares the chips' line*.
    *
-   * The fixture is sized so the chips very nearly fill the row (~26px of real
-   * room left beside them, well under the old 64px floor). That is the case the
-   * user hit, and the case the old floor got wrong.
+   * The fixture has to leave less room beside the chips than that 64px floor,
+   * or it does not reproduce the case at all. How much room it actually leaves
+   * cannot be reasoned about from the production chip theme: `chip-test.gts`
+   * calls `registerCustomStyles` at module scope, which replaces the `chip`
+   * theme for the whole suite with padding-free stub classnames, so the chips
+   * here are narrower than production chips by their entire horizontal
+   * padding. The tightness is therefore measured at runtime and asserted below
+   * ("premise"), rather than assumed — if the chip theme (real or stubbed) ever
+   * changes enough that the row stops being tight, this test fails loudly
+   * instead of quietly guarding nothing.
    */
   test('Multiple mode: the trigger shares the chips line instead of wrapping below them', async function (assert) {
     const selectedKeys = cell<string[]>([
@@ -1997,6 +2110,22 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     const lastChipRect = (
       chips[chips.length - 1] as HTMLElement
     ).getBoundingClientRect();
+
+    // Premise check. The QUnit container is `transform: scale(.5)`, so
+    // getBoundingClientRect returns halved values while getComputedStyle does
+    // not; normalise back to CSS pixels before comparing against the 64px
+    // (`min-w-16`) floor this fix removed.
+    const scale = fieldRect.width / field.offsetWidth;
+    const roomBesideChips =
+      (fieldRect.right - lastChipRect.right) / scale -
+      parseFloat(getComputedStyle(field).paddingRight);
+
+    assert.ok(
+      roomBesideChips < 64,
+      `premise: the fixture must leave less room beside the chips than the ` +
+        `removed 64px min-width floor, or it is not reproducing the wrapping ` +
+        `case at all (measured ${roomBesideChips}px)`
+    );
 
     assert.ok(
       triggerRect.top < lastChipRect.bottom &&

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1609,16 +1609,55 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     isSelected(assert, '[value="apple"]');
   });
 
+  test("Multiple mode: clicking a chip's body opens the dropdown", async function (assert) {
+    // A narrow single-chip trigger is hard to hit directly, so
+    // `handleFieldClick` forwards a click landing on a chip's body to the
+    // trigger -- the same way it already forwards clicks on the field's
+    // empty area. Only the chip's own close button is excluded from this
+    // (covered separately below).
+    const selectedKeys = cell<string[]>(['apple']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-component="listbox"]').doesNotExist();
+
+    await click('[data-test-id="selected-chip"][data-key="apple"]');
+
+    assert
+      .dom('[data-component="listbox"]')
+      .exists("clicking a chip's body opens the dropdown");
+    assert
+      .dom('[data-test-id="trigger"]')
+      .hasAttribute('aria-expanded', 'true');
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple'],
+      'the selection is unchanged by the click'
+    );
+  });
+
   test('Multiple mode: a chip close button works with no runtime dependency on data-test-id', async function (assert) {
-    // `handleFieldClick` must tell "inside the chips" from "the field's
-    // empty area" without keying off `data-test-id="selected-chip"` --
-    // that attribute is only a test hook, and tools like
-    // ember-test-selectors strip `data-test-*` from production builds. If
-    // the click forwarder ever regresses to a selector-based check, this
-    // simulates a stripped build by removing the attributes from the
-    // rendered chips before clicking, which makes `closest(...)` return
-    // null and the click fall through to `trigger.click()` -- popping the
-    // dropdown open even though a chip was removed.
+    // `handleFieldClick` must tell a chip's close button apart from the
+    // rest of the chip (and the field) without keying off
+    // `data-test-id="selected-chip"` -- that attribute is only a test
+    // hook, and tools like ember-test-selectors strip `data-test-*` from
+    // production builds. If the click forwarder ever regresses to a
+    // selector-based check, this simulates a stripped build by removing
+    // the attributes from the rendered chips before clicking, which would
+    // make a selector-based `closest(...)` return null and the click fall
+    // through to `trigger.click()` -- popping the dropdown open even
+    // though a chip was removed. The real detection (an ancestor `<button>`
+    // inside the chips container) does not depend on the attribute at all.
     const selectedKeys = cell<string[]>(['apple', 'banana', 'cherry']);
     const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
 

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1651,7 +1651,22 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
         '@chip.intent overrides the inherited @intent'
       );
     assert.dom(chip).hasClass('intent-danger', '@chip.intent applies');
-    assert.dom(`${chip} span:first-child`).exists('withDot renders the dot');
+    assert.dom(chip).hasClass('chip-outlined', '@chip.appearance applies');
+    assert
+      .dom(chip)
+      .doesNotHaveClass(
+        'chip-faded',
+        '@chip.appearance overrides the faded default'
+      );
+    assert.dom(chip).hasClass('chip-lg', '@chip.size applies');
+    assert
+      .dom(chip)
+      .doesNotHaveClass('chip-sm', '@chip.size overrides the sm default');
+    // `span:first-child` would pass regardless of @withDot, because
+    // chip.gts renders the content span as the first child when there is no
+    // dot. Target the dot's own stub class instead (chip-test.gts registers
+    // `dot: ['chip-dot']` on the mocked chip theme).
+    assert.dom(`${chip} .chip-dot`).exists('@chip.withDot renders the dot');
   });
 
   test('Multiple mode: @classes.chip is merged onto every chip', async function (assert) {

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1609,6 +1609,101 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     isSelected(assert, '[value="apple"]');
   });
 
+  test('Multiple mode: a chip close button works with no runtime dependency on data-test-id', async function (assert) {
+    // `handleFieldClick` must tell "inside the chips" from "the field's
+    // empty area" without keying off `data-test-id="selected-chip"` --
+    // that attribute is only a test hook, and tools like
+    // ember-test-selectors strip `data-test-*` from production builds. If
+    // the click forwarder ever regresses to a selector-based check, this
+    // simulates a stripped build by removing the attributes from the
+    // rendered chips before clicking, which makes `closest(...)` return
+    // null and the click fall through to `trigger.click()` -- popping the
+    // dropdown open even though a chip was removed.
+    const selectedKeys = cell<string[]>(['apple', 'banana', 'cherry']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 3 });
+
+    const closeButton = document.querySelector(
+      '[data-test-id="selected-chip"][data-key="banana"] button'
+    ) as HTMLButtonElement;
+    if (!closeButton) {
+      throw new Error('banana chip close button not found');
+    }
+
+    document
+      .querySelectorAll('[data-test-id="selected-chip"]')
+      .forEach((chip) => chip.removeAttribute('data-test-id'));
+
+    // `@ember/test-helpers`' `click()` awaits `settled()` between the
+    // simulated `mousedown`/`mouseup`/`click` events. `onPress` fires
+    // synchronously off `mouseup` here and removes the chip, so that
+    // `settled()` lets Ember's render runloop flush and detach the chip
+    // from the DOM *before* the simulated `click` event is dispatched --
+    // a detached node cannot bubble its click to the field, so the click
+    // forwarder never runs regardless of what it checks, and the test
+    // would pass for the wrong reason. A real physical click fires
+    // mousedown/mouseup/click back-to-back with no render flush in
+    // between, so this dispatches all three synchronously (no `await`
+    // between them) to match that and actually exercise the forwarder.
+    const mouseEventOptions = { bubbles: true, cancelable: true, button: 0 };
+    closeButton.dispatchEvent(new MouseEvent('mousedown', mouseEventOptions));
+    closeButton.dispatchEvent(new MouseEvent('mouseup', mouseEventOptions));
+    closeButton.dispatchEvent(new MouseEvent('click', mouseEventOptions));
+    await settled();
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple', 'cherry'],
+      'the chip was still removed'
+    );
+    assert
+      .dom('[data-component="listbox"]')
+      .doesNotExist('the dropdown did not open');
+    assert.notEqual(
+      document
+        .querySelector('[data-test-id="trigger"]')
+        ?.getAttribute('aria-expanded'),
+      'true',
+      'the trigger does not report itself expanded'
+    );
+  });
+
+  test('Multiple mode: clicking the field empty area still opens the dropdown', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    assert.dom('[data-component="listbox"]').doesNotExist();
+
+    await click('[data-test-id="chips-field"]');
+
+    assert
+      .dom('[data-component="listbox"]')
+      .exists('clicking the empty field area opens the dropdown');
+  });
+
   test('Multiple mode: chip close buttons are individually labelled', async function (assert) {
     const selectedKeys = cell<string[]>(['apple', 'banana']);
     const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -1797,6 +1797,84 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     );
   });
 
+  /**
+   * Bug B. Driven through a real keypress on the trigger — the event the
+   * Listbox actually listens to for Enter — rather than by calling internals.
+   */
+  test('Filterable multiple mode: Enter on a filtered option adds to the selection', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    await click('[data-component="select-trigger"]');
+    await fillIn('[data-component="select-trigger"]', 'cherry');
+
+    assert
+      .dom('[data-component="listbox"] [data-key="cherry"]')
+      .exists('only the filtered option is listed');
+    assert
+      .dom('[data-component="listbox"] [data-key="apple"]')
+      .doesNotExist('the already-selected option is filtered out of the list');
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keypress',
+      'Enter'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple', 'banana', 'cherry'],
+      'Enter adds the active option without dropping the filtered-out selections'
+    );
+
+    checkSelected(assert, '[data-key="apple"]', true);
+    checkSelected(assert, '[data-key="banana"]', true);
+    checkSelected(assert, '[data-key="cherry"]', true);
+  });
+
+  /**
+   * Bug B, mouse path — proof the data loss is not Enter-specific.
+   */
+  test('Filterable multiple mode: clicking a filtered option keeps the filtered-out selections', async function (assert) {
+    const selectedKeys = cell<string[]>(['apple', 'banana']);
+    const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{array "apple" "banana" "cherry"}}
+          @selectionMode="multiple"
+          @isFilterable={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onSelectionChange}}
+        />
+      </template>
+    );
+
+    await click('[data-component="select-trigger"]');
+    await fillIn('[data-component="select-trigger"]', 'cherry');
+    await click('[data-component="listbox"] [data-key="cherry"]');
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['apple', 'banana', 'cherry'],
+      'clicking a filtered option adds to the selection'
+    );
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 3 });
+  });
+
   test('Multiple mode: chips default to the faded appearance and inherit @intent', async function (assert) {
     const selectedKeys = cell<string[]>(['apple', 'banana']);
     const onSelectionChange = (keys: string[]) => (selectedKeys.current = keys);

--- a/test-app/tests/integration/components/overlays/popover-test.gts
+++ b/test-app/tests/integration/components/overlays/popover-test.gts
@@ -5,13 +5,34 @@ import {
   render,
   triggerEvent,
   find,
-  settled
+  settled,
+  waitUntil
 } from '@ember/test-helpers';
 import { registerCustomStyles } from '@frontile/theme';
 import { tv } from 'tailwind-variants';
 import { Popover } from 'frontile/overlays';
 import { on } from '@ember/modifier';
 import { cell } from 'ember-resources';
+
+/**
+ * `Popover` measures width inside a `requestAnimationFrame`, which does not
+ * reliably land within `settled()` on a slow CI runner. Poll for the expected
+ * value, then assert — the assertion still runs after a timeout so a genuine
+ * mismatch reports a readable diff rather than a bare timeout.
+ */
+async function waitForTriggerWidth(
+  content: HTMLElement,
+  expected: string
+): Promise<void> {
+  try {
+    await waitUntil(
+      () => content.style.getPropertyValue('--trigger-width') === expected,
+      { timeout: 2000 }
+    );
+  } catch {
+    // fall through to the assertion for a readable failure
+  }
+}
 
 module(
   'Integration | Component | Popover | @frontile/overlays',
@@ -325,6 +346,7 @@ module(
       await click('[data-test-id="trigger"]');
 
       const content = find('[data-test-id="content"]') as HTMLElement;
+      await waitForTriggerWidth(content, '120px');
       assert.strictEqual(
         content.style.getPropertyValue('--trigger-width'),
         '120px',
@@ -359,6 +381,7 @@ module(
       await click('[data-test-id="trigger"]');
 
       const content = find('[data-test-id="content"]') as HTMLElement;
+      await waitForTriggerWidth(content, '300px');
       assert.strictEqual(
         content.style.getPropertyValue('--trigger-width'),
         '300px',
@@ -439,6 +462,7 @@ module(
       await settled();
 
       const content = find('[data-test-id="content"]') as HTMLElement;
+      await waitForTriggerWidth(content, '250px');
       assert.strictEqual(
         content.style.getPropertyValue('--trigger-width'),
         '250px',

--- a/test-app/tests/integration/components/overlays/popover-test.gts
+++ b/test-app/tests/integration/components/overlays/popover-test.gts
@@ -300,5 +300,150 @@ module(
 
       assert.dom('[data-test-id="content"]').exists();
     });
+    test('trigger width comes from the trigger element by default', async function (assert) {
+      await render(
+        <template>
+          <div style="width: 400px">
+            <Popover as |p|>
+              <button
+                data-test-id="trigger"
+                type="button"
+                style="width: 120px"
+                {{p.trigger}}
+                {{p.anchor}}
+              >
+                Trigger
+              </button>
+              <p.Content data-test-id="content" @size="trigger">
+                Content here
+              </p.Content>
+            </Popover>
+          </div>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+
+      const content = find('[data-test-id="content"]') as HTMLElement;
+      assert.strictEqual(
+        content.style.getPropertyValue('--trigger-width'),
+        '120px',
+        'the trigger element is the width reference'
+      );
+    });
+
+    test('p.measureWidth overrides the trigger as the width reference', async function (assert) {
+      await render(
+        <template>
+          <div style="width: 400px">
+            <Popover as |p|>
+              <div data-test-id="field" {{p.measureWidth}} style="width: 300px">
+                <button
+                  data-test-id="trigger"
+                  type="button"
+                  style="width: 120px"
+                  {{p.trigger}}
+                  {{p.anchor}}
+                >
+                  Trigger
+                </button>
+              </div>
+              <p.Content data-test-id="content" @size="trigger">
+                Content here
+              </p.Content>
+            </Popover>
+          </div>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+
+      const content = find('[data-test-id="content"]') as HTMLElement;
+      assert.strictEqual(
+        content.style.getPropertyValue('--trigger-width'),
+        '300px',
+        'the measured element wins over the trigger, regardless of install order'
+      );
+    });
+
+    test('p.measureWidth keeps precedence when the trigger is resized', async function (assert) {
+      await render(
+        <template>
+          <div style="width: 400px">
+            <Popover as |p|>
+              <div data-test-id="field" {{p.measureWidth}} style="width: 300px">
+                <button
+                  data-test-id="trigger"
+                  type="button"
+                  style="width: 120px"
+                  {{p.trigger}}
+                  {{p.anchor}}
+                >
+                  Trigger
+                </button>
+              </div>
+              <p.Content data-test-id="content" @size="trigger">
+                Content here
+              </p.Content>
+            </Popover>
+          </div>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+
+      // Resizing the trigger must not steal the width back from the measured
+      // element: both modifiers observe their own element, so this would race
+      // without an explicit precedence rule.
+      (find('[data-test-id="trigger"]') as HTMLElement).style.width = '80px';
+      await settled();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await settled();
+
+      const content = find('[data-test-id="content"]') as HTMLElement;
+      assert.strictEqual(
+        content.style.getPropertyValue('--trigger-width'),
+        '300px',
+        'the trigger resize is ignored while measureWidth is installed'
+      );
+    });
+
+    test('p.measureWidth tracks its own element resizing', async function (assert) {
+      await render(
+        <template>
+          <div style="width: 400px">
+            <Popover as |p|>
+              <div data-test-id="field" {{p.measureWidth}} style="width: 300px">
+                <button
+                  data-test-id="trigger"
+                  type="button"
+                  {{p.trigger}}
+                  {{p.anchor}}
+                >
+                  Trigger
+                </button>
+              </div>
+              <p.Content data-test-id="content" @size="trigger">
+                Content here
+              </p.Content>
+            </Popover>
+          </div>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+
+      (find('[data-test-id="field"]') as HTMLElement).style.width = '250px';
+      await settled();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await settled();
+
+      const content = find('[data-test-id="content"]') as HTMLElement;
+      assert.strictEqual(
+        content.style.getPropertyValue('--trigger-width'),
+        '250px',
+        'the measured element is re-measured when it changes size'
+      );
+    });
   }
 );


### PR DESCRIPTION
## Summary

Multi-select `Select` now renders each selected option as a removable `Chip` instead of a comma-joined string, and multiple selection finally gets a real documentation section instead of being buried inside a form-validation example.

```gts
<Select
  @selectionMode="multiple"
  @selectedKeys={{this.selected}}
  @onSelectionChange={{this.onChange}}
  @intent="primary"
/>
```

Chips are the **default** for `@selectionMode="multiple"`. `@selectedItemsDisplay="text"` restores the previous appearance.

## API

| Component | Addition |
| --- | --- |
| `Select` | `@selectedItemsDisplay?: 'chips' \| 'text'` (default `'chips'`) |
| `Select` | `@chip?: SelectChipOptions` — `appearance` (default `faded`), `intent` (defaults to the Select's own `@intent`), `size` (default `sm`), `radius`, `withDot` |
| `Select` | `@classes` gains `chipsField`, `chipsContainer`, `chip` |
| `Popover` | new yielded `measureWidth` modifier |
| `Chip` | new `@closeButtonTabIndex` |
| `@frontile/theme` | `select` gains `chipsField` / `chipsContainer` / `chip` slots and a `hasChips` variant |

## Please look closely at these three

They were **not** in the original plan and each widens shared surface:

1. **`ListManager` (`fix(collections)`)** — `toggleSelectedItem` rebuilt the selection from only the *currently rendered* items, so anything hidden by an active filter was silently discarded, and deselection was blocked too. **This bug pre-dates this branch** — reproduced on a clean `main` worktree with main's own filterable multi-select, no chips involved. The union is deliberately scoped to `multiple` mode so single mode stays bit-identical. Backs Listbox, Select and Autocomplete.
2. **`Popover.measureWidth`** — the chips-mode trigger shrinks to sit beside the chips, so `--trigger-width` (measured from the `{{p.trigger}}` element) made the dropdown too narrow. This lets a popover take its width from a nominated element instead. Strictly additive: every existing consumer co-locates `p.anchor` and `p.trigger` on one element and is unaffected.
3. **`Chip.@closeButtonTabIndex`** — chip close buttons are deliberately out of the tab order, so the combobox is the single tab stop.

## Behaviour worth knowing

- `@allowEmpty` defaults to `false`, so the last remaining chip renders with **no close button** rather than a dead one. `@isClearable` clears everything and ignores `@allowEmpty`.
- Keyboard: the combobox is the only tab stop; **Backspace removes the last chip in both filterable and non-filterable modes**. Close buttons are pointer affordances (`tabindex="-1"`).
- Chips reflect the *selection*, not the filter — a chip stays put while its option is filtered out.
- Chips render in item order, not click order.
- The hidden native `<select>` now receives unfiltered `@items`, so a form submitted mid-filter carries the full value. This also let ~45 lines of label-accumulation heuristic be deleted.

## Testing

870 tests, 867 pass, 3 skip, 0 fail. `pnpm build` clean, type checks clean, `lint:js` 0 errors. Site builds 68 rendered / 0 failed.

**A note on the tests, because it matters here.** Four user-facing bugs shipped past a fully green suite during development — most starkly, the chips trigger was `height: 0` and completely unclickable while every test passed, because `@ember/test-helpers`' `click()` dispatches at an element regardless of whether a user could reach it. Three separate assertions were also found that passed with their implementation deleted.

The new tests were written against that failure mode: the geometry test uses `elementFromPoint` hit-testing rather than `click()`, asserts the trigger shares a flex line with the chips, and makes its own environmental premise self-checking. Every regression test on this branch was confirmed red before its fix.

## Also here

- `docs/superpowers/` is excluded from the site build — working documents were rendering as real pages with a nav tab.
- Migration note in the v0.18 guide for the changed default.

## Separately: a repo bug found in passing, not fixed here

`pnpm lint:hbs --fix` — which `CLAUDE.md`'s pre-commit checklist tells contributors to run — mutates unrelated files, and one autofix **deleted a real `aria-invalid` attribute** from `packages/frontile/src/components/forms/radio.gts`. It was kept out of every commit on this branch and `radio.gts` is intact. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
