### PR TITLE
feat(forms): add a Select <:selectedItem> block for custom selected content

### DIFF
--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -363,6 +363,134 @@ const users = [
 ];
 ```
 
+### Custom Selected Item Content
+
+`<:item>` styles an option **in the dropdown**. To style it once it is **selected**, add a
+`<:selectedItem>` block. It yields the same `{ item, key, label }` the `<:item>` block does,
+so markup moves between the two without being renamed, and it renders in every presentation
+of the selection: inside the single-mode trigger, inside each chip in multiple mode, and once
+per selection under `@selectedItemsDisplay="text"`.
+
+Typically the dropdown row is the rich one — avatar, name and email — while the trigger keeps
+a compact version of it.
+
+> **Note:** `selected.item` is your own entry from `@items`. It is `undefined` for options
+> written out with `<:default>` block syntax, because there is no collection entry behind
+> them; only `key` and `label` are available in that case.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { Select } from 'frontile';
+
+export default class CustomSelectedItem extends Component {
+  @tracked selectedKey: string | null = 'john-doe';
+  @tracked selectedKeys: string[] = ['john-doe', 'jane-smith'];
+
+  onSelectionChange = (key: string | null) => {
+    this.selectedKey = key;
+  };
+
+  onMultipleSelectionChange = (keys: string[]) => {
+    this.selectedKeys = keys;
+  };
+
+  <template>
+    <Select
+      @label='Assignee'
+      @placeholder='Select a user'
+      @items={{people}}
+      @selectedKey={{this.selectedKey}}
+      @onSelectionChange={{this.onSelectionChange}}
+    >
+      <:item as |o|>
+        <o.Item>
+          <div class='flex items-center space-x-4'>
+            <img
+              src='{{o.item.avatar}}'
+              alt=''
+              class='w-10 h-10 rounded-full'
+            />
+            <div>
+              <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
+              <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+            </div>
+          </div>
+        </o.Item>
+      </:item>
+      <:selectedItem as |selected|>
+        <span class='flex items-center space-x-2'>
+          <img src='{{selected.item.avatar}}' alt='' class='w-5 h-5 rounded-full' />
+          <span>{{selected.label}}</span>
+        </span>
+      </:selectedItem>
+    </Select>
+
+    <Select
+      @label='Reviewers'
+      @selectionMode='multiple'
+      @allowEmpty={{true}}
+      @placeholder='Select reviewers'
+      @items={{people}}
+      @selectedKeys={{this.selectedKeys}}
+      @onSelectionChange={{this.onMultipleSelectionChange}}
+      class='mt-6'
+    >
+      <:item as |o|>
+        <o.Item>
+          <div class='flex items-center space-x-4'>
+            <img
+              src='{{o.item.avatar}}'
+              alt=''
+              class='w-10 h-10 rounded-full'
+            />
+            <div>
+              <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
+              <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+            </div>
+          </div>
+        </o.Item>
+      </:item>
+      <:selectedItem as |selected|>
+        <span class='flex items-center space-x-1'>
+          <img src='{{selected.item.avatar}}' alt='' class='w-4 h-4 rounded-full' />
+          <span>{{selected.label}}</span>
+        </span>
+      </:selectedItem>
+    </Select>
+  </template>
+}
+
+const people = [
+  {
+    id: 'john-doe',
+    name: 'John Doe',
+    email: 'john.doe@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=1'
+  },
+  {
+    id: 'jane-smith',
+    name: 'Jane Smith',
+    email: 'jane.smith@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=2'
+  },
+  {
+    id: 'alice-johnson',
+    name: 'Alice Johnson',
+    email: 'alice.johnson@example.com',
+    avatar: 'https://i.pravatar.cc/150?img=3'
+  }
+];
+```
+
+In multiple mode the chip chrome is kept around your content — the appearance, `@chip`
+options and the close button are still the Select's, so removal, `@allowEmpty` and the
+`Backspace` keyboard path keep working unchanged.
+
+The block is not applied to a filterable trigger's own text: an `<input>` cannot hold markup,
+so a filterable Select still shows the selection as text inside the input (the chips beside it
+do use the block).
+
 ### Declarative Items with Named Blocks
 
 You can also define options directly inside the component using block syntax (referred to here as declarative items). In this case, filtering is not available. This example also demonstrates the use of the `@disabledKeys` and `@allowEmpty` options. When `@allowEmpty` is enabled, clicking a selected item will toggle its selection state (i.e. deselect it).
@@ -847,6 +975,7 @@ several pieces:
 | Options    | `role="option"` with `aria-labelledby`, `aria-selected` reflecting selection, and `aria-disabled="true"` on disabled keys                                                                                                          |
 | Form value | A visually hidden native `<select>` mirrors the options, so `@name` submits normally                                                                                                                                               |
 | Chips      | Each chip's close button is named `Remove <label>` with visually hidden text, so the buttons are announced distinctly. The chips sit beside the trigger rather than inside it, so no interactive element is nested in the combobox. The close buttons carry `tabindex="-1"` — see the keyboard model below |
+| `<:selectedItem>` | Supplying the block gives the trigger an explicit `aria-label` — see below |
 
 Keyboard handling comes from the listbox:
 
@@ -879,6 +1008,23 @@ it alone.
 If you set `@chip` or restyle the chips, do not re-enable the close buttons as tab stops
 without also removing this keyboard path — a visual order that disagrees with focus order is
 its own WCAG 2.4.3 problem.
+
+### Naming the trigger with `<:selectedItem>`
+
+Left alone, the single-mode trigger takes its accessible name from its own text — the selected
+label, or the placeholder. A `<:selectedItem>` block owns that text and may render nothing
+readable at all (an avatar, an icon), which would leave the combobox announced as an unnamed
+button.
+
+So whenever the block is supplied, the trigger carries an explicit `aria-label` built from the
+field label (falling back to `@placeholder`, then to `Select options`) and the selected
+options' own text — `Assignee, John Doe` for the example above. You do not have to add
+anything; hiding decorative images from assistive technology (`alt=''`) is enough.
+
+Chips mode is unaffected: the trigger there is already named by `aria-label`, and the chips
+are its siblings, so they are read on their own. Chip close buttons keep taking their
+`Remove <label>` text from the option, never from your block, so a purely graphical chip is
+still removable by name.
 
 ## API
 

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -367,16 +367,21 @@ const users = [
 
 `<:item>` styles an option **in the dropdown**. To style it once it is **selected**, add a
 `<:selectedItem>` block. It yields the same `{ item, key, label }` the `<:item>` block does,
-so markup moves between the two without being renamed, and it renders in every presentation
-of the selection: inside the single-mode trigger, inside each chip in multiple mode, and once
-per selection under `@selectedItemsDisplay="text"`.
+so markup moves between the two without being renamed, and it renders wherever the selection
+is drawn as markup: inside the single-mode trigger, inside each chip in multiple mode, and
+once per selection under `@selectedItemsDisplay="text"`.
 
 Typically the dropdown row is the rich one — avatar, name and email — while the trigger keeps
 a compact version of it.
 
 > **Note:** `selected.item` is your own entry from `@items`. It is `undefined` for options
 > written out with `<:default>` block syntax, because there is no collection entry behind
-> them; only `key` and `label` are available in that case.
+> them; only `key` and `label` are available in that case — so guard on it, as the demo
+> below does, before reaching into your own object.
+
+> **Note:** A **filterable** Select's trigger is an `<input>`, which cannot hold markup, so
+> the block does not render there: a filterable Select still shows the selection as plain
+> text inside the input. The chips beside that input do use the block.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -420,7 +425,13 @@ export default class CustomSelectedItem extends Component {
       </:item>
       <:selectedItem as |selected|>
         <span class='flex items-center space-x-2'>
-          <img src='{{selected.item.avatar}}' alt='' class='w-5 h-5 rounded-full' />
+          {{#if selected.item}}
+            <img
+              src='{{selected.item.avatar}}'
+              alt=''
+              class='w-5 h-5 rounded-full'
+            />
+          {{/if}}
           <span>{{selected.label}}</span>
         </span>
       </:selectedItem>
@@ -453,7 +464,13 @@ export default class CustomSelectedItem extends Component {
       </:item>
       <:selectedItem as |selected|>
         <span class='flex items-center space-x-1'>
-          <img src='{{selected.item.avatar}}' alt='' class='w-4 h-4 rounded-full' />
+          {{#if selected.item}}
+            <img
+              src='{{selected.item.avatar}}'
+              alt=''
+              class='w-4 h-4 rounded-full'
+            />
+          {{/if}}
           <span>{{selected.label}}</span>
         </span>
       </:selectedItem>
@@ -486,10 +503,6 @@ const people = [
 In multiple mode the chip chrome is kept around your content — the appearance, `@chip`
 options and the close button are still the Select's, so removal, `@allowEmpty` and the
 `Backspace` keyboard path keep working unchanged.
-
-The block is not applied to a filterable trigger's own text: an `<input>` cannot hold markup,
-so a filterable Select still shows the selection as text inside the input (the chips beside it
-do use the block).
 
 ### Declarative Items with Named Blocks
 
@@ -975,7 +988,7 @@ several pieces:
 | Options    | `role="option"` with `aria-labelledby`, `aria-selected` reflecting selection, and `aria-disabled="true"` on disabled keys                                                                                                          |
 | Form value | A visually hidden native `<select>` mirrors the options, so `@name` submits normally                                                                                                                                               |
 | Chips      | Each chip's close button is named `Remove <label>` with visually hidden text, so the buttons are announced distinctly. The chips sit beside the trigger rather than inside it, so no interactive element is nested in the combobox. The close buttons carry `tabindex="-1"` — see the keyboard model below |
-| `<:selectedItem>` | Supplying the block gives the trigger an explicit `aria-label` — see below |
+| `<:selectedItem>` | Supplying the block gives the **button** trigger an explicit `aria-label` composed from the field label and the option's text — see below |
 
 Keyboard handling comes from the listbox:
 
@@ -1016,10 +1029,27 @@ label, or the placeholder. A `<:selectedItem>` block owns that text and may rend
 readable at all (an avatar, an icon), which would leave the combobox announced as an unnamed
 button.
 
-So whenever the block is supplied, the trigger carries an explicit `aria-label` built from the
-field label (falling back to `@placeholder`, then to `Select options`) and the selected
-options' own text — `Assignee, John Doe` for the example above. You do not have to add
-anything; hiding decorative images from assistive technology (`alt=''`) is enough.
+So whenever the block is supplied, the **button** trigger carries an explicit `aria-label`
+composed from two halves: the field label (falling back to `@placeholder`) and the selected
+options' own text — `Assignee, John Doe` for the example above. Either half on its own is used
+alone when the other is missing, so the name is never `Assignee, ` and never prefixes the
+selection with the untranslatable `Select options`.
+
+**This name replaces whatever your block renders, so keep the two in agreement.** If your
+block's visible text is the option's `label`, they already agree and there is nothing to do —
+hiding decorative images from assistive technology (`alt=''`) is enough. If your block shows
+something *else* — an email address, an abbreviation, an initial — then the announced name and
+the visible text disagree, which fails WCAG 2.5.3 *Label in Name* and leaves speech-input
+users unable to say what they see. In that case, render the option's `label` somewhere in the
+block, or set `@label` / `@placeholder` to the wording that is actually visible.
+
+> **Note:** `aria-label` passed to `<Select>` itself does **not** override this. Attributes on
+> `<Select>` land on the field's wrapper element, not on the combobox, so the composed name is
+> what the trigger announces either way. The block's own text is the lever you have.
+
+A **filterable** Select is not affected at all: its trigger is an `<input>` whose value is the
+selection as text, so it is already named by that value and gets no `aria-label` — one that
+duplicated the value would also change as the user typed.
 
 Chips mode is unaffected: the trigger there is already named by `aria-label`, and the chips
 are its siblings, so they are read on their own. Chip close buttons keep taking their

--- a/packages/frontile/src/components/forms/select/select.gts
+++ b/packages/frontile/src/components/forms/select/select.gts
@@ -511,15 +511,30 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
    *   the combobox announced as an unnamed button. The selection is not
    *   readable anywhere else in that case, so the name carries it: the control
    *   name *and* the selected options' text.
+   *
+   * The two halves are composed so that the separator only appears when both
+   * are there. A selected key with no registered option behind it resolves to
+   * no text at all, and `"Owner, "` is announced as "Owner comma"; and with
+   * neither `@label` nor `@placeholder` the only control name available is the
+   * hardcoded, unlocalizable `Select options`, so the selected text is left to
+   * name the control on its own rather than be prefixed by English.
    */
   get triggerAccessibleName(): string {
-    const name = this.args.label || this.args.placeholder || 'Select options';
+    const name = this.args.label || this.args.placeholder;
 
-    if (this.showChips || !this.hasSelection) {
-      return name;
+    // Chips mode names the *control* only -- the chips are read separately --
+    // and has no better fallback than the literal.
+    if (this.showChips) {
+      return name || 'Select options';
     }
 
-    return `${name}, ${this.selectedTextValue}`;
+    const selectedText = this.hasSelection ? this.selectedTextValue : '';
+
+    if (!name) {
+      return selectedText || 'Select options';
+    }
+
+    return selectedText ? `${name}, ${selectedText}` : name;
   }
 
   /**

--- a/packages/frontile/src/components/forms/select/select.gts
+++ b/packages/frontile/src/components/forms/select/select.gts
@@ -31,7 +31,8 @@ import type {
   SelectArgs,
   SelectChipOptions,
   SelectSignature,
-  SelectedItem
+  SelectedItem,
+  SelectedItemBlockArg
 } from './types';
 
 // Import helper function directly instead of using ember-truth-helpers
@@ -493,16 +494,32 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
   }
 
   /**
-   * The accessible name for the trigger while chips are shown.
+   * The accessible name for the trigger when its own text cannot supply one.
    *
-   * In every other mode the trigger names itself from its own text -- the
-   * selected label, or the placeholder. In chips mode it renders nothing (the
-   * chips are its siblings, so they are read separately), which would leave the
-   * combobox announced as an unnamed button. This names the *control*, never the
-   * selection.
+   * Left to itself the trigger names itself from its own text -- the selected
+   * label, or the placeholder -- and that is still what happens in the plain
+   * case; see the trigger, which only applies this when it has to.
+   *
+   * Two cases need it:
+   *
+   * - **Chips mode.** The trigger renders nothing; the chips are its siblings
+   *   and are read separately. Naming the *control* is both enough and
+   *   correct here -- appending the selection would have it read twice -- so
+   *   this returns the bare name.
+   * - **A `:selectedItem` block.** The block owns the trigger's content and may
+   *   render nothing readable at all (an avatar, an icon), which would leave
+   *   the combobox announced as an unnamed button. The selection is not
+   *   readable anywhere else in that case, so the name carries it: the control
+   *   name *and* the selected options' text.
    */
   get triggerAccessibleName(): string {
-    return this.args.label || this.args.placeholder || 'Select options';
+    const name = this.args.label || this.args.placeholder || 'Select options';
+
+    if (this.showChips || !this.hasSelection) {
+      return name;
+    }
+
+    return `${name}, ${this.selectedTextValue}`;
   }
 
   /**
@@ -721,6 +738,10 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
               }}
             >
               {{#if (and this.showChips this.hasSelection)}}
+                {{! A block cannot be passed conditionally in Glimmer, so the
+                :item block below is always supplied and the branch lives
+                inside it: with no :selectedItem block from the consumer, both
+                it and the trigger render exactly what they rendered before. }}
                 <SelectedChips
                   @containerRef={{this.chipsContainerRef.setup}}
                   @items={{this.selectedItems}}
@@ -730,7 +751,15 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                   @isDisabled={{@isDisabled}}
                   @isRemovable={{this.chipsRemovable}}
                   @onRemove={{this.removeSelectedKey}}
-                />
+                >
+                  <:item as |selected|>
+                    {{~#if (has-block "selectedItem")~}}
+                      {{~yield selected to="selectedItem"~}}
+                    {{~else~}}
+                      {{~selected.label~}}
+                    {{~/if~}}
+                  </:item>
+                </SelectedChips>
               {{/if}}
               <SelectTrigger
                 @isFilterable={{@isFilterable}}
@@ -750,7 +779,16 @@ class Select<T = unknown> extends Component<SelectSignature<T>> {
                 @onFilterKeydown={{this.handleFilterKeydown}}
                 @onKeydown={{this.handleTriggerKeydown}}
                 @onBlur={{this.handleBlur}}
-              />
+                @hasCustomContent={{has-block "selectedItem"}}
+              >
+                <:selectedItem as |selected|>
+                  {{~#if (has-block "selectedItem")~}}
+                    {{~yield selected to="selectedItem"~}}
+                  {{~else~}}
+                    {{~selected.label~}}
+                  {{~/if~}}
+                </:selectedItem>
+              </SelectTrigger>
             </div>
             <SelectEndContent
               @classes={{this.classes}}
@@ -837,6 +875,7 @@ export {
   Select,
   type SelectSignature,
   type SelectChipOptions,
-  type SelectedItem
+  type SelectedItem,
+  type SelectedItemBlockArg
 };
 export default Select;

--- a/packages/frontile/src/components/forms/select/selected-items.gts
+++ b/packages/frontile/src/components/forms/select/selected-items.gts
@@ -6,7 +6,8 @@ import { Chip } from '../../buttons/chip';
 import type {
   ResolvedSelectChipOptions,
   SelectClasses,
-  SelectedItem
+  SelectedItem,
+  SelectedItemBlockArg
 } from './types';
 
 /**
@@ -16,10 +17,46 @@ import type {
 const joinTextValues = (items: SelectedItem[]): string =>
   items.map((item) => item.textValue).join(', ');
 
+/**
+ * Maps the internal {@link SelectedItem} projection onto what the `:item`
+ * block here -- and, through it, the Select's `:selectedItem` block -- is
+ * handed: `{ item, key, label }`, the same shape the `:item` block of the
+ * listbox yields, so markup moves between the two unchanged.
+ *
+ * `item` is `unknown` at this level (it comes off the registered option
+ * nodes), so it is typed `never` to stay assignable to the consumer's own `T`
+ * when Select re-yields it. It is optional either way: an option written in
+ * block form has no collection entry behind it.
+ */
+const toBlockArg = (item: SelectedItem): SelectedItemBlockArg<never> => ({
+  item: item.item as never,
+  key: item.key,
+  label: item.textValue
+});
+
+/** Whether a comma separator is needed before this selection. */
+const isNotFirst = (index: number): boolean => index > 0;
+
 interface SelectedTextSignature {
   Args: {
     /** The selection, in item order. */
     items: SelectedItem[];
+
+    /**
+     * Whether the `:item` block is the consumer's own content rather than the
+     * fallback the Select fills it with.
+     *
+     * A block cannot be passed conditionally in Glimmer, so the Select always
+     * supplies one; this is how the plain presentation stays *exactly* what it
+     * was -- the whole selection as one joined string in a single text node --
+     * instead of becoming a per-item loop that merely renders the same
+     * characters.
+     */
+    hasCustomContent?: boolean;
+  };
+  Blocks: {
+    /** Content for one selected option, in place of its text. */
+    item: [SelectedItemBlockArg<never>];
   };
   Element: HTMLSpanElement;
 }
@@ -33,7 +70,14 @@ interface SelectedTextSignature {
  */
 const SelectedText: TOC<SelectedTextSignature> = <template>
   <span ...attributes>
-    {{joinTextValues @items}}
+    {{#if @hasCustomContent}}
+      {{#each @items key="key" as |item index|}}
+        {{~#if (isNotFirst index)}}, {{/if~}}
+        {{~yield (toBlockArg item) to="item"~}}
+      {{/each}}
+    {{else}}
+      {{joinTextValues @items}}
+    {{/if}}
   </span>
 </template>;
 
@@ -62,6 +106,14 @@ interface SelectedChipsSignature {
 
     onRemove: (key: string) => void;
   };
+  Blocks: {
+    /**
+     * The body of one chip, in place of the option's text. The chip chrome --
+     * its appearance, its dot and its close button -- is not the block's to
+     * replace, so it stays put around whatever is rendered here.
+     */
+    item: [SelectedItemBlockArg<never>];
+  };
   Element: HTMLDivElement;
 }
 
@@ -72,6 +124,9 @@ interface SelectedChipsSignature {
  * The close buttons are deliberately outside the tab order
  * (`@closeButtonTabIndex="-1"`) so the trigger keeps the first Tab stop in the
  * field; Backspace on the field is the keyboard route to removal.
+ *
+ * The close button's title is built from `textValue`, never from the block, so
+ * a chip whose body is purely graphical is still announced as "Remove <label>".
  */
 const SelectedChips: TOC<SelectedChipsSignature> = <template>
   <div
@@ -95,7 +150,7 @@ const SelectedChips: TOC<SelectedChipsSignature> = <template>
         @closeButtonTabIndex="-1"
         @onClose={{if @isRemovable (fn @onRemove item.key)}}
       >
-        {{item.textValue}}
+        {{yield (toBlockArg item) to="item"}}
       </Chip>
     {{/each}}
   </div>

--- a/packages/frontile/src/components/forms/select/trigger.gts
+++ b/packages/frontile/src/components/forms/select/trigger.gts
@@ -3,9 +3,14 @@ import type { TOC } from '@ember/component/template-only';
 import type { ModifierLike } from '@glint/template';
 import type { SlotsToClasses, SelectSlots } from '@frontile/theme';
 import { SelectedText } from './selected-items';
-import type { SelectClasses, SelectedItem } from './types';
+import type {
+  SelectClasses,
+  SelectedItem,
+  SelectedItemBlockArg
+} from './types';
 
 const and = (a: unknown, b: unknown) => Boolean(a) && Boolean(b);
+const or = (a: unknown, b: unknown) => Boolean(a) || Boolean(b);
 const valueUnless = <T,>(condition: unknown, value: T): T | undefined =>
   condition ? undefined : value;
 
@@ -29,11 +34,24 @@ interface SelectTriggerSignature {
     showChips: boolean;
 
     /**
-     * Names the *control* while chips are shown. In chips mode the trigger
-     * renders no text of its own, so without this the combobox would be
-     * announced unnamed.
+     * Names the trigger when its own text cannot.
+     *
+     * In chips mode the trigger renders no text of its own (the chips are its
+     * siblings and are read separately), so without this the combobox would be
+     * announced unnamed. The same is true whenever `@hasCustomContent` is set:
+     * the block may render nothing readable at all.
      */
     accessibleName: string;
+
+    /**
+     * Whether the consumer supplied a `:selectedItem` block, i.e. whether the
+     * text inside the trigger is theirs rather than the option's label.
+     *
+     * Two things hang off this: the trigger stops trusting its own text
+     * content for its accessible name, and {@link SelectedText} switches from
+     * the joined string to a per-selection loop.
+     */
+    hasCustomContent?: boolean;
 
     placeholder?: string;
     hasSelection: boolean;
@@ -51,6 +69,15 @@ interface SelectTriggerSignature {
     onFilterKeydown: (event: KeyboardEvent) => void;
     onKeydown: (event: KeyboardEvent) => void;
     onBlur: () => void;
+  };
+  Blocks: {
+    /**
+     * Content for one selected option, forwarded straight through to
+     * {@link SelectedText}. Always supplied by the Select -- a block cannot be
+     * passed conditionally -- so `@hasCustomContent` is what says whether it
+     * holds the consumer's markup or the plain-label fallback.
+     */
+    selectedItem: [SelectedItemBlockArg<never>];
   };
 }
 
@@ -71,7 +98,7 @@ const SelectTrigger: TOC<SelectTriggerSignature> = <template>
       data-test-id="trigger"
       data-component="select-trigger"
       disabled={{@isDisabled}}
-      aria-label={{if @showChips @accessibleName}}
+      aria-label={{if (or @showChips @hasCustomContent) @accessibleName}}
       placeholder={{valueUnless (and @showChips @hasSelection) @placeholder}}
       class={{@classes.input
         class=@userClasses.input
@@ -92,7 +119,7 @@ const SelectTrigger: TOC<SelectTriggerSignature> = <template>
       data-test-id="trigger"
       data-component="select-trigger"
       disabled={{@isDisabled}}
-      aria-label={{if @showChips @accessibleName}}
+      aria-label={{if (or @showChips @hasCustomContent) @accessibleName}}
       class={{@classes.input
         class=@userClasses.input
         hasStartContent=@hasStartContent
@@ -104,7 +131,12 @@ const SelectTrigger: TOC<SelectTriggerSignature> = <template>
     >
       {{#if @hasSelection}}
         {{#unless @showChips}}
-          <SelectedText @items={{@items}} />
+          <SelectedText
+            @items={{@items}}
+            @hasCustomContent={{@hasCustomContent}}
+          >
+            <:item as |selected|>{{yield selected to="selectedItem"}}</:item>
+          </SelectedText>
         {{/unless}}
       {{else}}
         <span class={{@classes.placeholder class=@userClasses.placeholder}}>

--- a/packages/frontile/src/components/forms/select/trigger.gts
+++ b/packages/frontile/src/components/forms/select/trigger.gts
@@ -47,9 +47,11 @@ interface SelectTriggerSignature {
      * Whether the consumer supplied a `:selectedItem` block, i.e. whether the
      * text inside the trigger is theirs rather than the option's label.
      *
-     * Two things hang off this: the trigger stops trusting its own text
-     * content for its accessible name, and {@link SelectedText} switches from
-     * the joined string to a per-selection loop.
+     * Two things hang off this: the `<button>` trigger stops trusting its own
+     * text content for its accessible name, and {@link SelectedText} switches
+     * from the joined string to a per-selection loop. The filterable
+     * `<input>` trigger ignores it -- the block never renders there, so the
+     * input's own value still names it.
      */
     hasCustomContent?: boolean;
 
@@ -91,6 +93,11 @@ interface SelectTriggerSignature {
  */
 const SelectTrigger: TOC<SelectTriggerSignature> = <template>
   {{#if @isFilterable}}
+    {{! The filterable trigger is an input: the selectedItem block cannot
+    render here, so the input always has its own value as its accessible text.
+    Naming it from the selection as well would duplicate that value and make
+    the combobox name change as the user types, so only chips mode, where the
+    input shows nothing of the selection, names it. }}
     <input
       type="text"
       {{@trigger}}
@@ -98,7 +105,7 @@ const SelectTrigger: TOC<SelectTriggerSignature> = <template>
       data-test-id="trigger"
       data-component="select-trigger"
       disabled={{@isDisabled}}
-      aria-label={{if (or @showChips @hasCustomContent) @accessibleName}}
+      aria-label={{if @showChips @accessibleName}}
       placeholder={{valueUnless (and @showChips @hasSelection) @placeholder}}
       class={{@classes.input
         class=@userClasses.input

--- a/packages/frontile/src/components/forms/select/types.ts
+++ b/packages/frontile/src/components/forms/select/types.ts
@@ -32,6 +32,30 @@ interface SelectedItem {
 }
 
 /**
+ * What the `:selectedItem` block is handed for one selected option.
+ *
+ * Deliberately the same `{ item, key, label }` shape the `:item` block yields,
+ * so markup can move between the two blocks without being renamed. It is the
+ * public face of {@link SelectedItem}: `label` is that projection's
+ * `textValue`.
+ */
+interface SelectedItemBlockArg<T = unknown> {
+  /**
+   * The entry of `@items` this selection came from.
+   *
+   * Undefined for an option written out in block form rather than rendered
+   * from `@items` -- there is no collection entry behind it, so only `key` and
+   * `label` are available there.
+   */
+  item?: T;
+
+  key: string;
+
+  /** The option's text, i.e. what would be rendered without this block. */
+  label: string;
+}
+
+/**
  * Appearance options forwarded to the {@link Chip} rendered for each selected
  * option in multiple selection mode. Derived from {@link ChipSignature} so the
  * two can never drift apart; see {@link MultipleSelectArgs.chip} for the
@@ -428,6 +452,35 @@ interface SelectSignature<T> {
      * If `hideEmptyContent` argument is true, this content will not be shown.
      */
     emptyContent: [];
+
+    /**
+     * Custom content for each *selected* option, in place of its plain text.
+     *
+     * Renders in every presentation of the selection: inside the single-mode
+     * trigger, inside each chip in multiple mode (the chip chrome, `@chip`
+     * options and close button are kept), and once per selection --
+     * comma-separated -- under `@selectedItemsDisplay="text"`.
+     *
+     * Yields the same `{ item, key, label }` the `:item` block does, so the
+     * same markup works in both. `item` is undefined for options written in
+     * block form rather than rendered from `@items`.
+     *
+     * Because a block rendering only graphics would otherwise leave the
+     * single-mode trigger with no accessible name, supplying this block also
+     * gives the trigger a guaranteed `aria-label` built from the field label
+     * and the selected options' text.
+     *
+     * @example
+     * ```gts
+     * <Select @items={{this.users}} as |s|>
+     *   <:selectedItem as |selected|>
+     *     <Avatar @src={{selected.item.avatar}} />
+     *     {{selected.label}}
+     *   </:selectedItem>
+     * </Select>
+     * ```
+     */
+    selectedItem: [SelectedItemBlockArg<T>];
   };
 }
 
@@ -454,6 +507,7 @@ export {
   type SelectClasses,
   type ResolvedSelectChipOptions,
   type SelectedItem,
+  type SelectedItemBlockArg,
   type SelectChipOptions,
   type BaseSelectArgs,
   type ExplicitSingleSelectArgs,

--- a/packages/frontile/src/components/forms/select/types.ts
+++ b/packages/frontile/src/components/forms/select/types.ts
@@ -456,10 +456,14 @@ interface SelectSignature<T> {
     /**
      * Custom content for each *selected* option, in place of its plain text.
      *
-     * Renders in every presentation of the selection: inside the single-mode
-     * trigger, inside each chip in multiple mode (the chip chrome, `@chip`
-     * options and close button are kept), and once per selection --
+     * Renders wherever the selection is drawn as markup: inside the
+     * single-mode trigger, inside each chip in multiple mode (the chip chrome,
+     * `@chip` options and close button are kept), and once per selection --
      * comma-separated -- under `@selectedItemsDisplay="text"`.
+     *
+     * **Not** inside a filterable trigger: that is an `<input>`, which cannot
+     * hold markup, so a filterable Select still shows the selection as plain
+     * text there. The chips beside the input do use the block.
      *
      * Yields the same `{ item, key, label }` the `:item` block does, so the
      * same markup works in both. `item` is undefined for options written in
@@ -467,8 +471,11 @@ interface SelectSignature<T> {
      *
      * Because a block rendering only graphics would otherwise leave the
      * single-mode trigger with no accessible name, supplying this block also
-     * gives the trigger a guaranteed `aria-label` built from the field label
-     * and the selected options' text.
+     * gives that (button) trigger an `aria-label` composed from the field
+     * label and the selected options' text. That name replaces what the block
+     * renders, so a block whose visible text is not the option's `label`
+     * should carry the label too, or set `@label`/`@placeholder` to the
+     * wording that is visible -- see the guide.
      *
      * @example
      * ```gts

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -17380,7 +17380,7 @@ const data: ComponentDoc[] = [
         isRequired: true,
         isInternal: false,
         description:
-          '<p>Custom content for each <em>selected</em> option, in place of its plain text.</p>\n<p>Renders in every presentation of the selection: inside the single-mode\ntrigger, inside each chip in multiple mode (the chip chrome, <code>@chip</code>\noptions and close button are kept), and once per selection --\ncomma-separated -- under <code>@selectedItemsDisplay="text"</code>.</p>\n<p>Yields the same <code>{ item, key, label }</code> the <code>:item</code> block does, so the\nsame markup works in both. <code>item</code> is undefined for options written in\nblock form rather than rendered from <code>@items</code>.</p>\n<p>Because a block rendering only graphics would otherwise leave the\nsingle-mode trigger with no accessible name, supplying this block also\ngives the trigger a guaranteed <code>aria-label</code> built from the field label\nand the selected options\' text.</p>',
+          '<p>Custom content for each <em>selected</em> option, in place of its plain text.</p>\n<p>Renders wherever the selection is drawn as markup: inside the\nsingle-mode trigger, inside each chip in multiple mode (the chip chrome,\n<code>@chip</code> options and close button are kept), and once per selection --\ncomma-separated -- under <code>@selectedItemsDisplay="text"</code>.</p>\n<p><strong>Not</strong> inside a filterable trigger: that is an <code>&#x3C;input></code>, which cannot\nhold markup, so a filterable Select still shows the selection as plain\ntext there. The chips beside the input do use the block.</p>\n<p>Yields the same <code>{ item, key, label }</code> the <code>:item</code> block does, so the\nsame markup works in both. <code>item</code> is undefined for options written in\nblock form rather than rendered from <code>@items</code>.</p>\n<p>Because a block rendering only graphics would otherwise leave the\nsingle-mode trigger with no accessible name, supplying this block also\ngives that (button) trigger an <code>aria-label</code> composed from the field\nlabel and the selected options\' text. That name replaces what the block\nrenders, so a block whose visible text is not the option\'s <code>label</code>\nshould carry the label too, or set <code>@label</code>/<code>@placeholder</code> to the\nwording that is visible -- see the guide.</p>',
         tags: {
           example: { name: 'example', value: '```gts\n<Select' },
           items: {
@@ -17860,7 +17860,7 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          "<p>Whether the consumer supplied a <code>:selectedItem</code> block, i.e. whether the\ntext inside the trigger is theirs rather than the option's label.</p>\n<p>Two things hang off this: the trigger stops trusting its own text\ncontent for its accessible name, and {@link SelectedText } switches from\nthe joined string to a per-selection loop.</p>",
+          "<p>Whether the consumer supplied a <code>:selectedItem</code> block, i.e. whether the\ntext inside the trigger is theirs rather than the option's label.</p>\n<p>Two things hang off this: the <code>&#x3C;button></code> trigger stops trusting its own\ntext content for its accessible name, and {@link SelectedText } switches\nfrom the joined string to a per-selection loop. The filterable\n<code>&#x3C;input></code> trigger ignores it -- the block never renders there, so the\ninput's own value still names it.</p>",
         tags: {},
       },
       {

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -17330,6 +17330,71 @@ const data: ComponentDoc[] = [
           'The content to display when there are no available options.\nIf <code>hideEmptyContent</code> argument is true, this content will not be shown.',
         tags: {},
       },
+      {
+        identifier: 'selectedItem',
+        type: {
+          type: '<span class="hljs-title class_">Array</span>',
+          raw: '[<span class="hljs-title class_">SelectedItemBlockArg</span>&#x3C;T>]',
+          items: [
+            {
+              identifier: '0',
+              type: {
+                type: '<span class="hljs-title class_">Object</span>',
+                items: [
+                  {
+                    identifier: 'item',
+                    type: { type: 'T' },
+                    isRequired: false,
+                    isInternal: false,
+                    description:
+                      'The entry of `@items` this selection came from.\n\nUndefined for an option written out in block form rather than rendered\nfrom `@items` -- there is no collection entry behind it, so only `key` and\n`label` are available there.',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'key',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'label',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description:
+                      "The option's text, i.e. what would be rendered without this block.",
+                    tags: {},
+                  },
+                ],
+              },
+              isRequired: true,
+              isInternal: false,
+              description:
+                "What the `:selectedItem` block is handed for one selected option.\n\nDeliberately the same `{ item, key, label }` shape the `:item` block yields,\nso markup can move between the two blocks without being renamed. It is the\npublic face of {@link SelectedItem}: `label` is that projection's\n`textValue`.",
+              tags: {},
+            },
+          ],
+        },
+        isRequired: true,
+        isInternal: false,
+        description:
+          '<p>Custom content for each <em>selected</em> option, in place of its plain text.</p>\n<p>Renders in every presentation of the selection: inside the single-mode\ntrigger, inside each chip in multiple mode (the chip chrome, <code>@chip</code>\noptions and close button are kept), and once per selection --\ncomma-separated -- under <code>@selectedItemsDisplay="text"</code>.</p>\n<p>Yields the same <code>{ item, key, label }</code> the <code>:item</code> block does, so the\nsame markup works in both. <code>item</code> is undefined for options written in\nblock form rather than rendered from <code>@items</code>.</p>\n<p>Because a block rendering only graphics would otherwise leave the\nsingle-mode trigger with no accessible name, supplying this block also\ngives the trigger a guaranteed <code>aria-label</code> built from the field label\nand the selected options\' text.</p>',
+        tags: {
+          example: { name: 'example', value: '```gts\n<Select' },
+          items: {
+            name: 'items',
+            value:
+              '={{this.users}} as |s|>\n<:selectedItem as |selected|>\n<Avatar',
+          },
+          src: {
+            name: 'src',
+            value:
+              '={{selected.item.avatar}} />\n{{selected.label}}\n</:selectedItem>\n</Select>\n```',
+          },
+        },
+      },
     ],
     Element: {
       identifier: 'Element',
@@ -17359,8 +17424,70 @@ const data: ComponentDoc[] = [
         description: 'The selection, in item order.',
         tags: {},
       },
+      {
+        identifier: 'hasCustomContent',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description:
+          "<p>Whether the <code>:item</code> block is the consumer's own content rather than the\nfallback the Select fills it with.</p>\n<p>A block cannot be passed conditionally in Glimmer, so the Select always\nsupplies one; this is how the plain presentation stays <em>exactly</em> what it\nwas -- the whole selection as one joined string in a single text node --\ninstead of becoming a per-item loop that merely renders the same\ncharacters.</p>",
+        tags: {},
+      },
     ],
-    Blocks: [],
+    Blocks: [
+      {
+        identifier: 'item',
+        type: {
+          type: '<span class="hljs-title class_">Array</span>',
+          raw: '[<span class="hljs-title class_">SelectedItemBlockArg</span>&#x3C;<span class="hljs-built_in">never</span>>]',
+          items: [
+            {
+              identifier: '0',
+              type: {
+                type: '<span class="hljs-title class_">Object</span>',
+                items: [
+                  {
+                    identifier: 'item',
+                    type: { type: '<span class="hljs-built_in">never</span>' },
+                    isRequired: false,
+                    isInternal: false,
+                    description:
+                      'The entry of `@items` this selection came from.\n\nUndefined for an option written out in block form rather than rendered\nfrom `@items` -- there is no collection entry behind it, so only `key` and\n`label` are available there.',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'key',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'label',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description:
+                      "The option's text, i.e. what would be rendered without this block.",
+                    tags: {},
+                  },
+                ],
+              },
+              isRequired: true,
+              isInternal: false,
+              description:
+                "What the `:selectedItem` block is handed for one selected option.\n\nDeliberately the same `{ item, key, label }` shape the `:item` block yields,\nso markup can move between the two blocks without being renamed. It is the\npublic face of {@link SelectedItem}: `label` is that projection's\n`textValue`.",
+              tags: {},
+            },
+          ],
+        },
+        isRequired: true,
+        isInternal: false,
+        description: 'Content for one selected option, in place of its text.',
+        tags: {},
+      },
+    ],
     Element: {
       identifier: 'Element',
       type: { type: '<span class="hljs-title class_">HTMLSpanElement</span>' },
@@ -17526,7 +17653,61 @@ const data: ComponentDoc[] = [
         tags: {},
       },
     ],
-    Blocks: [],
+    Blocks: [
+      {
+        identifier: 'item',
+        type: {
+          type: '<span class="hljs-title class_">Array</span>',
+          raw: '[<span class="hljs-title class_">SelectedItemBlockArg</span>&#x3C;<span class="hljs-built_in">never</span>>]',
+          items: [
+            {
+              identifier: '0',
+              type: {
+                type: '<span class="hljs-title class_">Object</span>',
+                items: [
+                  {
+                    identifier: 'item',
+                    type: { type: '<span class="hljs-built_in">never</span>' },
+                    isRequired: false,
+                    isInternal: false,
+                    description:
+                      'The entry of `@items` this selection came from.\n\nUndefined for an option written out in block form rather than rendered\nfrom `@items` -- there is no collection entry behind it, so only `key` and\n`label` are available there.',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'key',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'label',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description:
+                      "The option's text, i.e. what would be rendered without this block.",
+                    tags: {},
+                  },
+                ],
+              },
+              isRequired: true,
+              isInternal: false,
+              description:
+                "What the `:selectedItem` block is handed for one selected option.\n\nDeliberately the same `{ item, key, label }` shape the `:item` block yields,\nso markup can move between the two blocks without being renamed. It is the\npublic face of {@link SelectedItem}: `label` is that projection's\n`textValue`.",
+              tags: {},
+            },
+          ],
+        },
+        isRequired: true,
+        isInternal: false,
+        description:
+          "The body of one chip, in place of the option's text. The chip chrome --\nits appearance, its dot and its close button -- is not the block's to\nreplace, so it stays put around whatever is rendered here.",
+        tags: {},
+      },
+    ],
     Element: {
       identifier: 'Element',
       type: { type: '<span class="hljs-title class_">HTMLDivElement</span>' },
@@ -17534,7 +17715,7 @@ const data: ComponentDoc[] = [
       url: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement',
     },
     description:
-      '<p>The selection presented as a row of removable {@link Chip }s beside the\ntrigger.</p>\n<p>The close buttons are deliberately outside the tab order\n(<code>@closeButtonTabIndex="-1"</code>) so the trigger keeps the first Tab stop in the\nfield; Backspace on the field is the keyboard route to removal.</p>',
+      '<p>The selection presented as a row of removable {@link Chip }s beside the\ntrigger.</p>\n<p>The close buttons are deliberately outside the tab order\n(<code>@closeButtonTabIndex="-1"</code>) so the trigger keeps the first Tab stop in the\nfield; Backspace on the field is the keyboard route to removal.</p>\n<p>The close button\'s title is built from <code>textValue</code>, never from the block, so\na chip whose body is purely graphical is still announced as "Remove ".</p>',
     tags: {},
   },
   {
@@ -17550,7 +17731,7 @@ const data: ComponentDoc[] = [
         isRequired: true,
         isInternal: false,
         description:
-          'Names the <em>control</em> while chips are shown. In chips mode the trigger\nrenders no text of its own, so without this the combobox would be\nannounced unnamed.',
+          '<p>Names the trigger when its own text cannot.</p>\n<p>In chips mode the trigger renders no text of its own (the chips are its\nsiblings and are read separately), so without this the combobox would be\nannounced unnamed. The same is true whenever <code>@hasCustomContent</code> is set:\nthe block may render nothing readable at all.</p>',
         tags: {},
       },
       {
@@ -17674,6 +17855,15 @@ const data: ComponentDoc[] = [
         tags: {},
       },
       {
+        identifier: 'hasCustomContent',
+        type: { type: '<span class="hljs-built_in">boolean</span>' },
+        isRequired: false,
+        isInternal: false,
+        description:
+          "<p>Whether the consumer supplied a <code>:selectedItem</code> block, i.e. whether the\ntext inside the trigger is theirs rather than the option's label.</p>\n<p>Two things hang off this: the trigger stops trusting its own text\ncontent for its accessible name, and {@link SelectedText } switches from\nthe joined string to a per-selection loop.</p>",
+        tags: {},
+      },
+      {
         identifier: 'isDisabled',
         type: { type: '<span class="hljs-built_in">boolean</span>' },
         isRequired: false,
@@ -17709,7 +17899,61 @@ const data: ComponentDoc[] = [
         tags: {},
       },
     ],
-    Blocks: [],
+    Blocks: [
+      {
+        identifier: 'selectedItem',
+        type: {
+          type: '<span class="hljs-title class_">Array</span>',
+          raw: '[<span class="hljs-title class_">SelectedItemBlockArg</span>&#x3C;<span class="hljs-built_in">never</span>>]',
+          items: [
+            {
+              identifier: '0',
+              type: {
+                type: '<span class="hljs-title class_">Object</span>',
+                items: [
+                  {
+                    identifier: 'item',
+                    type: { type: '<span class="hljs-built_in">never</span>' },
+                    isRequired: false,
+                    isInternal: false,
+                    description:
+                      'The entry of `@items` this selection came from.\n\nUndefined for an option written out in block form rather than rendered\nfrom `@items` -- there is no collection entry behind it, so only `key` and\n`label` are available there.',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'key',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description: '',
+                    tags: {},
+                  },
+                  {
+                    identifier: 'label',
+                    type: { type: '<span class="hljs-built_in">string</span>' },
+                    isRequired: true,
+                    isInternal: false,
+                    description:
+                      "The option's text, i.e. what would be rendered without this block.",
+                    tags: {},
+                  },
+                ],
+              },
+              isRequired: true,
+              isInternal: false,
+              description:
+                "What the `:selectedItem` block is handed for one selected option.\n\nDeliberately the same `{ item, key, label }` shape the `:item` block yields,\nso markup can move between the two blocks without being renamed. It is the\npublic face of {@link SelectedItem}: `label` is that projection's\n`textValue`.",
+              tags: {},
+            },
+          ],
+        },
+        isRequired: true,
+        isInternal: false,
+        description:
+          "Content for one selected option, forwarded straight through to\n{@link SelectedText }. Always supplied by the Select -- a block cannot be\npassed conditionally -- so <code>@hasCustomContent</code> is what says whether it\nholds the consumer's markup or the plain-label fallback.",
+        tags: {},
+      },
+    ],
     description:
       '<p>The Select\'s trigger: a filter <code>&#x3C;input></code> when <code>@isFilterable</code>, otherwise a\n<code>&#x3C;button></code>.</p>\n<p>Both carry <code>data-component="select-trigger"</code> and the same <code>input</code> slot, whose\n<code>hasChips</code> variant is what gives the trigger a hittable box when it has to\nshare a flex line with the chips instead of being the whole field.</p>',
     tags: {},

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -2603,6 +2603,21 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
           @selectedKeys={{array "ana" "cleo"}}
           @onSelectionChange={{noopKeys}}
         />
+        <Select
+          @items={{demoUsers}}
+          @label="Reviewers"
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{array "ana" "cleo"}}
+          @onSelectionChange={{noopKeys}}
+        />
+        <Select
+          @items={{demoUsers}}
+          @label="Filterable owner"
+          @isFilterable={{true}}
+          @selectedKey="bruno"
+          @onSelectionChange={{noop}}
+        />
       </template>
     );
 
@@ -2623,6 +2638,243 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
     assert
       .dom(triggers[1])
       .doesNotHaveAttribute('aria-label', 'and is still named by that text');
+
+    // The chip body is the markup this feature actually replaced
+    // (`{{item.textValue}}` became a yielded block with a fallback), so it is
+    // the presentation most worth pinning. Matched from the start of the chip
+    // so the close button's visually hidden `Remove Ana` cannot stand in for
+    // the body, and case-sensitively so the key (`ana`) cannot either.
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="ana"]')
+      .hasText(/^\s*Ana\b/, 'the chip body is still the option label');
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="cleo"]')
+      .hasText(/^\s*Cleo\b/);
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="ana"] button')
+      .hasText(
+        'Remove Ana',
+        'and the close button is still named from the option'
+      );
+
+    assert
+      .dom(triggers[3])
+      .hasTagName('input', 'a filterable trigger is an input');
+    assert
+      .dom(triggers[3])
+      .hasValue('Bruno', 'which still shows the selection as its own value');
+    assert
+      .dom(triggers[3])
+      .doesNotHaveAttribute(
+        'aria-label',
+        'and is still named by that value alone'
+      );
+  });
+
+  test('a filterable trigger is not given an `aria-label` by `:selectedItem`', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @isFilterable={{true}}
+          @selectedKey="bruno"
+          @onSelectionChange={{noop}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @selectedKey="bruno"
+          @onSelectionChange={{noop}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    const triggers = document.querySelectorAll(
+      '[data-component="select-trigger"]'
+    );
+
+    // The block cannot render into an `<input>`, so the input is never left
+    // unnamed: its own value is its accessible text. An `aria-label` here
+    // would both duplicate that value and change as the user types.
+    assert.dom(triggers[0]).hasTagName('input');
+    assert
+      .dom(triggers[0])
+      .hasValue('Bruno', 'the input still shows the selection as text');
+    assert
+      .dom(triggers[0])
+      .doesNotHaveAttribute(
+        'aria-label',
+        'the filterable trigger keeps its value as its only name'
+      );
+
+    // The `<button>` trigger does hand its content to the block, so it still
+    // needs the explicit name.
+    assert.dom(triggers[1]).hasTagName('button');
+    assert
+      .dom(triggers[1])
+      .hasAttribute(
+        'aria-label',
+        'Owner, Bruno',
+        'the non-filterable trigger is still named explicitly'
+      );
+  });
+
+  test('a filterable trigger in chips mode keeps its `aria-label`', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owners"
+          @isFilterable={{true}}
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{array "ana"}}
+          @onSelectionChange={{noopKeys}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+        <Select
+          @items={{demoUsers}}
+          @label="Reviewers"
+          @isFilterable={{true}}
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{array "ana"}}
+          @onSelectionChange={{noopKeys}}
+        />
+      </template>
+    );
+
+    const triggers = document.querySelectorAll(
+      '[data-component="select-trigger"]'
+    );
+
+    // In chips mode the input shows nothing of the selection, so it has no
+    // text of its own -- the control name is still required there, block or
+    // no block.
+    assert.dom(triggers[0]).hasAttribute('aria-label', 'Owners');
+    assert.dom(triggers[1]).hasAttribute('aria-label', 'Reviewers');
+  });
+
+  test('the composed name never ends in a dangling separator', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @selectedKey="nobody"
+          @onSelectionChange={{noop}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    // A key with no registered option behind it counts as a selection but
+    // resolves to no text, and `Owner, ` is announced as "Owner comma".
+    assert
+      .dom('[data-component="select-trigger"] [data-test-id="custom-selected"]')
+      .doesNotExist('there is no option behind the key, so nothing renders');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute(
+        'aria-label',
+        'Owner',
+        'the separator only appears between two non-empty halves'
+      );
+  });
+
+  test('with no label or placeholder the name is the selected text alone', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @selectedKey="ana"
+          @onSelectionChange={{noop}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+        <Select
+          @items={{demoUsers}}
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{array "ana"}}
+          @onSelectionChange={{noopKeys}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    const triggers = document.querySelectorAll(
+      '[data-component="select-trigger"]'
+    );
+
+    // `Select options` is a hardcoded English literal; prefixing the selected
+    // text with it names the control no better and localizes worse.
+    assert
+      .dom(triggers[0])
+      .hasAttribute(
+        'aria-label',
+        'Ana',
+        'the selection names the control on its own'
+      );
+
+    // Chips mode has no selected text inside the trigger to fall back to, so
+    // the literal is still the only answer there -- unchanged.
+    assert
+      .dom(triggers[1])
+      .hasAttribute(
+        'aria-label',
+        'Select options',
+        'chips mode is untouched by that fallback'
+      );
+  });
+
+  test('an `aria-label` on the Select does not reach the trigger', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @selectedKey="ana"
+          @onSelectionChange={{noop}}
+          aria-label="Pick an owner"
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    // `...attributes` on `<Select>` land on the wrapper element, not on the
+    // combobox, so a consumer cannot override the composed name this way.
+    // The docs say so rather than promising an override that does not exist.
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasAttribute(
+        'aria-label',
+        'Owner, Ana',
+        'the composed name still wins on the trigger'
+      );
   });
 
   test('`selected.item` is the `@items` entry the selection came from', async function (assert) {

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -2457,4 +2457,359 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       .dom('[data-test-id="chips-field"]')
       .hasAttribute('data-invalid', 'true');
   });
+
+  // --- `:selectedItem` block -------------------------------------------------
+
+  interface DemoUser {
+    key: string;
+    label: string;
+    email: string;
+  }
+
+  const demoUsers: DemoUser[] = [
+    { key: 'ana', label: 'Ana', email: 'ana@example.com' },
+    { key: 'bruno', label: 'Bruno', email: 'bruno@example.com' },
+    { key: 'cleo', label: 'Cleo', email: 'cleo@example.com' }
+  ];
+
+  const noop = (_key: string | null): void => {};
+  const noopKeys = (_keys: string[]): void => {};
+
+  // `selected.item` is `unknown` at the block boundary and is genuinely absent
+  // for block-form options, so the test reads it the way a consumer has to.
+  const emailOf = (item: unknown): string =>
+    (item as DemoUser | undefined)?.email ?? 'no-item';
+
+  test('`:selectedItem` renders custom content inside the single-mode trigger', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @selectedKey="bruno"
+          @onSelectionChange={{noop}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected" data-key={{selected.key}}>
+              {{selected.label}}
+            </span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert
+      .dom('[data-component="select-trigger"] [data-test-id="custom-selected"]')
+      .exists('the block renders inside the trigger');
+    assert
+      .dom('[data-component="select-trigger"] [data-test-id="custom-selected"]')
+      .hasAttribute('data-key', 'bruno', 'the block is handed the option key');
+    assert
+      .dom('[data-component="select-trigger"] [data-test-id="custom-selected"]')
+      .hasText('Bruno', '`label` is the option text');
+  });
+
+  test('`:selectedItem` renders inside each chip, keeping the chip chrome', async function (assert) {
+    const selectedKeys = cell<string[]>(['ana', 'cleo']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owners"
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').exists({ count: 2 });
+    assert
+      .dom(
+        '[data-test-id="selected-chip"][data-key="ana"] [data-test-id="custom-selected"]'
+      )
+      .hasText('Ana', 'the block renders inside the chip');
+    assert
+      .dom(
+        '[data-test-id="selected-chip"][data-key="cleo"] [data-test-id="custom-selected"]'
+      )
+      .hasText('Cleo');
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="ana"] button')
+      .exists('the chip keeps its close button');
+    // CloseButton renders its @title as visually hidden *text*, not a `title`
+    // attribute -- so this reads the accessible text, which is what a screen
+    // reader announces.
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="ana"] button')
+      .hasText(
+        'Remove Ana',
+        'the close button is still labelled from the option text'
+      );
+  });
+
+  test('`:selectedItem` renders once per selection in @selectedItemsDisplay="text"', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owners"
+          @selectionMode="multiple"
+          @selectedItemsDisplay="text"
+          @selectedKeys={{array "ana" "cleo"}}
+          @onSelectionChange={{noopKeys}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert.dom('[data-test-id="selected-chip"]').doesNotExist();
+    assert
+      .dom('[data-component="select-trigger"] [data-test-id="custom-selected"]')
+      .exists({ count: 2 }, 'the block renders once per selection');
+    // The plain presentation deliberately keeps one text node; the block
+    // branch renders many, so assert on the text, not the node shape. The
+    // separator is matched loosely because the whitespace around it belongs to
+    // the consumer's own block markup, not to the Select.
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasText(/Ana\s*,\s*Cleo/, 'the selections stay comma-separated');
+  });
+
+  test('without `:selectedItem`, every presentation is unchanged', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @selectedKey="bruno"
+          @onSelectionChange={{noop}}
+        />
+        <Select
+          @items={{demoUsers}}
+          @label="Owners"
+          @selectionMode="multiple"
+          @selectedItemsDisplay="text"
+          @selectedKeys={{array "ana" "cleo"}}
+          @onSelectionChange={{noopKeys}}
+        />
+      </template>
+    );
+
+    const triggers = document.querySelectorAll(
+      '[data-component="select-trigger"]'
+    );
+
+    assert.dom(triggers[0]).hasText('Bruno', 'single mode renders the label');
+    assert
+      .dom(triggers[0])
+      .doesNotHaveAttribute(
+        'aria-label',
+        'the trigger is still named by its own text'
+      );
+    assert
+      .dom(triggers[1])
+      .hasText('Ana, Cleo', 'text mode still renders the joined string');
+    assert
+      .dom(triggers[1])
+      .doesNotHaveAttribute('aria-label', 'and is still named by that text');
+  });
+
+  test('`selected.item` is the `@items` entry the selection came from', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @selectedKey="cleo"
+          @onSelectionChange={{noop}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-email">{{emailOf selected.item}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="custom-email"]')
+      .hasText(
+        'cleo@example.com',
+        'the block can reach the consumer’s own object'
+      );
+  });
+
+  test('`selected.item` is undefined for options written in block form', async function (assert) {
+    await render(
+      <template>
+        <Select @label="Owner" @selectedKey="ana" @onSelectionChange={{noop}}>
+          <:default as |l|>
+            <l.Item @key="ana">Ana</l.Item>
+            <l.Item @key="bruno">Bruno</l.Item>
+          </:default>
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-email">{{emailOf selected.item}}</span>
+            <span data-test-id="custom-label">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="custom-email"]')
+      .hasText('no-item', 'there is no collection entry behind a block option');
+    assert
+      .dom('[data-test-id="custom-label"]')
+      .hasText('Ana', 'the label is still available');
+  });
+
+  test('a `:selectedItem` block rendering no text still leaves the trigger named', async function (assert) {
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owner"
+          @selectedKey="bruno"
+          @onSelectionChange={{noop}}
+        >
+          <:selectedItem as |selected|>
+            <span
+              data-test-id="graphic-only"
+              data-key={{selected.key}}
+              aria-hidden="true"
+            ></span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert
+      .dom('[data-component="select-trigger"] [data-test-id="graphic-only"]')
+      .exists('the block rendered, and rendered nothing readable');
+    assert
+      .dom('[data-component="select-trigger"]')
+      .hasText('', 'the trigger has no text of its own to be named by');
+
+    const trigger = document.querySelector(
+      '[data-component="select-trigger"]'
+    ) as HTMLElement;
+    const ariaLabel = trigger.getAttribute('aria-label');
+
+    assert.ok(
+      ariaLabel && ariaLabel.trim() !== '',
+      `the trigger carries a non-empty aria-label (got ${JSON.stringify(ariaLabel)})`
+    );
+    assert.strictEqual(
+      ariaLabel,
+      'Owner, Bruno',
+      'built from the field label and the selected option text'
+    );
+  });
+
+  test('chips carrying custom content are still removable, tabbable-past and Backspace-able', async function (assert) {
+    const selectedKeys = cell<string[]>(['ana', 'bruno', 'cleo']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owners"
+          @selectionMode="multiple"
+          @allowEmpty={{true}}
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="bruno"] button')
+      .hasAttribute(
+        'tabindex',
+        '-1',
+        'close buttons stay out of the tab order'
+      );
+
+    await click('[data-test-id="selected-chip"][data-key="bruno"] button');
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['ana', 'cleo'],
+      'the close button removed just that selection'
+    );
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="bruno"]')
+      .doesNotExist();
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Backspace'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['ana'],
+      'Backspace on the trigger still removes the last chip'
+    );
+  });
+
+  test('@allowEmpty still governs chips carrying custom content', async function (assert) {
+    const selectedKeys = cell<string[]>(['ana']);
+    const onChange = (keys: string[]) => (selectedKeys.current = keys);
+
+    await render(
+      <template>
+        <Select
+          @items={{demoUsers}}
+          @label="Owners"
+          @selectionMode="multiple"
+          @selectedKeys={{selectedKeys.current}}
+          @onSelectionChange={{onChange}}
+        >
+          <:selectedItem as |selected|>
+            <span data-test-id="custom-selected">{{selected.label}}</span>
+          </:selectedItem>
+        </Select>
+      </template>
+    );
+
+    assert
+      .dom(
+        '[data-test-id="selected-chip"][data-key="ana"] [data-test-id="custom-selected"]'
+      )
+      .exists('the chip carries the custom content');
+    assert
+      .dom('[data-test-id="selected-chip"][data-key="ana"] button')
+      .doesNotExist(
+        'the last selection cannot be removed without @allowEmpty, so no dead close button'
+      );
+
+    await triggerKeyEvent(
+      '[data-component="select-trigger"]',
+      'keydown',
+      'Backspace'
+    );
+
+    assert.deepEqual(
+      selectedKeys.current,
+      ['ana'],
+      'and Backspace cannot remove it either'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Adds `<:selectedItem>` to `Select` — a block for rendering custom content in place of a selected option's text. Modelled on the use case where the dropdown row is rich (avatar, name, email) while the trigger shows a compact version of it.

```hbs
<Select @items={{this.users}} @selectedKey={{this.assignee}} @onSelectionChange={{this.onChange}}>
  <:selectedItem as |selected|>
    <img src={{selected.item.avatar}} alt="" class="w-5 h-5 rounded-full" />
    <span>{{selected.label}}</span>
  </:selectedItem>

  <:item as |o|>
    …the rich dropdown row…
  </:item>
</Select>
```

## API

The block yields `{ item, key, label }` — deliberately **the same shape as the existing `:item` block**, so markup can move between the two without being renamed.

It renders in every presentation of the selection:

| Mode | Result |
| --- | --- |
| single | inside the trigger, in place of the text |
| multiple, chips (default) | inside each `<Chip>`, replacing its label — chip chrome, `@chip` options and the close button all kept |
| multiple, `@selectedItemsDisplay="text"` | once per selection, comma-separated |

Supply no block and behaviour is exactly what it was — this is backward compatible.

## Accessibility

This was the part with a real hazard. A single-mode trigger takes its accessible name from its own text content, so a consumer rendering *only* an avatar would leave it announcing nothing. Whenever the block is in use the trigger now carries a composed `aria-label` — `"Assignee, John Doe"` — built from the field label and the selected text values. Chip close buttons keep using the option's text for `"Remove <label>"`, so they stay labelled even when the chip is purely graphical.

## Known limits, documented rather than worked around

- `selected.item` is `undefined` for options written in `<:default>` block form — there is no collection entry behind them, so only `key` and `label` are available. It is also typed `unknown` at the block boundary, since internal template-only signatures cannot be generic; consumers narrow it.
- A **filterable** trigger ignores the block for its own content — an `<input>` cannot hold markup. Its chips do use it.
- In `@selectedItemsDisplay="text"` mode the separator renders as `Ana , Cleo`: the extra space is the consumer's own template whitespace around their block, which cannot be stripped from inside the component. Fixing it exactly needs a CSS separator, i.e. a new theme slot, which was outside this change.

## Where the code went

`selected-items.gts`, `trigger.gts`, `types.ts` and the wiring in `select.gts`. **No change to `ListManager` or the selection plumbing** — the `item` reference this needs landed with the decomposition in #510. That was the stated test of that refactor's seams, and it held.

## Testing

890 tests / 887 pass / 3 skip / 0 fail (+9). Every new test was proven red by mutating the line that implements it — ten mutations, recorded in the branch's working notes.

Two of those runs earned their keep. A first attempt at a chip assertion used `hasAttribute('title', …)` and **failed**, correctly: `CloseButton` renders `@title` as visually hidden text and no `title` attribute exists — the same wrong assumption that drove a bad change to a shared component two PRs ago, caught this time by the test rather than by a reviewer. And the first text-mode run exposed a genuine `"Ana , Cleo"` whitespace defect, since fixed with Glimmer whitespace control.

The accessible-name test was independently mutation-checked: dropping the custom-content arm from the trigger's `aria-label` turns it red.

Verified in the browser as well as in the suite — single mode renders avatar + name with `aria-label="Assignee, John Doe"`; multiple mode renders two chips each carrying avatar + name, trigger labelled `"Reviewers"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
