### PR TITLE
fix(collapsible): ignore transitionend from descendants and stop leaking waiters

### DIFF
--- a/packages/frontile/src/components/utilities/collapsible.gts
+++ b/packages/frontile/src/components/utilities/collapsible.gts
@@ -7,6 +7,39 @@ import type Owner from '@ember/owner';
 
 const waiter = buildWaiter('frontile:collapsible');
 
+/**
+ * Runs a caller-supplied height through the browser's own CSS parser.
+ *
+ * `@initialHeight` ends up in an inline `style` attribute, so a value such as
+ * `10px; position: fixed` would otherwise smuggle in a second declaration.
+ * Assigning it to a detached element's `style.height` lets the CSSOM decide:
+ * it accepts every real height (`10px`, `2rem`, `50%`, `0`,
+ * `calc(1rem + 2px)`, `var(--x)`, …) and drops anything it cannot parse as a
+ * single height value — a trailing declaration included. Returns the parsed
+ * value, or `undefined` when the input is unusable.
+ */
+function parseHeight(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  // Reject anything that could terminate the declaration up front. The CSSOM
+  // check below catches this too, but the explicit test keeps the guarantee
+  // even where `document` has no real CSS parser (SSR / prerender).
+  if (/[;}]/.test(value)) {
+    return undefined;
+  }
+
+  if (typeof document === 'undefined') {
+    return value;
+  }
+
+  const probe = document.createElement('div');
+  probe.style.height = value;
+
+  return probe.style.height || undefined;
+}
+
 interface CollapsibleArgs {
   /**
    * If true, the content will be visible
@@ -15,7 +48,9 @@ interface CollapsibleArgs {
 
   /**
    * The height for the content in it's collapsed state.
-   * The unit of the value should be included, eg. '10px'.
+   * The unit of the value should be included, eg. '10px'. Any CSS height is
+   * accepted (`2rem`, `50%`, `calc(1rem + 2px)`, …); a value the CSS parser
+   * rejects is ignored and the content collapses to `0`.
    *
    * @defaultValue 0
    */
@@ -44,18 +79,28 @@ class Collapsible extends Component<CollapsibleSignature> {
     }
   }
 
+  /**
+   * `@initialHeight`, validated by the CSS parser. `undefined` when it was not
+   * given or could not be parsed as a height, in which case the collapsed
+   * state falls back to `0`.
+   */
+  get initialHeight(): string | undefined {
+    return parseHeight(this.args.initialHeight);
+  }
+
   get styles(): ReturnType<typeof safeStyles> {
     let styles: Record<string, string | number> = {};
+    const initialHeight = this.initialHeight;
 
     if (!this.isInitiallyOpen) {
       styles = {
         ...styles,
-        height: this.args.initialHeight || 0,
-        opacity: this.args.initialHeight ? '1' : '0'
+        height: initialHeight || 0,
+        opacity: initialHeight ? '1' : '0'
       };
     }
 
-    if (this.args.initialHeight || !this.isInitiallyOpen) {
+    if (initialHeight || !this.isInitiallyOpen) {
       styles = {
         ...styles,
         overflow: 'hidden'
@@ -110,12 +155,14 @@ class Collapsible extends Component<CollapsibleSignature> {
       return;
     }
 
+    const element = event.currentTarget as HTMLElement;
+
     if (
       (event.propertyName === 'height' || event.propertyName == 'opacity') &&
       this.args.isOpen
     ) {
-      (event.target as HTMLElement).style.height = 'auto';
-      (event.target as HTMLElement).style.overflow = '';
+      element.style.height = 'auto';
+      element.style.overflow = '';
     }
     if (this.waiterToken) {
       // when is opened, wait for height transition to finish
@@ -126,12 +173,12 @@ class Collapsible extends Component<CollapsibleSignature> {
         (this.args.isOpen && event.propertyName === 'height') ||
         (!this.args.isOpen &&
           event.propertyName === 'opacity' &&
-          (event.target as HTMLElement).style.opacity == '0') ||
+          element.style.opacity == '0') ||
         (this.args.isOpen &&
           event.propertyName === 'opacity' &&
-          (event.target as HTMLElement).style.opacity == '1') ||
+          element.style.opacity == '1') ||
         (!this.args.isOpen &&
-          this.args.initialHeight &&
+          this.initialHeight &&
           event.propertyName === 'height')
       ) {
         this.endWaiter();
@@ -176,10 +223,12 @@ class Collapsible extends Component<CollapsibleSignature> {
       ].join(', ');
 
       window.requestAnimationFrame(() => {
-        if (!this.args.initialHeight) {
+        const initialHeight = this.initialHeight;
+
+        if (!initialHeight) {
           element.style.opacity = '0';
         }
-        element.style.height = this.args.initialHeight || '0';
+        element.style.height = initialHeight || '0';
       });
     });
   }

--- a/packages/frontile/src/components/utilities/collapsible.gts
+++ b/packages/frontile/src/components/utilities/collapsible.gts
@@ -74,6 +74,9 @@ class Collapsible extends Component<CollapsibleSignature> {
     }
 
     if (this.isCurrentlyOpen !== !!isOpen) {
+      // A previous transition may still be in flight; end its token first so
+      // toggling faster than the animation cannot leak a test waiter.
+      this.endWaiter();
       this.waiterToken = waiter.beginAsync();
     }
 
@@ -84,7 +87,29 @@ class Collapsible extends Component<CollapsibleSignature> {
     }
   });
 
+  endWaiter(): void {
+    if (this.waiterToken) {
+      const token = this.waiterToken;
+      // Clear before ending so the same token can never be ended twice.
+      this.waiterToken = undefined;
+      waiter.endAsync(token);
+    }
+  }
+
+  willDestroy(): void {
+    super.willDestroy();
+    // Do not leave a waiter pending if we are torn down mid-transition.
+    this.endWaiter();
+  }
+
   onTransitionEnd = (event: TransitionEvent) => {
+    // `transitionend` bubbles, so ignore transitions of our own descendants.
+    // Otherwise any child that animates height/opacity would get our inline
+    // styles stamped onto it.
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
     if (
       (event.propertyName === 'height' || event.propertyName == 'opacity') &&
       this.args.isOpen
@@ -109,7 +134,7 @@ class Collapsible extends Component<CollapsibleSignature> {
           this.args.initialHeight &&
           event.propertyName === 'height')
       ) {
-        waiter.endAsync(this.waiterToken);
+        this.endWaiter();
       }
     }
   };

--- a/packages/frontile/src/utils/safe-styles.ts
+++ b/packages/frontile/src/utils/safe-styles.ts
@@ -9,17 +9,7 @@ export default function safeStyles(
   const styles: string[] = [];
 
   Object.keys(style).forEach((key): void => {
-    // Values come from component arguments, so strip declaration separators to
-    // keep a single value from injecting additional CSS declarations.
-    //
-    // Limitation: values that legitimately contain a `;` are not supported by
-    // this helper — the realistic case is a data URI, e.g.
-    // `background-image: url(data:image/png;base64,...)`, which this would
-    // silently corrupt. A caller needing such a value should set the property
-    // through the CSSOM (`element.style.setProperty(...)`) instead, which
-    // cannot inject extra declarations in the first place.
-    const value = String(style[key]).replace(/;/g, '');
-    styles.push(`${key}:${value}`);
+    styles.push(`${key}:${style[key]}`);
   });
 
   return htmlSafe(styles.join(';'));

--- a/packages/frontile/src/utils/safe-styles.ts
+++ b/packages/frontile/src/utils/safe-styles.ts
@@ -9,7 +9,17 @@ export default function safeStyles(
   const styles: string[] = [];
 
   Object.keys(style).forEach((key): void => {
-    styles.push(`${key}:${style[key]}`);
+    // Values come from component arguments, so strip declaration separators to
+    // keep a single value from injecting additional CSS declarations.
+    //
+    // Limitation: values that legitimately contain a `;` are not supported by
+    // this helper — the realistic case is a data URI, e.g.
+    // `background-image: url(data:image/png;base64,...)`, which this would
+    // silently corrupt. A caller needing such a value should set the property
+    // through the CSSOM (`element.style.setProperty(...)`) instead, which
+    // cannot inject extra declarations in the first place.
+    const value = String(style[key]).replace(/;/g, '');
+    styles.push(`${key}:${value}`);
   });
 
   return htmlSafe(styles.join(';'));

--- a/test-app/tests/integration/components/utilities/collapsible-test.gts
+++ b/test-app/tests/integration/components/utilities/collapsible-test.gts
@@ -1,8 +1,38 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { render, rerender, settled } from '@ember/test-helpers';
+import { getPendingWaiterState, getWaiters } from '@ember/test-waiters';
 import { Collapsible } from 'frontile';
 import { cell } from 'ember-resources';
+
+const WAITER_NAME = 'frontile:collapsible';
+
+function collapsibleWaiter() {
+  const waiter = getWaiters().find((w) => w.name === WAITER_NAME);
+
+  if (!waiter) {
+    throw new Error(`Could not find the '${WAITER_NAME}' test waiter`);
+  }
+
+  return waiter;
+}
+
+function isCollapsibleWaiterPending(): boolean {
+  return WAITER_NAME in getPendingWaiterState().waiters;
+}
+
+// Polls instead of `settled()` so a leaked waiter fails the assertion below
+// rather than hanging the test (and the whole suite) until QUnit times out.
+async function waitForCollapsibleWaiter(timeout = 3000): Promise<void> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    if (!isCollapsibleWaiterPending()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
 
 module(
   'Integration | Component | @frontile/utilities/Collapsible',
@@ -112,6 +142,199 @@ module(
       assert.dom('[data-test-id=collapsible]').hasStyle({ opacity: '1' });
       assert.dom('[data-test-id=collapsible]').hasStyle({ height: '2px' });
       assert.dom('[data-test-id=collapsible]').hasStyle({ overflow: 'hidden' });
+    });
+
+    test('does not let @initialHeight inject extra CSS declarations', async function (assert) {
+      await render(
+        <template>
+          <Collapsible
+            @isOpen={{false}}
+            @initialHeight="10px; position: fixed"
+            data-test-id="collapsible"
+          >
+            Content
+          </Collapsible>
+        </template>
+      );
+
+      assert
+        .dom('[data-test-id=collapsible]')
+        .hasStyle(
+          { position: 'static' },
+          'the injected declaration is not applied'
+        );
+      assert.dom('[data-test-id=collapsible]').hasStyle({ overflow: 'hidden' });
+    });
+
+    test('does not modify descendants when a transitionend bubbles up from a child', async function (assert) {
+      await render(
+        <template>
+          <Collapsible @isOpen={{true}} data-test-id="collapsible">
+            <div data-test-id="child">Content</div>
+          </Collapsible>
+        </template>
+      );
+
+      const collapsible = document.querySelector(
+        '[data-test-id=collapsible]'
+      ) as HTMLElement;
+      const child = document.querySelector(
+        '[data-test-id=child]'
+      ) as HTMLElement;
+
+      for (const propertyName of ['height', 'opacity']) {
+        child.dispatchEvent(
+          new TransitionEvent('transitionend', {
+            propertyName,
+            bubbles: true
+          })
+        );
+      }
+      await settled();
+
+      assert.strictEqual(
+        child.style.height,
+        '',
+        'the child keeps its own height'
+      );
+      assert.strictEqual(
+        child.style.overflow,
+        '',
+        'the child keeps its own overflow'
+      );
+      assert.strictEqual(
+        collapsible.style.height,
+        '',
+        'a descendant transition does not resize the collapsible either'
+      );
+
+      // The collapsible's own transitions must still be handled.
+      collapsible.dispatchEvent(
+        new TransitionEvent('transitionend', { propertyName: 'height' })
+      );
+      await settled();
+
+      assert.strictEqual(
+        collapsible.style.height,
+        'auto',
+        'its own transitionend still resets the collapsible to height auto'
+      );
+      assert.strictEqual(
+        child.style.height,
+        '',
+        'the child is still untouched'
+      );
+    });
+
+    test('resets its own height and overflow when the open transition ends', async function (assert) {
+      const isOpen = cell(false);
+      await render(
+        <template>
+          <Collapsible @isOpen={{isOpen.current}} data-test-id="collapsible">
+            Content
+          </Collapsible>
+        </template>
+      );
+
+      isOpen.current = true;
+      await settled();
+
+      const collapsible = document.querySelector(
+        '[data-test-id=collapsible]'
+      ) as HTMLElement;
+
+      assert.strictEqual(collapsible.style.height, 'auto', 'height is auto');
+      assert.strictEqual(collapsible.style.overflow, '', 'overflow is cleared');
+    });
+
+    test('does not leak a test waiter when toggled twice before the transition finishes', async function (assert) {
+      const isOpen = cell(false);
+      await render(
+        <template>
+          <Collapsible @isOpen={{isOpen.current}} data-test-id="collapsible">
+            Content
+          </Collapsible>
+        </template>
+      );
+
+      try {
+        isOpen.current = true;
+        await rerender();
+
+        isOpen.current = false;
+        await rerender();
+
+        await waitForCollapsibleWaiter();
+
+        assert.false(
+          isCollapsibleWaiterPending(),
+          'no collapsible test waiter is left pending after a rapid double toggle'
+        );
+      } finally {
+        // Keep a leak from hanging teardown (and every test after it).
+        collapsibleWaiter().reset();
+      }
+
+      await settled();
+      assert.dom('[data-test-id=collapsible]').hasStyle({ height: '0px' });
+    });
+
+    test('ends the test waiter only once per toggle', async function (assert) {
+      const waiter = collapsibleWaiter();
+      const originalEndAsync = waiter.endAsync;
+      let endCount = 0;
+
+      waiter.endAsync = function (token: unknown) {
+        endCount++;
+        return originalEndAsync.call(this, token);
+      };
+
+      try {
+        const isOpen = cell(false);
+        await render(
+          <template>
+            <Collapsible @isOpen={{isOpen.current}} data-test-id="collapsible">
+              Content
+            </Collapsible>
+          </template>
+        );
+
+        const collapsible = document.querySelector(
+          '[data-test-id=collapsible]'
+        ) as HTMLElement;
+
+        isOpen.current = true;
+        await rerender();
+        // `expand` applies the target styles inside a rAF callback.
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => resolve(null))
+        );
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => resolve(null))
+        );
+
+        assert.strictEqual(collapsible.style.opacity, '1', 'is expanding');
+
+        // Both the opacity and the height transition can satisfy the
+        // "opening finished" condition; only the first one may end the waiter.
+        for (const propertyName of ['opacity', 'height']) {
+          collapsible.dispatchEvent(
+            new TransitionEvent('transitionend', { propertyName })
+          );
+        }
+
+        await settled();
+
+        assert.strictEqual(
+          endCount,
+          1,
+          'endAsync is called exactly once for a single open toggle'
+        );
+        assert.false(isCollapsibleWaiterPending(), 'no waiter is left pending');
+      } finally {
+        waiter.endAsync = originalEndAsync;
+        collapsibleWaiter().reset();
+      }
     });
   }
 );

--- a/test-app/tests/integration/components/utilities/collapsible-test.gts
+++ b/test-app/tests/integration/components/utilities/collapsible-test.gts
@@ -21,6 +21,23 @@ function isCollapsibleWaiterPending(): boolean {
   return WAITER_NAME in getPendingWaiterState().waiters;
 }
 
+function collapsibleElement(): HTMLElement {
+  const element = document.querySelector('[data-test-id=collapsible]');
+
+  if (!element) {
+    throw new Error('Could not find the collapsible element');
+  }
+
+  return element as HTMLElement;
+}
+
+// `expand`/`contract` apply their target styles inside nested rAF callbacks.
+async function flushAnimationFrames(count = 2): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  }
+}
+
 // Polls instead of `settled()` so a leaked waiter fails the assertion below
 // rather than hanging the test (and the whole suite) until QUnit times out.
 async function waitForCollapsibleWaiter(timeout = 3000): Promise<void> {
@@ -166,6 +183,59 @@ module(
       assert.dom('[data-test-id=collapsible]').hasStyle({ overflow: 'hidden' });
     });
 
+    test('keeps every legitimate @initialHeight value', async function (assert) {
+      // `''` would mean the value was rejected, so assert on the inline style
+      // the component actually wrote rather than the computed one. The CSSOM
+      // re-serialises the math functions (Chrome reorders `calc` operands), so
+      // those are matched loosely.
+      const cases: [input: string, expected: string | RegExp][] = [
+        ['10px', '10px'],
+        ['2rem', '2rem'],
+        ['50%', '50%'],
+        ['0', '0px'],
+        ['calc(1rem + 2px)', /^calc\(.*1rem.*\)$/],
+        ['min(10px, 2rem)', /^min\(.*2rem.*\)$/],
+        ['clamp(1px, 2rem, 3rem)', /^clamp\(.*2rem.*\)$/],
+        ['var(--collapsible-height, 4px)', 'var(--collapsible-height, 4px)']
+      ];
+
+      for (const [input, expected] of cases) {
+        const initialHeight = cell(input);
+
+        await render(
+          <template>
+            <Collapsible
+              @isOpen={{false}}
+              @initialHeight={{initialHeight.current}}
+              data-test-id="collapsible"
+            >
+              Content
+            </Collapsible>
+          </template>
+        );
+
+        const height = collapsibleElement().style.height;
+
+        if (typeof expected === 'string') {
+          assert.strictEqual(
+            height,
+            expected,
+            `@initialHeight="${input}" is applied`
+          );
+        } else {
+          assert.ok(
+            expected.test(height),
+            `@initialHeight="${input}" is applied (got "${height}")`
+          );
+        }
+        assert.strictEqual(
+          collapsibleElement().style.opacity,
+          '1',
+          `@initialHeight="${input}" counts as a real height, so content stays visible`
+        );
+      }
+    });
+
     test('does not modify descendants when a transitionend bubbles up from a child', async function (assert) {
       await render(
         <template>
@@ -175,9 +245,7 @@ module(
         </template>
       );
 
-      const collapsible = document.querySelector(
-        '[data-test-id=collapsible]'
-      ) as HTMLElement;
+      const collapsible = collapsibleElement();
       const child = document.querySelector(
         '[data-test-id=child]'
       ) as HTMLElement;
@@ -239,9 +307,7 @@ module(
       isOpen.current = true;
       await settled();
 
-      const collapsible = document.querySelector(
-        '[data-test-id=collapsible]'
-      ) as HTMLElement;
+      const collapsible = collapsibleElement();
 
       assert.strictEqual(collapsible.style.height, 'auto', 'height is auto');
       assert.strictEqual(collapsible.style.overflow, '', 'overflow is cleared');
@@ -299,19 +365,11 @@ module(
           </template>
         );
 
-        const collapsible = document.querySelector(
-          '[data-test-id=collapsible]'
-        ) as HTMLElement;
+        const collapsible = collapsibleElement();
 
         isOpen.current = true;
         await rerender();
-        // `expand` applies the target styles inside a rAF callback.
-        await new Promise((resolve) =>
-          requestAnimationFrame(() => resolve(null))
-        );
-        await new Promise((resolve) =>
-          requestAnimationFrame(() => resolve(null))
-        );
+        await flushAnimationFrames();
 
         assert.strictEqual(collapsible.style.opacity, '1', 'is expanding');
 


### PR DESCRIPTION
## Problems

**1. A descendant's `transitionend` mutated consumer DOM.** `transitionend` bubbles, and `onTransitionEnd` never checked the event target before doing `(event.target as HTMLElement).style.height = 'auto'` and clearing `overflow`.

So any child inside an open collapsible that transitions `height` or `opacity` — a hover card, a nested accordion, a fading image, a Tailwind `transition-opacity` button — got `height: auto` stamped onto it as an inline style, permanently overriding its own layout.

**2. The test waiter was leaked and double-ended.** One `waiterToken` field, two defects:
- Toggling twice before the first transition finished called `beginAsync()` again and overwrote the token. The first was never ended, so `settled()` / `await click()` never resolves — a hang in the *consumer's* test suite.
- When opening, both the `height` branch and the `opacity == '1'` branch can match, so `endAsync` ran twice with the same token (never nulled).

**3. `@initialHeight` could inject extra CSS declarations.** It reaches an `htmlSafe` style string via `safeStyles`, which interpolates values verbatim, so `@initialHeight="10px; position: fixed"` smuggled in a second declaration. Not an XSS vector (Glimmer sets attributes through the DOM API), but a consumer-controlled value should not be able to add declarations.

## Fixes

- Ignore `transitionend` whose `target` is not the collapsible itself.
- Route every end through `endWaiter()`, which clears `waiterToken` *before* ending it so the same token can never be ended twice; end any in-flight token before `beginAsync()`; end the token in `willDestroy` so a teardown mid-transition doesn't leave a waiter pending.
- Validate `@initialHeight` in `Collapsible` itself; `safeStyles` is left exactly as it was on `main`. A shared helper that silently rewrites its caller's values is the wrong place for this, so the check lives where the untrusted value enters. Rather than a length regex — easy to get wrong on `calc`/`min`/`clamp`/`var()` — the value is assigned to a detached element's `style.height` and read back, letting the browser's own CSS parser decide: it keeps every real height and drops anything it cannot parse as one, a trailing declaration included. A rejected value falls back to the collapsed default of `0`.

## Tests

6 added (4 → 10). Four were confirmed failing before the fix; the two marked below are baseline guards that passed before and after.

- `does not modify descendants when a transitionend bubbles up from a child` — dispatches a synthetic bubbling `transitionend` from a child, asserts the child's inline `height`/`overflow` stay empty, then dispatches on the collapsible itself and asserts its own reset still works
- `does not leak a test waiter when toggled twice before the transition finishes` — polls `getPendingWaiterState()` rather than `settled()`, since a genuinely leaked waiter would hang the test itself
- `ends the test waiter only once per toggle`
- `does not let @initialHeight inject extra CSS declarations`
- `keeps every legitimate @initialHeight value` — `10px`, `2rem`, `50%`, `0`, `calc(1rem + 2px)`, `min()`, `clamp()`, `var()`; **passed before and after**, it exists to prove the new validation is not over-eager
- `resets its own height and overflow when the open transition ends` — the missing baseline coverage; **passed before and after**, added as a guard

No pre-existing test asserted the buggy behavior; the original 4 are untouched.

Full suite: **903 tests, 900 pass, 3 skip, 0 fail** (897 baseline + 6 new). `lint:types` clean.

## Two notes for the reviewer

1. **Defect 2b does not throw in the installed `@ember/test-waiters` 4.1.2** — after a first end the token is in the completed-operations map, so a double-end is silently tolerated rather than asserting. It is still wrong and is fixed, but the failure mode was quieter than expected.
2. **Pre-existing, deliberately not fixed here:** the open animation truncates. The opacity transition finishes at 0.3s and the handler's `height: auto` is not animatable, so the in-flight 0.4s height transition emits `transitioncancel` rather than `transitionend`. A consequence worth knowing: the `isOpen && propertyName === 'height'` branch in `onTransitionEnd` is largely dead in practice when opening without an `@initialHeight` — the opacity branch is what actually ends the waiter. Any future fix for the truncation should re-check that branch logic alongside it. This behavior is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

