### PR TITLE
fix(status): clamp progress bar percentage and fix value formatting

### DIFF
--- a/packages/frontile/src/components/status/progress-bar.gts
+++ b/packages/frontile/src/components/status/progress-bar.gts
@@ -73,8 +73,11 @@ interface ProgressBarSignature {
     showValueLabel?: boolean;
 
     /**
-     * The display format of the value.
-     * Values are formatted as a percentage by default.
+     * The display format of the value, passed to `Intl.NumberFormat`.
+     *
+     * A `percent` style formats the position on the min/max scale as a
+     * fraction; every other style formats the raw `progress` value. With no
+     * format options, the value is displayed as a whole percentage.
      */
     formatOptions?: Intl.NumberFormatOptions;
 
@@ -116,21 +119,37 @@ class ProgressBar extends Component<ProgressBarSignature> {
   }
 
   get minValue(): number {
-    return this.args.minValue || 0;
+    return this.args.minValue ?? 0;
   }
 
   get maxValue(): number {
-    return this.args.maxValue || 100;
+    return this.args.maxValue ?? 100;
   }
 
+  /**
+   * `@progress={{0}}` is a legitimate value, so this falls back to `minValue`
+   * only when nothing was passed — a truthiness check would report the bar as
+   * already at the bottom of the scale instead of at zero.
+   */
   get progress(): number {
-    return this.args.progress || this.minValue;
+    return this.args.progress ?? this.minValue;
   }
 
+  /**
+   * The position on the scale as 0–100. Clamped, because the result drives an
+   * inline `width` — an out-of-range or `NaN` percentage is dropped by the CSS
+   * parser, which renders as a silently empty bar rather than as an error.
+   * A non-positive range has no meaningful position, so it reports 0.
+   */
   get percentage(): number {
-    return (
-      ((this.progress - this.minValue) / (this.maxValue - this.minValue)) * 100
-    );
+    const range = this.maxValue - this.minValue;
+    if (range <= 0) {
+      return 0;
+    }
+
+    const percentage = ((this.progress - this.minValue) / range) * 100;
+
+    return Math.min(100, Math.max(0, percentage));
   }
 
   get showValueLabel(): boolean {
@@ -158,10 +177,20 @@ class ProgressBar extends Component<ProgressBarSignature> {
         ...(this.args.formatOptions || {})
       };
 
-      return new Intl.NumberFormat(
-        navigator?.language || 'en-US',
-        options
-      ).format(this.progress);
+      // `Intl` scales a `percent` style by 100 itself, so it has to be handed
+      // the fraction of the min–max range — passing the already-scaled
+      // percentage announces `@progress={{50}}` as "5,000%". Every other style
+      // (`decimal`, `currency`, `unit`) formats the raw value on its own scale.
+      const value =
+        options.style === 'percent' ? this.percentage / 100 : this.progress;
+
+      // `navigator` is a browser global with no counterpart in Node, so a bare
+      // `navigator?.language` is a hard `ReferenceError` rather than
+      // `undefined` when a ProgressBar is server-rendered.
+      const locale =
+        typeof navigator !== 'undefined' ? navigator.language : undefined;
+
+      return new Intl.NumberFormat(locale || 'en-US', options).format(value);
     }
 
     return this.percentage.toFixed(0) + '%';
@@ -170,9 +199,19 @@ class ProgressBar extends Component<ProgressBarSignature> {
   /**
    * ARIA requires aria-valuenow to be absent when the value is unknown —
    * reporting a number would announce "0%" rather than "amount unknown".
+   *
+   * Otherwise it is clamped to the scale, because assistive technology
+   * announces a percentage computed from valuenow/valuemin/valuemax. Reporting
+   * a raw 150 on a 0–100 scale would say "150%" to a screen-reader user while
+   * the bar sits pinned at 100% for everyone else — the people who cannot see
+   * the bar would be the only ones given the wrong number.
    */
   get ariaValueNow(): number | undefined {
-    return this.args.isIndeterminate ? undefined : this.progress;
+    if (this.args.isIndeterminate) {
+      return undefined;
+    }
+
+    return Math.min(this.maxValue, Math.max(this.minValue, this.progress));
   }
 
   get progressWidth(): SafeString {

--- a/packages/frontile/src/components/status/progress-bar.md
+++ b/packages/frontile/src/components/status/progress-bar.md
@@ -161,6 +161,79 @@ import { hash } from '@ember/helper';
 </template>
 ```
 
+### `@formatOptions`
+
+`@formatOptions` is passed straight to `Intl.NumberFormat`, and which number it
+formats depends on the `style`:
+
+| `style`                          | What is formatted                        | `@progress={{50}}` on a 0–100 scale |
+| -------------------------------- | ---------------------------------------- | ----------------------------------- |
+| `percent`                        | The position on the scale, as a fraction | `50%`                               |
+| `decimal`, `currency`, `unit`, … | The raw `@progress` value                | `50`, `$50.00`, …                   |
+
+`Intl` scales a `percent` style by 100 itself, so it is handed the fraction
+rather than the already-computed percentage — otherwise `50` would be announced
+as `5,000%`. Because it formats the _position_, a `percent` style respects
+`@minValue`/`@maxValue`: `@progress={{20}}` on a 10–30 scale reads `50%`.
+
+```gts preview
+import { ProgressBar } from 'frontile';
+import { hash } from '@ember/helper';
+
+<template>
+  <div class='mt-6 grid grid-cols-2 gap-4 items-end'>
+    <ProgressBar
+      @progress={{50}}
+      @label='Percent style'
+      @formatOptions={{(hash style='percent')}}
+    />
+    <ProgressBar
+      @progress={{20}}
+      @minValue={{10}}
+      @maxValue={{30}}
+      @label='Percent style, 10–30 scale'
+      @formatOptions={{(hash style='percent')}}
+    />
+  </div>
+</template>
+```
+
+With no `@formatOptions` and no `@valueLabel`, the value label is the position
+rounded to a whole percentage — `50%`.
+
+## Out-of-range values
+
+The rendered width is clamped to 0–100%, so a `@progress` above `@maxValue` fills
+the track rather than overflowing it, and one below `@minValue` (or negative)
+renders empty. A `@minValue` equal to `@maxValue` has no meaningful position and
+renders at 0% instead of emitting an invalid width.
+
+`aria-valuenow` is clamped to the same range. Assistive technology derives the
+percentage it announces from `aria-valuenow` against
+`aria-valuemin`/`aria-valuemax`, so reporting a raw `150` would announce "150%"
+to a screen-reader user while the bar sits pinned at 100% for everyone else —
+the people who cannot see the bar would be the only ones given the wrong
+number. ARIA also requires `aria-valuenow` to fall within the declared range.
+
+In the demo below, both bars report a value on the scale — `100` and `0` —
+matching what they render.
+
+```gts preview
+import { ProgressBar } from 'frontile';
+
+<template>
+  <div class='grid grid-cols-2 gap-4 items-end'>
+    <ProgressBar @progress={{150}} @label='Progress of 150' />
+    <ProgressBar @progress={{-20}} @label='Progress of -20' />
+  </div>
+</template>
+```
+
+Clamping is a display safeguard, not validation — nothing warns about an
+out-of-range value, since a legitimately jittery source (a byte count
+overshooting its total) would warn on every render. A bar pinned at 100% is the
+signal.
+
 ## ProgressBar Description
 
 ```gts preview
@@ -218,6 +291,9 @@ position on the scale you defined rather than a raw percentage.
 | `@label`                | Becomes the progress bar's accessible name, wired with `aria-labelledby`.                        |
 | `@minValue`/`@maxValue` | Set the scale, so `@progress={{20}}` on a 10–30 scale is reported as halfway rather than as 20%. |
 | `@description`          | Visible text only. It is **not** associated with the progress bar.                               |
+
+`aria-valuenow` is clamped to `@minValue`/`@maxValue`; see
+[Out-of-range values](#out-of-range-values).
 
 ### `@label` is what names it
 

--- a/test-app/tests/integration/components/status/progress-bar-test.gts
+++ b/test-app/tests/integration/components/status/progress-bar-test.gts
@@ -312,19 +312,20 @@ module(
         );
       });
 
-      // The bug here was `||` swallowing a legitimate 0: `@progress={{0}}` on a
-      // 10–30 scale used to compute as though progress were 10, giving a
-      // non-zero width. The reported value is a separate matter — 0 is below
-      // the scale, so `aria-valuenow` is clamped up to `minValue` rather than
-      // announcing a position that does not exist on the scale.
+      // `||` swallowed a legitimate 0, substituting `minValue`. A 0-anchored
+      // scale cannot catch that — both readings land on the same width — so
+      // this straddles zero: on a -10–10 scale, a real 0 sits at the midpoint
+      // (50%), while the substituted -10 sits at the bottom (0%). The reported
+      // value is a separate matter: 0 is inside this scale, so `aria-valuenow`
+      // is 0, whereas the substituted -10 would be reported as -10.
       test('it treats a progress of 0 as 0, not as minValue', async function (assert) {
         await render(
           <template>
             <ProgressBar
               data-test-id="progress-bar"
               @progress={{0}}
-              @minValue={{10}}
-              @maxValue={{30}}
+              @minValue={{-10}}
+              @maxValue={{10}}
               @label="Progress"
             />
           </template>
@@ -333,12 +334,13 @@ module(
         const selector = '[data-test-id="progress-bar"] div.pb-progress';
         assert.equal(
           document.querySelector(selector)?.getAttribute('style'),
-          'width: 0%'
+          'width: 50%',
+          'a real 0 sits at the midpoint of a -10–10 scale, not at the bottom'
         );
         assert
           .dom('[data-test-id="progress-bar"] div.pb-label > div')
-          .containsText('0%');
-        assert.dom(selector).hasAria('valuenow', '10');
+          .containsText('50%');
+        assert.dom(selector).hasAria('valuenow', '0');
       });
 
       test('it renders 50% width when indeterminate', async function (assert) {

--- a/test-app/tests/integration/components/status/progress-bar-test.gts
+++ b/test-app/tests/integration/components/status/progress-bar-test.gts
@@ -231,6 +231,132 @@ module(
         assert.dom(selector).hasAria('valuemin', '10');
         assert.dom(selector).hasAria('valuemax', '30');
       });
+
+      test('it clamps progress above maxValue to 100%', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar data-test-id="progress-bar" @progress={{150}} />
+          </template>
+        );
+
+        const selector = '[data-test-id="progress-bar"] div.pb-progress';
+        assert.equal(
+          document.querySelector(selector)?.getAttribute('style'),
+          'width: 100%'
+        );
+        // Assistive technology derives the announced percentage from
+        // valuenow/valuemin/valuemax, so a raw 150 here would say "150%" while
+        // the bar is pinned at 100% for sighted users.
+        assert.dom(selector).hasAria('valuenow', '100');
+      });
+
+      test('it clamps progress below minValue to 0%', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar
+              data-test-id="progress-bar"
+              @progress={{5}}
+              @minValue={{10}}
+              @maxValue={{30}}
+            />
+          </template>
+        );
+
+        const selector = '[data-test-id="progress-bar"] div.pb-progress';
+        assert.equal(
+          document.querySelector(selector)?.getAttribute('style'),
+          'width: 0%'
+        );
+        assert.dom(selector).hasAria('valuenow', '10');
+      });
+
+      test('it clamps a negative progress to 0%', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar data-test-id="progress-bar" @progress={{-20}} />
+          </template>
+        );
+
+        const selector = '[data-test-id="progress-bar"] div.pb-progress';
+        assert.equal(
+          document.querySelector(selector)?.getAttribute('style'),
+          'width: 0%'
+        );
+        assert.dom(selector).hasAria('valuenow', '0');
+      });
+
+      test('it renders a valid width when minValue equals maxValue', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar
+              data-test-id="progress-bar"
+              @progress={{50}}
+              @minValue={{50}}
+              @maxValue={{50}}
+            />
+          </template>
+        );
+
+        const selector = '[data-test-id="progress-bar"] div.pb-progress';
+        const element = document.querySelector(selector) as HTMLElement;
+
+        assert.equal(element.getAttribute('style'), 'width: 0%');
+        assert.notOk(
+          (element.getAttribute('style') || '').includes('NaN'),
+          'the inline width is never NaN%'
+        );
+        assert.equal(
+          element.style.width,
+          '0%',
+          'the CSS parser accepts the declared width'
+        );
+      });
+
+      // The bug here was `||` swallowing a legitimate 0: `@progress={{0}}` on a
+      // 10–30 scale used to compute as though progress were 10, giving a
+      // non-zero width. The reported value is a separate matter — 0 is below
+      // the scale, so `aria-valuenow` is clamped up to `minValue` rather than
+      // announcing a position that does not exist on the scale.
+      test('it treats a progress of 0 as 0, not as minValue', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar
+              data-test-id="progress-bar"
+              @progress={{0}}
+              @minValue={{10}}
+              @maxValue={{30}}
+              @label="Progress"
+            />
+          </template>
+        );
+
+        const selector = '[data-test-id="progress-bar"] div.pb-progress';
+        assert.equal(
+          document.querySelector(selector)?.getAttribute('style'),
+          'width: 0%'
+        );
+        assert
+          .dom('[data-test-id="progress-bar"] div.pb-label > div')
+          .containsText('0%');
+        assert.dom(selector).hasAria('valuenow', '10');
+      });
+
+      test('it renders 50% width when indeterminate', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar
+              data-test-id="progress-bar"
+              @isIndeterminate={{true}}
+            />
+          </template>
+        );
+
+        const selector = '[data-test-id="progress-bar"] div.pb-progress';
+        assert.equal(
+          document.querySelector(selector)?.getAttribute('style'),
+          'width: 50%'
+        );
+      });
     });
 
     module('indeterminate arias', () => {
@@ -328,6 +454,66 @@ module(
         assert
           .dom('[data-test-id="progress-bar"] div.pb-label > div')
           .containsText('$20.00');
+      });
+
+      // Intl multiplies a `percent` style by 100, so it has to be fed the
+      // fraction of the min–max range, not the already-scaled percentage.
+      test('it formats a percent style value label without scaling it twice', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar
+              data-test-id="progress-bar"
+              @progress={{50}}
+              @label="Progress"
+              @formatOptions={{(hash style="percent")}}
+            />
+          </template>
+        );
+        const selector = '[data-test-id="progress-bar"] div.pb-label > div';
+        assert.dom(selector).containsText('50%');
+        assert.dom(selector).doesNotContainText('5,000');
+      });
+
+      test('it formats a percent style value label against the min/max range', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar
+              data-test-id="progress-bar"
+              @progress={{20}}
+              @label="Progress"
+              @minValue={{10}}
+              @maxValue={{30}}
+              @formatOptions={{(hash style="percent")}}
+            />
+          </template>
+        );
+        assert
+          .dom('[data-test-id="progress-bar"] div.pb-label > div')
+          .containsText('50%');
+      });
+
+      test('it shows the value label by default when a label is given', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar
+              data-test-id="progress-bar"
+              @progress={{40}}
+              @label="Progress"
+            />
+          </template>
+        );
+        assert
+          .dom('[data-test-id="progress-bar"] div.pb-label > div')
+          .containsText('40%');
+      });
+
+      test('it renders no label row when no label is given', async function (assert) {
+        await render(
+          <template>
+            <ProgressBar data-test-id="progress-bar" @progress={{40}} />
+          </template>
+        );
+        assert.dom('[data-test-id="progress-bar"] div.pb-label').doesNotExist();
       });
 
       test('it hides value label if showValueLabel false', async function (assert) {


### PR DESCRIPTION
## Problems

**1. `percentage` was unclamped and undefended against a zero range.**
- `@minValue` equal to `@maxValue` → division by zero → `Infinity`/`NaN` → `style="width: NaN%"`, which the CSS parser drops, so the bar silently rendered at zero with no warning.
- `@progress={{150}}` on the default 0–100 scale → 150% width, a bar overflowing its track.
- Negative values → a negative width, also dropped.

**2. `get progress()` swallowed a legitimate `0`.** `this.args.progress || this.minValue` meant `@progress={{0}}` was computed as though progress were `minValue` — the wrong position on the scale and a wrong label. On a `-10`–`10` scale, a real `0` is the midpoint (50%) but rendered at the bottom (0%).

**3. Percent formatting was wrong by 100×.** The arg docs say values are formatted as a percentage by default, but `formattedValueLabel` passed the raw `progress` to `Intl.NumberFormat`, which multiplies a `percent` style by 100 itself. So the documented `@formatOptions={{hash style="percent"}}` with `@progress={{50}}` announced **"5,000%"**.

**4. `navigator?.language` was not SSR-safe.** Optional chaining does not protect an *undeclared* global — if `navigator` doesn't exist this throws `ReferenceError`, and this repo prerenders its documentation site.

## Fixes

- `percentage` clamps to 0–100 and returns 0 when the range is not positive.
- `progress`, `minValue`, and `maxValue` use `??` instead of `||`. (`@maxValue={{0}}` previously became `100` silently — same class of defect; now a zero range, which `percentage` handles safely.)
- `formattedValueLabel` feeds a `percent` style the fraction of the min–max range, and every other style (`decimal`, `currency`, `unit`) the raw `progress`. This makes `style="percent"` a locale-aware equivalent of the default label — the two now agree — and makes it respect `@minValue`/`@maxValue`, so `@progress={{20}}` on a 10–30 scale reads `50%`. Raw-value styles keep the consumer's own units, which is what the existing currency tests expect.
- `typeof navigator !== 'undefined'` guard, following the precedent already documented for `File`/`FileList` in `utils/nested-data.ts`.
- **`aria-valuenow` clamps to the scale too.** ARIA requires it to sit within `valuemin`/`valuemax`, and assistive technology computes the announced percentage from those three. Reporting a raw `150` meant a sighted user saw a bar pinned at 100% while a screen-reader user was told "150%" — the wrong answer going to exactly the people who cannot see the bar. The indeterminate early-return is preserved, so `aria-valuenow` is still *absent* rather than clamped in that state.

Clamping is a display safeguard, not validation: nothing warns, deliberately, since a legitimately jittery value (byte counts overshooting a total) would spam a warning on every render. Documented so nobody adds one later.

## Tests

10 added (22 → 32); the bug reproductions were confirmed failing first, with the exact wrong values in the output — `5,000%` and `2,000%` for the percent style, `width: NaN%` / overflowing widths for the clamp cases, and `width: 0%` where a real `0` should sit mid-scale for the `||` case.

- clamps above `maxValue` / below `minValue` / negative → asserts both the width and the reported `aria-valuenow`
- renders a valid width when `minValue` equals `maxValue` — asserts the `style` contains no `NaN` *and* that `element.style.width === '0%'`, i.e. the CSS parser actually accepted it
- treats a progress of `0` as `0`, not as `minValue` — on a **-10–10 scale that straddles zero**, so the two readings are distinguishable: a real `0` is the midpoint (`width: 50%`, label `50%`, `aria-valuenow="0"`), while the `||` substitution of `minValue` pins it at the bottom (`width: 0%`, label `0%`, `aria-valuenow="-10"`). An earlier version of this test used a 10–30 scale, where `0` and the substituted `10` both compute to `0%` and both clamp `aria-valuenow` to `10` — every assertion was insensitive to the fix. Re-verified by reverting the `??` and watching it fail.
- formats a percent style without scaling it twice, and against the min/max range
- regression guards: indeterminate 50% width (previously unasserted), `@showValueLabel` defaulting, no label row when no label

No assertions were deleted. Full suite: **907 tests, 904 pass, 3 skip, 0 fail** (897 baseline + 10 new). `lint:types` clean.

## Notes

- The default label is derived from the clamped percentage, so `@progress={{150}}` displays `100%` — consistent with both the bar and the now-clamped `aria-valuenow`.
- An inverted scale (`@maxValue` < `@minValue`) resolves to `maxValue` for the reported value and `0%` for the width. Coherent but untested — a caller error with no defined correct rendering.
- The SSR guard is not covered by an executing test: the browser test environment always has `navigator`, so there is no honest way to exercise it from the integration suite. It follows an established in-repo precedent instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

