### PR TITLE
fix(press): stop swallowing document-level pointerup

### DIFF
--- a/packages/frontile/src/modifiers/press.md
+++ b/packages/frontile/src/modifiers/press.md
@@ -81,13 +81,13 @@ export default class PressExample extends Component {
 
 The press modifier accepts an optional positional `onPress` function and the following named options:
 
-| Name            | Type                           | Description                                                                                                     |
-| --------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `onPress`       | `(e: PressEvent) => void`      | Handler called when press is released over the target.                                                          |
-| `onPressStart`  | `(e: PressEvent) => void`      | Handler called when a press interaction starts.                                                                 |
-| `onPressEnd`    | `(e: PressEvent) => void`      | Handler called when a press interaction ends, either over the target or when the pointer leaves the target.     |
-| `onPressUp`     | `(e: PressEvent) => void`      | Handler called when a press is released over the target, regardless of whether it started on the target or not. |
-| `onPressChange` | `(isPressed: boolean) => void` | Handler called when the press state changes.                                                                    |
+| Name            | Type                           | Description                                                                                                         |
+| --------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `onPress`       | `(e: PressEvent) => void`      | Handler called when press is released over the target.                                                              |
+| `onPressStart`  | `(e: PressEvent) => void`      | Handler called when a press interaction starts.                                                                     |
+| `onPressEnd`    | `(e: PressEvent) => void`      | Handler called when a press interaction ends, either over the target or when the pointer leaves the target.         |
+| `onPressUp`     | `(e: PressEvent) => void`      | Handler called when a press is released over the target. Not called when the release happens outside of the target. |
+| `onPressChange` | `(isPressed: boolean) => void` | Handler called when the press state changes.                                                                        |
 
 ### PressEvent
 
@@ -114,3 +114,8 @@ Press events are normalized across different input methods and provide consisten
 - **Performance**: Only adds event listeners for callbacks you provide
 - **Accessibility**: Automatically handles Enter and Space key interactions
 - **Cross-platform**: Supports mouse, touch, and keyboard across all browsers
+- **Propagation**: By default a press stops propagation of the underlying
+  event to parent elements. Call `continuePropagation()` on the `PressEvent` in
+  any handler to let it through. Only events on the pressed element itself are
+  stopped - a release that happens outside of the element is left untouched, so
+  other listeners on the page (including document-level ones) still receive it.

--- a/packages/frontile/src/modifiers/press.md
+++ b/packages/frontile/src/modifiers/press.md
@@ -111,7 +111,9 @@ Press events are normalized across different input methods and provide consisten
 - **Positional argument**: Pass `onPress` as the first argument: `{{press this.handlePress}}`
 - **Mixed arguments**: Combine positional `onPress` with named arguments for other callbacks
 - **Conflict handling**: Cannot provide both positional and named `onPress` (assertion error)
-- **Performance**: Only adds event listeners for callbacks you provide
+- **Performance**: Only adds the event listeners your callbacks require - a
+  single callback can need more than one (e.g. `onPressChange` also needs
+  `pointercancel`)
 - **Accessibility**: Automatically handles Enter and Space key interactions
 - **Cross-platform**: Supports mouse, touch, and keyboard across all browsers
 - **Propagation**: By default a press stops propagation of the underlying

--- a/packages/frontile/src/modifiers/press.ts
+++ b/packages/frontile/src/modifiers/press.ts
@@ -234,14 +234,37 @@ const press = modifier<PressSignature>(
       return false;
     };
 
+    // The document listeners exist only as a fallback for releases that happen
+    // outside of the element (the pointer was dragged off before being
+    // released). They run in the capture phase, which is the very first node in
+    // the propagation path, so they must never handle - and never stop - an
+    // event that belongs to the element itself: the element's own listeners
+    // (including any registered by the consumer) still need to see it.
+    const isOnTarget = (event: Event): boolean =>
+      element.contains(event.target as Node);
+
+    const endFromDocument = (event: Event): void => {
+      if (isOnTarget(event)) {
+        return;
+      }
+      end(event);
+    };
+
+    const cancelFromDocument = (event: PointerEvent): void => {
+      if (isOnTarget(event)) {
+        return;
+      }
+      cancel(event);
+    };
+
     const addDocumentListeners = (): void => {
       if (documentListenersActive || !needsEndEvents) {
         return;
       }
       documentListenersActive = true;
-      document.addEventListener('pointerup', end, true);
-      document.addEventListener('mouseup', end, true);
-      document.addEventListener('pointercancel', cancel, true);
+      document.addEventListener('pointerup', endFromDocument, true);
+      document.addEventListener('mouseup', endFromDocument, true);
+      document.addEventListener('pointercancel', cancelFromDocument, true);
     };
 
     const removeDocumentListeners = (): void => {
@@ -249,9 +272,9 @@ const press = modifier<PressSignature>(
         return;
       }
       documentListenersActive = false;
-      document.removeEventListener('pointerup', end, true);
-      document.removeEventListener('mouseup', end, true);
-      document.removeEventListener('pointercancel', cancel, true);
+      document.removeEventListener('pointerup', endFromDocument, true);
+      document.removeEventListener('mouseup', endFromDocument, true);
+      document.removeEventListener('pointercancel', cancelFromDocument, true);
     };
 
     const start = (event: Event): void => {
@@ -287,6 +310,9 @@ const press = modifier<PressSignature>(
       removeDocumentListeners();
       named.onPressChange?.(false);
 
+      const onTarget = isOnTarget(event);
+      let shouldPropagate = false;
+
       const pressEndEvent = new PressEvent(
         'pressend',
         getPointerType(event),
@@ -294,8 +320,10 @@ const press = modifier<PressSignature>(
         element
       );
       named.onPressEnd?.(pressEndEvent);
+      shouldPropagate = shouldPropagate || pressEndEvent.shouldPropagate;
 
-      if (element.contains(event.target as Node)) {
+      // `press` and `pressup` only describe a release on the element itself.
+      if (onTarget) {
         const pressEvent = new PressEvent(
           'press',
           getPointerType(event),
@@ -303,20 +331,21 @@ const press = modifier<PressSignature>(
           element
         );
         onPress?.(pressEvent);
-        if (!pressEvent.shouldPropagate) {
-          event.stopPropagation();
-        }
+        shouldPropagate = shouldPropagate || pressEvent.shouldPropagate;
+
+        const pressUpEvent = new PressEvent(
+          'pressup',
+          getPointerType(event),
+          event,
+          element
+        );
+        named.onPressUp?.(pressUpEvent);
+        shouldPropagate = shouldPropagate || pressUpEvent.shouldPropagate;
       }
 
-      const pressUpEvent = new PressEvent(
-        'pressup',
-        getPointerType(event),
-        event,
-        element
-      );
-      named.onPressUp?.(pressUpEvent);
-
-      if (!pressEndEvent.shouldPropagate) {
+      // Only the element's own release is ours to stop. Stopping a release that
+      // happened elsewhere would hide it from the rest of the page.
+      if (onTarget && !shouldPropagate) {
         event.stopPropagation();
       }
     };
@@ -336,7 +365,7 @@ const press = modifier<PressSignature>(
         element
       );
       named.onPressEnd?.(pressEvent);
-      if (!pressEvent.shouldPropagate) {
+      if (isOnTarget(event) && !pressEvent.shouldPropagate) {
         event.stopPropagation();
       }
     };
@@ -381,8 +410,11 @@ const press = modifier<PressSignature>(
       });
     }
 
-    // Add pointer cancel only if we have onPressEnd (since cancel triggers onPressEnd)
-    if (named.onPressEnd) {
+    // Add pointer cancel whenever we track the end of an interaction: cancel
+    // resets the pressed state and triggers onPressEnd/onPressChange. It has to
+    // be on the element as well as on the document, because the document
+    // fallback deliberately ignores events targeting the element.
+    if (needsEndEvents) {
       element.addEventListener('pointercancel', cancel);
 
       cleanupFunctions.push(() => {

--- a/packages/frontile/src/modifiers/press.ts
+++ b/packages/frontile/src/modifiers/press.ts
@@ -240,22 +240,21 @@ const press = modifier<PressSignature>(
     // the propagation path, so they must never handle - and never stop - an
     // event that belongs to the element itself: the element's own listeners
     // (including any registered by the consumer) still need to see it.
-    const isOnTarget = (event: Event): boolean =>
+    const isInsideElement = (event: Event): boolean =>
       element.contains(event.target as Node);
 
-    const endFromDocument = (event: Event): void => {
-      if (isOnTarget(event)) {
-        return;
-      }
-      end(event);
-    };
-
-    const cancelFromDocument = (event: PointerEvent): void => {
-      if (isOnTarget(event)) {
-        return;
-      }
-      cancel(event);
-    };
+    // Wraps a handler so it only runs for events that originated outside of the
+    // element, which is the whole contract of the document-level fallback. Each
+    // wrapper is created once and stored, so add/removeEventListener always see
+    // the same function identity.
+    const onlyOutsideElement =
+      <E extends Event>(handler: (event: E) => void) =>
+      (event: E): void => {
+        if (isInsideElement(event)) {
+          return;
+        }
+        handler(event);
+      };
 
     const addDocumentListeners = (): void => {
       if (documentListenersActive || !needsEndEvents) {
@@ -310,8 +309,8 @@ const press = modifier<PressSignature>(
       removeDocumentListeners();
       named.onPressChange?.(false);
 
-      const onTarget = isOnTarget(event);
-      let shouldPropagate = false;
+      const onTarget = isInsideElement(event);
+      const dispatched: PressEvent[] = [];
 
       const pressEndEvent = new PressEvent(
         'pressend',
@@ -320,7 +319,7 @@ const press = modifier<PressSignature>(
         element
       );
       named.onPressEnd?.(pressEndEvent);
-      shouldPropagate = shouldPropagate || pressEndEvent.shouldPropagate;
+      dispatched.push(pressEndEvent);
 
       // `press` and `pressup` only describe a release on the element itself.
       if (onTarget) {
@@ -331,7 +330,7 @@ const press = modifier<PressSignature>(
           element
         );
         onPress?.(pressEvent);
-        shouldPropagate = shouldPropagate || pressEvent.shouldPropagate;
+        dispatched.push(pressEvent);
 
         const pressUpEvent = new PressEvent(
           'pressup',
@@ -340,12 +339,13 @@ const press = modifier<PressSignature>(
           element
         );
         named.onPressUp?.(pressUpEvent);
-        shouldPropagate = shouldPropagate || pressUpEvent.shouldPropagate;
+        dispatched.push(pressUpEvent);
       }
 
-      // Only the element's own release is ours to stop. Stopping a release that
-      // happened elsewhere would hide it from the rest of the page.
-      if (onTarget && !shouldPropagate) {
+      // Any handler opting in to propagation wins. Only the element's own
+      // release is ours to stop - stopping a release that happened elsewhere
+      // would hide it from the rest of the page.
+      if (onTarget && !dispatched.some((e) => e.shouldPropagate)) {
         event.stopPropagation();
       }
     };
@@ -365,10 +365,15 @@ const press = modifier<PressSignature>(
         element
       );
       named.onPressEnd?.(pressEvent);
-      if (isOnTarget(event) && !pressEvent.shouldPropagate) {
+      if (isInsideElement(event) && !pressEvent.shouldPropagate) {
         event.stopPropagation();
       }
     };
+
+    // Declared after `end`/`cancel` so the factory can capture them; the
+    // resulting functions are stored once and reused by add/removeEventListener.
+    const endFromDocument = onlyOutsideElement(end);
+    const cancelFromDocument = onlyOutsideElement<PointerEvent>(cancel);
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Enter' || event.key === ' ') {

--- a/test-app/tests/integration/modifiers/utilities/press-test.gts
+++ b/test-app/tests/integration/modifiers/utilities/press-test.gts
@@ -784,8 +784,8 @@ module(
       // Should capture start and end events
       assert.strictEqual(
         capturedEvents.length,
-        3,
-        'Should capture start, end, and up events'
+        2,
+        'Should capture start and end events'
       );
       assert.strictEqual(
         capturedEvents[0]!.type,
@@ -797,16 +797,18 @@ module(
         'end',
         'Second event should be end'
       );
-      assert.strictEqual(
-        capturedEvents[2]!.type,
-        'up',
-        'Third event should be up'
-      );
 
       // onPress should NOT trigger since the release wasn't on the element
       assert.ok(
         !capturedEvents.some((e) => e.type === 'press'),
         'onPress should not trigger when released outside element'
+      );
+
+      // onPressUp describes a release on the element, so it should not trigger
+      // either when the release happened elsewhere.
+      assert.ok(
+        !capturedEvents.some((e) => e.type === 'up'),
+        'onPressUp should not trigger when released outside element'
       );
     });
 
@@ -1456,6 +1458,316 @@ module(
         clickCount,
         0,
         'Click event should NOT fire on Enter key because type="button" gets preventDefault'
+      );
+    });
+
+    test('a release outside the element is not swallowed for other listeners', async function (assert) {
+      let pressCount = 0;
+
+      class OutsideReleaseComponent extends Component {
+        onPress = () => {
+          pressCount++;
+        };
+
+        <template>
+          <button
+            data-test-id="outside-release-target"
+            type="button"
+            {{press onPress=this.onPress}}
+          >
+            Outside Release Target
+          </button>
+          <div data-test-id="outside-release-other">Other element</div>
+        </template>
+      }
+
+      let documentPointerUpCount = 0;
+      let documentMouseUpCount = 0;
+      const onDocumentPointerUp = () => {
+        documentPointerUpCount++;
+      };
+      const onDocumentMouseUp = () => {
+        documentMouseUpCount++;
+      };
+
+      document.addEventListener('pointerup', onDocumentPointerUp);
+      document.addEventListener('mouseup', onDocumentMouseUp);
+
+      try {
+        await render(<template><OutsideReleaseComponent /></template>);
+
+        await triggerEvent(
+          '[data-test-id="outside-release-target"]',
+          'pointerdown'
+        );
+        await triggerEvent(
+          '[data-test-id="outside-release-other"]',
+          'pointerup'
+        );
+
+        assert.strictEqual(
+          documentPointerUpCount,
+          1,
+          'a document-level pointerup listener still receives a release that happened outside the pressed element'
+        );
+        assert.strictEqual(
+          pressCount,
+          0,
+          'onPress does not fire for a release outside the element'
+        );
+
+        await triggerEvent(
+          '[data-test-id="outside-release-target"]',
+          'mousedown'
+        );
+        await triggerEvent('[data-test-id="outside-release-other"]', 'mouseup');
+
+        assert.strictEqual(
+          documentMouseUpCount,
+          1,
+          'a document-level mouseup listener still receives a release that happened outside the pressed element'
+        );
+      } finally {
+        document.removeEventListener('pointerup', onDocumentPointerUp);
+        document.removeEventListener('mouseup', onDocumentMouseUp);
+      }
+    });
+
+    test('the pressed element own pointerup/mouseup listeners still fire', async function (assert) {
+      let pressCount = 0;
+      let elementPointerUpCount = 0;
+      let elementMouseUpCount = 0;
+
+      class OwnListenersComponent extends Component {
+        onPress = () => {
+          pressCount++;
+        };
+
+        onPointerUp = () => {
+          elementPointerUpCount++;
+        };
+
+        onMouseUp = () => {
+          elementMouseUpCount++;
+        };
+
+        <template>
+          <button
+            data-test-id="own-listeners-target"
+            type="button"
+            {{press onPress=this.onPress}}
+            {{on "pointerup" this.onPointerUp}}
+            {{on "mouseup" this.onMouseUp}}
+          >
+            Own Listeners
+          </button>
+        </template>
+      }
+
+      await render(<template><OwnListenersComponent /></template>);
+
+      await triggerEvent(
+        '[data-test-id="own-listeners-target"]',
+        'pointerdown'
+      );
+      await triggerEvent('[data-test-id="own-listeners-target"]', 'pointerup');
+
+      assert.strictEqual(pressCount, 1, 'onPress fired');
+      assert.strictEqual(
+        elementPointerUpCount,
+        1,
+        'the element own pointerup listener still fires'
+      );
+
+      await triggerEvent('[data-test-id="own-listeners-target"]', 'mousedown');
+      await triggerEvent('[data-test-id="own-listeners-target"]', 'mouseup');
+
+      assert.strictEqual(pressCount, 2, 'onPress fired for the mouse sequence');
+      assert.strictEqual(
+        elementMouseUpCount,
+        1,
+        'the element own mouseup listener still fires'
+      );
+    });
+
+    test('onPressUp does not fire when released outside the element', async function (assert) {
+      let endCount = 0;
+      let upCount = 0;
+      let pressCount = 0;
+
+      class PressUpOutsideComponent extends Component {
+        onPressEnd = () => {
+          endCount++;
+        };
+
+        onPressUp = () => {
+          upCount++;
+        };
+
+        onPress = () => {
+          pressCount++;
+        };
+
+        <template>
+          <button
+            data-test-id="pressup-outside-target"
+            type="button"
+            {{press
+              onPressEnd=this.onPressEnd
+              onPressUp=this.onPressUp
+              onPress=this.onPress
+            }}
+          >
+            Press Up Outside
+          </button>
+        </template>
+      }
+
+      await render(<template><PressUpOutsideComponent /></template>);
+
+      await triggerEvent(
+        '[data-test-id="pressup-outside-target"]',
+        'pointerdown'
+      );
+      await triggerEvent(document, 'pointerup');
+
+      assert.strictEqual(
+        endCount,
+        1,
+        'onPressEnd still fires when released outside'
+      );
+      assert.strictEqual(
+        pressCount,
+        0,
+        'onPress does not fire when released outside'
+      );
+      assert.strictEqual(
+        upCount,
+        0,
+        'onPressUp does not fire when released outside'
+      );
+    });
+
+    test('press events do not bubble to ancestor handlers by default', async function (assert) {
+      let ancestorDownCount = 0;
+      let ancestorUpCount = 0;
+      let pressCount = 0;
+
+      class AncestorDefaultComponent extends Component {
+        onPress = () => {
+          pressCount++;
+        };
+
+        onAncestorDown = () => {
+          ancestorDownCount++;
+        };
+
+        onAncestorUp = () => {
+          ancestorUpCount++;
+        };
+
+        <template>
+          <div
+            data-test-id="ancestor-default"
+            {{on "pointerdown" this.onAncestorDown}}
+            {{on "pointerup" this.onAncestorUp}}
+          >
+            <button
+              data-test-id="ancestor-default-target"
+              type="button"
+              {{press onPress=this.onPress}}
+            >
+              Inner
+            </button>
+          </div>
+        </template>
+      }
+
+      await render(<template><AncestorDefaultComponent /></template>);
+
+      await triggerEvent(
+        '[data-test-id="ancestor-default-target"]',
+        'pointerdown'
+      );
+      await triggerEvent(
+        '[data-test-id="ancestor-default-target"]',
+        'pointerup'
+      );
+
+      assert.strictEqual(pressCount, 1, 'onPress fired');
+      assert.strictEqual(
+        ancestorDownCount,
+        0,
+        'pointerdown does not reach the ancestor by default'
+      );
+      assert.strictEqual(
+        ancestorUpCount,
+        0,
+        'pointerup does not reach the ancestor by default'
+      );
+    });
+
+    test('press events bubble to ancestor handlers when continuePropagation is called', async function (assert) {
+      let ancestorDownCount = 0;
+      let ancestorUpCount = 0;
+      let pressCount = 0;
+
+      class AncestorContinueComponent extends Component {
+        onPressStart = (event: PressEvent) => {
+          event.continuePropagation();
+        };
+
+        onPress = (event: PressEvent) => {
+          pressCount++;
+          event.continuePropagation();
+        };
+
+        onAncestorDown = () => {
+          ancestorDownCount++;
+        };
+
+        onAncestorUp = () => {
+          ancestorUpCount++;
+        };
+
+        <template>
+          <div
+            data-test-id="ancestor-continue"
+            {{on "pointerdown" this.onAncestorDown}}
+            {{on "pointerup" this.onAncestorUp}}
+          >
+            <button
+              data-test-id="ancestor-continue-target"
+              type="button"
+              {{press onPressStart=this.onPressStart onPress=this.onPress}}
+            >
+              Inner
+            </button>
+          </div>
+        </template>
+      }
+
+      await render(<template><AncestorContinueComponent /></template>);
+
+      await triggerEvent(
+        '[data-test-id="ancestor-continue-target"]',
+        'pointerdown'
+      );
+      await triggerEvent(
+        '[data-test-id="ancestor-continue-target"]',
+        'pointerup'
+      );
+
+      assert.strictEqual(pressCount, 1, 'onPress fired');
+      assert.strictEqual(
+        ancestorDownCount,
+        1,
+        'pointerdown reaches the ancestor when continuePropagation is called'
+      );
+      assert.strictEqual(
+        ancestorUpCount,
+        1,
+        'pointerup reaches the ancestor when continuePropagation is called'
       );
     });
   }


### PR DESCRIPTION
## Problem

Two defects in the `press` modifier's release handling.

**A. Every `pointerup`/`mouseup` in the document was swallowed.** `addDocumentListeners` registered `end` on `document` in the **capture** phase, and `end` called `event.stopPropagation()` by default. Document capture is the first node in the propagation path, so after any press the release event never reached *any* element below it.

Failure: an app with a `mouseup` listener for drag-end, a canvas interaction, a resizer, or "dismiss on mouseup outside" stops receiving that event as soon as the user presses any `Button`, `ToggleButton`, or `CloseButton`. Even the pressed element's own `pointerup`/`mouseup` listeners were dead.

The documented intent of the default `stopPropagation` is to keep a press from bubbling to *parent elements* — not to kill the event for the whole page.

**B. `onPressUp` fired for releases outside the element.** It was constructed and invoked with no containment check, unlike `onPress`. Press a button, drag off it, release: `onPress` correctly skipped, `onPressUp` fired anyway. Contrary to the react-aria semantics this API mirrors.

## Fix

The document listeners are now a true outside-only fallback: `endFromDocument`/`cancelFromDocument` return immediately when `element.contains(event.target)`, letting the element's own bubble-phase listener handle that case. `stopPropagation()` is only called for a release that actually targeted the element.

They stay in the **capture** phase deliberately — that is what makes the outside-release fallback robust (an intermediate handler that stops propagation can't strand the modifier in a permanently-pressed state). Deferring rather than re-phasing keeps that property while restoring the documented intent.

`onPressUp` is now gated on containment, consistent with `onPress`.

Three follow-on changes were forced by the above and are the parts most worth reviewing:

1. **`continuePropagation()` now works.** A single DOM release produces up to three `PressEvent`s over one shared underlying event, and each previously stopped propagation independently — so a consumer who provided only `onPress` and called `continuePropagation()` there was overruled by the `pressend` event, which is constructed even with no `onPressEnd` callback. Propagation now continues if *any* handler asked for it. This only makes a previously non-functional API work, but it is a semantic choice (OR rather than AND) and is now documented in `press.md`.
2. **`pointercancel` is bound on the element whenever end events are tracked**, not only when `onPressEnd` was given. With the document fallback ignoring element-targeted events, an `onPressChange`-only consumer would otherwise have lost cancel handling entirely — caught by the pre-existing `onPressChange called on pointer cancel` test.
3. **`cancel()`'s `stopPropagation()` is now conditional too** (`isInsideElement(event) && !pressEvent.shouldPropagate`). `cancel` is reached from both the element listener and the document fallback, so it needed the same containment + opt-in gate as `end` — otherwise a `pointercancel` originating outside the element would still be swallowed, and `continuePropagation()` would be honoured on release but ignored on cancel.

## Tests

5 added, 4 confirmed failing before the fix (`# tests 57 / # pass 53 / # fail 4` on the filtered run):

- A release outside the element is not swallowed for other listeners (document `pointerup` **and** `mouseup`)
- The pressed element's own `pointerup`/`mouseup` listeners still fire
- `onPressUp` does not fire when released outside the element, while `onPressEnd` still does and `onPress` still doesn't
- Press events bubble to ancestor handlers when `continuePropagation()` is called
- Press events do **not** bubble to ancestors by default — added deliberately as the guard that this fix doesn't over-correct

Document-level listeners added by tests are removed in a `finally` so they cannot leak into later tests.

**One pre-existing test was changed:** `drag outside element and release still triggers end events` asserted 3 captured events including an `up` — it encoded defect B. It now expects 2 (`start`, `end`) plus an explicit assertion that no `up` event is captured. No assertions were removed; the `onPress`-not-fired assertion is intact.

Full suite: **902 tests, 899 pass, 3 skip, 0 fail** (897 baseline + 5 new). `--filter="press"` 57/57. `lint:types` clean.

## Verification status

Verified through the integration suite, which runs in real Chrome. Interactive browser verification of the downstream consumers (Button, CloseButton, Chip, and overlay outside-click on a live page) is being done centrally on an integration branch of all the current fixes; I'll follow up here if it turns anything up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

