### PR TITLE
fix(forms): guard unflattenData against prototype pollution

### DIFF
--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -822,6 +822,11 @@ object internally and unflattens it again for `@onChange` and `@onSubmit`, so yo
 your `@data` keep the shape you actually want. Errors and dirty entries are keyed by the same
 dotted path down to the leaf — `user.name.first`, never just `user`.
 
+`__proto__`, `constructor` and `prototype` are reserved: a field whose name uses one of those
+segments is dropped from the form data rather than nested. Building those keys out of untrusted
+field names would let a form write onto `Object.prototype` and change every object in the
+application, so they are refused outright.
+
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/packages/frontile/src/utils/nested-data.ts
+++ b/packages/frontile/src/utils/nested-data.ts
@@ -29,6 +29,46 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Path segments that are refused as object keys.
+ *
+ * Field names come from the `name` attribute of the form's controls, which an
+ * app may render from a server-supplied schema, a CMS, or URL state — so they
+ * are untrusted input.
+ *
+ * `__proto__` is the real vector: `isPlainObject(Object.prototype)` is `true`,
+ * so when the walk below reached a `__proto__` segment it accepted
+ * `Object.prototype` as an already-existing nested object instead of creating a
+ * fresh one, and the final assignment wrote onto every object in the
+ * application.
+ *
+ * `constructor` and `prototype` do not reach `Object.prototype` through the
+ * walk as it is written — `current['constructor']` is a function, which
+ * `isPlainObject` rejects, so the walk shadows it with a fresh own key. They
+ * are refused anyway, as defense in depth: it keeps form data from shadowing
+ * those names, and it means a later change to the walk (or an intermediate that
+ * is a plain object with a `constructor` of its own) cannot quietly turn them
+ * into live vectors.
+ */
+const UNSAFE_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/**
+ * Checks a single path segment. Callers refuse the whole entry rather than
+ * substituting a safe key, so no partially-built path is left behind.
+ */
+function isUnsafeKey(key: string): boolean {
+  return UNSAFE_KEYS.includes(key);
+}
+
+/**
+ * Checks whether a dotted path is safe to materialize. A single unsafe segment
+ * anywhere in the path poisons the whole path, so the entry is refused wholesale
+ * rather than partially built.
+ */
+function isSafePath(keys: string[]): boolean {
+  return !keys.some(isUnsafeKey);
+}
+
+/**
  * Flattens a nested object into a flat object with dotted-path keys.
  *
  * @example
@@ -47,6 +87,13 @@ export function flattenData<T = unknown>(
 
   for (const key in data) {
     if (!Object.prototype.hasOwnProperty.call(data, key)) {
+      continue;
+    }
+
+    // Refuse unsafe keys here too, so a hostile or already-polluted input
+    // cannot produce a dotted path that `unflattenData` would have to reject
+    // on the way back in.
+    if (isUnsafeKey(key)) {
       continue;
     }
 
@@ -87,6 +134,11 @@ export function unflattenData<T = unknown>(
 
     const value = data[path];
     const keys = path.split('.');
+
+    if (!isSafePath(keys)) {
+      continue;
+    }
+
     let current = result;
 
     // Navigate/create nested structure

--- a/test-app/tests/integration/components/forms/form-nested-test.gts
+++ b/test-app/tests/integration/components/forms/form-nested-test.gts
@@ -768,5 +768,75 @@ module(
         'First name reset to initial value'
       );
     });
+
+    module('prototype pollution', function (hooks) {
+      // A regression here writes to a shared global, which would silently
+      // corrupt every test that runs afterwards. Scrub the targets.
+      hooks.afterEach(function () {
+        delete (Object.prototype as Record<string, unknown>)['isAdmin'];
+      });
+
+      test('a hostile field name cannot pollute Object.prototype', async function (assert) {
+        // Apps that render fields from a server-supplied schema, a CMS, or URL
+        // state let untrusted input choose the `name` attribute.
+        let lastData: Record<string, unknown> | undefined;
+
+        class TestComponent extends Component {
+          handleChange = (data: FormResultData<Record<string, unknown>>) => {
+            lastData = data.data;
+          };
+
+          handleSubmit = (data: FormResultData<Record<string, unknown>>) => {
+            lastData = data.data;
+          };
+
+          <template>
+            <Form
+              @onChange={{this.handleChange}}
+              @onSubmit={{this.handleSubmit}}
+              as |form|
+            >
+              <form.Field @name="__proto__.isAdmin" as |field|>
+                <field.Input data-test-hostile />
+              </form.Field>
+
+              <form.Field @name="email" as |field|>
+                <field.Input data-test-email />
+              </form.Field>
+
+              <button type="submit" data-test-submit>Submit</button>
+            </Form>
+          </template>
+        }
+
+        await render(<template><TestComponent /></template>);
+
+        await fillIn('[data-test-hostile]', 'true');
+        await fillIn('[data-test-email]', 'john@example.com');
+
+        assert.strictEqual(
+          ({} as Record<string, unknown>)['isAdmin'],
+          undefined,
+          'typing into the hostile field did not pollute Object.prototype'
+        );
+
+        await click('[data-test-submit]');
+
+        assert.strictEqual(
+          ({} as Record<string, unknown>)['isAdmin'],
+          undefined,
+          'submitting did not pollute Object.prototype'
+        );
+        assert.notOk(
+          Object.prototype.hasOwnProperty.call(lastData ?? {}, '__proto__'),
+          'no own __proto__ key reaches the consumer data'
+        );
+        assert.strictEqual(
+          lastData?.['email'],
+          'john@example.com',
+          'safe fields still come through'
+        );
+      });
+    });
   }
 );

--- a/test-app/tests/unit/forms/utils/nested-data-test.ts
+++ b/test-app/tests/unit/forms/utils/nested-data-test.ts
@@ -79,6 +79,25 @@ module('Unit | Forms | Utils | nested-data', function (hooks) {
       assert.strictEqual(result['user.birthdate'], date);
     });
 
+    test('passes File values through untouched', function (assert) {
+      const file = new File(['contents'], 'resume.txt', { type: 'text/plain' });
+      const nested = {
+        user: {
+          name: 'John',
+          resume: file
+        }
+      };
+
+      const result = flattenData(nested);
+
+      assert.strictEqual(
+        result['user.resume'],
+        file,
+        'the same File instance is preserved'
+      );
+      assert.strictEqual(result['user.name'], 'John');
+    });
+
     test('handles null and undefined values', function (assert) {
       const nested = {
         user: {
@@ -206,6 +225,22 @@ module('Unit | Forms | Utils | nested-data', function (hooks) {
       assert.deepEqual(result, flat);
     });
 
+    test('passes File values through untouched', function (assert) {
+      const file = new File(['contents'], 'resume.txt', { type: 'text/plain' });
+      const flat = {
+        'user.name': 'John',
+        'user.resume': file
+      };
+
+      const result = unflattenData(flat);
+
+      assert.strictEqual(
+        (result['user'] as Record<string, unknown>)['resume'],
+        file,
+        'the same File instance is preserved'
+      );
+    });
+
     test('round-trip: flatten then unflatten', function (assert) {
       const original = {
         user: {
@@ -225,6 +260,152 @@ module('Unit | Forms | Utils | nested-data', function (hooks) {
       const unflattened = unflattenData(flattened);
 
       assert.deepEqual(unflattened, original);
+    });
+  });
+
+  module('prototype pollution', function (hooks) {
+    // These tests write to a shared global (`Object.prototype`) if the guard
+    // regresses, so scrub the known pollution targets after every test. A
+    // leaked property here would silently corrupt every later test in the run.
+    hooks.afterEach(function () {
+      delete (Object.prototype as Record<string, unknown>)['isAdmin'];
+      delete (Object.prototype as Record<string, unknown>)['polluted'];
+    });
+
+    test('unflattenData does not pollute Object.prototype via __proto__', function (assert) {
+      const flat = {
+        '__proto__.isAdmin': true,
+        email: 'john@example.com'
+      };
+
+      const result = unflattenData(flat);
+
+      assert.strictEqual(
+        ({} as Record<string, unknown>)['isAdmin'],
+        undefined,
+        'Object.prototype was not polluted'
+      );
+      assert.deepEqual(
+        result,
+        { email: 'john@example.com' },
+        'the dangerous path is dropped and safe data is kept'
+      );
+    });
+
+    test('unflattenData does not pollute via constructor.prototype', function (assert) {
+      // `constructor` never reached `Object.prototype` through the walk (it is
+      // a function, which `isPlainObject` rejects) — before the guard this
+      // produced `{constructor: {prototype: {polluted: true}}}`. It is refused
+      // as defense in depth, so what this pins is the shape, plus the absence
+      // of pollution if the walk is ever changed.
+      const flat = {
+        'constructor.prototype.polluted': true,
+        email: 'john@example.com'
+      };
+
+      const result = unflattenData(flat);
+
+      assert.strictEqual(
+        ({} as Record<string, unknown>)['polluted'],
+        undefined,
+        'Object.prototype was not polluted'
+      );
+      assert.deepEqual(
+        result,
+        { email: 'john@example.com' },
+        'the dangerous path is dropped and safe data is kept'
+      );
+    });
+
+    test('unflattenData refuses a bare __proto__ final segment', function (assert) {
+      // An object literal `{__proto__: ...}` would set the prototype rather
+      // than create an own key, so build the own key explicitly.
+      const flat: Record<string, unknown> = {};
+      Object.defineProperty(flat, '__proto__', {
+        value: { isAdmin: true },
+        enumerable: true,
+        writable: true,
+        configurable: true
+      });
+      flat['email'] = 'john@example.com';
+
+      const result = unflattenData(flat);
+
+      assert.strictEqual(
+        ({} as Record<string, unknown>)['isAdmin'],
+        undefined,
+        'Object.prototype was not polluted'
+      );
+      assert.notOk(
+        Object.prototype.hasOwnProperty.call(result, '__proto__'),
+        'no own __proto__ key is created on the result'
+      );
+      assert.strictEqual(
+        result['email'],
+        'john@example.com',
+        'safe data is kept'
+      );
+    });
+
+    test('unflattenData refuses dangerous segments in the middle of a path', function (assert) {
+      const flat = {
+        'user.__proto__.isAdmin': true,
+        'user.constructor.prototype.polluted': true,
+        'user.name': 'John'
+      };
+
+      const result = unflattenData(flat);
+
+      assert.strictEqual(
+        ({} as Record<string, unknown>)['isAdmin'],
+        undefined,
+        'Object.prototype was not polluted via __proto__'
+      );
+      assert.strictEqual(
+        ({} as Record<string, unknown>)['polluted'],
+        undefined,
+        'Object.prototype was not polluted via constructor.prototype'
+      );
+      assert.deepEqual(
+        result,
+        { user: { name: 'John' } },
+        'only the safe path is materialized'
+      );
+    });
+
+    test('unflattenData returns objects with a normal prototype', function (assert) {
+      // The result is consumed by Glimmer templates and Ember's `get()`, so it
+      // must not be a null-prototype object.
+      const result = unflattenData({ 'user.name': 'John' });
+
+      assert.strictEqual(
+        Object.getPrototypeOf(result),
+        Object.prototype,
+        'the root object has the normal Object prototype'
+      );
+      assert.strictEqual(
+        Object.getPrototypeOf(result['user'] as object),
+        Object.prototype,
+        'nested objects have the normal Object prototype'
+      );
+    });
+
+    test('flattenData drops dangerous keys so they cannot round-trip', function (assert) {
+      const nested: Record<string, unknown> = { name: 'John' };
+      Object.defineProperty(nested, '__proto__', {
+        value: { isAdmin: true },
+        enumerable: true,
+        writable: true,
+        configurable: true
+      });
+
+      const result = flattenData(nested);
+
+      assert.deepEqual(
+        result,
+        { name: 'John' },
+        'the dangerous key is not emitted'
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

`unflattenData` is vulnerable to prototype pollution.

It splits a dotted path and walks/creates nested objects. For the segment `__proto__`, `isPlainObject(current['__proto__'])` returns `true` — it *is* `Object.prototype` — so the "create a fresh object" branch is skipped, `current` becomes `Object.prototype`, and the final assignment writes onto every object in the application.

Verified against the unmodified function body:

```
unflattenData({'__proto__.isAdmin': true, 'email':'a@b.c'})
  => returns {"email":"a@b.c"}
  => ({}).isAdmin === true      // global pollution
```

The vector is reachable through the public `Form` component: `handleInput`, `handleSubmit`, and `handleReset` all run `unflattenData` over keys taken from the `name` attributes of the form's controls. Apps that render fields from a server-supplied schema, a CMS, or URL state let untrusted input choose those names.

CWE-1321. There was no existing test coverage for this.

## Fix

Refuse `__proto__`, `constructor`, and `prototype` as path segments, anywhere in a path, in both `unflattenData` and `flattenData`. An entry with an unsafe segment is dropped wholesale rather than partially materialized.

`__proto__` is the live vector. `constructor` and `prototype` do **not** reach `Object.prototype` through the walk as written (`isPlainObject` rejects the function they resolve to, so the walk shadows them with a fresh own key) — they are refused as defense in depth, so form data cannot shadow those names and a later change to the walk cannot quietly turn them into live vectors. The code comment says exactly this rather than overstating the risk.

Ordinary data keeps its shape and its normal prototype: the result is consumed by Glimmer templates and Ember's `get()`, so deliberately **not** `Object.create(null)`. A test pins that.

## Behavior change

`flattenData`/`unflattenData` are publicly exported, so these three names are now reserved: a field named e.g. `constructor` is silently dropped from the form data. Kept silent deliberately — these run on every input event — and documented in `form.md`.

## Tests

9 added; 5 of them confirmed failing before the fix.

- `unflattenData` does not pollute via `__proto__` / via `constructor.prototype` / via a dangerous segment mid-path / via a bare `__proto__` final segment
- `unflattenData` returns objects with a normal prototype (guards against a future `Object.create(null)` "fix")
- `flattenData` drops dangerous keys so they cannot round-trip
- Integration: a hostile field name inside a real `<Form>` cannot pollute, and safe fields still come through
- Regression lock-ins: `File` instances pass through both functions by identity

Both pollution submodules scrub `Object.prototype` in `afterEach`, so a regression cannot poison the rest of the suite run.

Full suite: **906 tests, 903 pass, 3 skip, 0 fail** (897 baseline + 9 new). `lint:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
