### PR TITLE
fix(table): stop hijacking keys from interactive cell content

### DIFF
--- a/packages/frontile/src/components/collections/table.md
+++ b/packages/frontile/src/components/collections/table.md
@@ -1207,11 +1207,19 @@ export default class DemoComponent extends Component {
 
 ### Keyboard Navigation
 
-When selection is enabled, rows can be selected using keyboard:
+When selection is enabled, rows follow the WAI-ARIA grid pattern:
 
+- **Tab**: Moves into the rows. The table is a single tab stop — it uses a
+  roving `tabindex`, so exactly one row is tabbable at a time. That is the first
+  selected row, or the first row when nothing is selected.
+- **Arrow Down** / **Arrow Up**: Move focus between rows, carrying the
+  `tabindex="0"` along with focus.
 - **Space** or **Enter**: Toggle selection (multiple mode) or select row (single mode)
-- Rows are focusable with `tabindex="0"` for keyboard accessibility
-- Disabled rows cannot be selected via keyboard
+- Disabled rows cannot be selected via keyboard, but can still be focused
+- Interactive content inside cells keeps its own keys: a button, link or input in
+  a cell handles Enter, Space and the arrow keys itself, and the row does not
+  toggle its selection. Row keyboard handling only applies to keys pressed on the
+  row itself.
 
 ```gts preview
 import Component from '@glimmer/component';

--- a/packages/frontile/src/components/collections/table/table.gts
+++ b/packages/frontile/src/components/collections/table/table.gts
@@ -298,6 +298,11 @@ class Table<
     return keys ? new Set(keys) : new Set();
   }
 
+  // Roving tabindex (WAI-ARIA grid pattern): the key of the row the user last
+  // moved to with the keyboard. `undefined` until they move — see
+  // `rovingRowKey` for the default tab stop.
+  @tracked activeRowKey?: string;
+
   // Extract actual data from row (handles both row.data and direct row)
   getRowData = (row: Row<T>): T => {
     if (row.data && row.table) {
@@ -308,10 +313,10 @@ class Table<
 
   // Get key from item or row - unified method
   getKey = (itemOrRow: T | Row<T>): string => {
-    // Extract the actual item from row if needed
-    const item = (itemOrRow as Row<T>).data
-      ? this.getRowData(itemOrRow as Row<T>)
-      : (itemOrRow as T);
+    // Extract the actual item from row if needed. `getRowData` already returns
+    // the argument untouched when it is not a table row, so a plain item that
+    // happens to have a `data` property is not mistaken for one.
+    const item = this.getRowData(itemOrRow as Row<T>);
 
     // Use provided getKey function if available
     if (this.args.getKey) {
@@ -326,6 +331,28 @@ class Table<
       // Final fallback
       return String(item);
     }
+  };
+
+  // The single row that owns the table's tab stop. Defaults to the first
+  // selected row - so tabbing back into the table lands on the user's own
+  // selection - and to the first row when nothing is selected.
+  @cached
+  get rovingRowKey(): string | undefined {
+    // `sortedItems` is what feeds the headless table, so this is row order.
+    const keys = this.sortedItems.map((item) => this.getKey(item));
+
+    if (this.activeRowKey !== undefined && keys.includes(this.activeRowKey)) {
+      return this.activeRowKey;
+    }
+
+    return keys.find((key) => this.selectedKeysSet.has(key)) ?? keys[0];
+  }
+
+  // Only one row is tabbable at a time; arrow keys move the tab stop along
+  // with focus. Without selection, rows are not part of the tab order at all.
+  rowTabIndex = (row: Row<T>): string => {
+    if (!this.hasSelection) return '-1';
+    return this.getKey(row) === this.rovingRowKey ? '0' : '-1';
   };
 
   // Check if a key is disabled
@@ -398,6 +425,11 @@ class Table<
   handleRowKeydown = (row: Row<T>, event: KeyboardEvent): void => {
     if (!this.hasSelection) return;
 
+    // Only react to keys pressed on the row itself. Anything bubbling up from
+    // interactive cell content (buttons, links, inputs) belongs to that
+    // control, not to the row.
+    if (event.target !== event.currentTarget) return;
+
     // Handle arrow key navigation
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault();
@@ -410,11 +442,18 @@ class Table<
       ) as HTMLElement[];
 
       const currentIndex = allRows.indexOf(currentElement);
+      let nextRow: HTMLElement | undefined;
 
       if (event.key === 'ArrowDown' && currentIndex < allRows.length - 1) {
-        allRows[currentIndex + 1]?.focus();
+        nextRow = allRows[currentIndex + 1];
       } else if (event.key === 'ArrowUp' && currentIndex > 0) {
-        allRows[currentIndex - 1]?.focus();
+        nextRow = allRows[currentIndex - 1];
+      }
+
+      if (nextRow) {
+        nextRow.focus();
+        // Keep the roving tab stop on the focused row.
+        this.activeRowKey = nextRow.dataset['key'];
       }
 
       return;
@@ -431,6 +470,9 @@ class Table<
 
     const key = this.getKey(row.data);
     const isSelected = this.isRowSelected(row);
+
+    // This row is focused, so it keeps the tab stop even as selection changes.
+    this.activeRowKey = key;
 
     if (this.selectionMode === 'single') {
       // Single selection: always select the row
@@ -785,7 +827,7 @@ class Table<
               data-selected={{if (this.isRowSelected row) "true" "false"}}
               data-disabled={{if (this.isRowDisabled row) "true"}}
               data-selectable={{if this.hasSelection "true"}}
-              tabindex={{if this.hasSelection "0" "-1"}}
+              tabindex={{this.rowTabIndex row}}
             >
               {{#each this.headlessColumns as |column|}}
                 <t.Cell

--- a/packages/frontile/src/components/collections/table/table.gts
+++ b/packages/frontile/src/components/collections/table/table.gts
@@ -313,9 +313,10 @@ class Table<
 
   // Get key from item or row - unified method
   getKey = (itemOrRow: T | Row<T>): string => {
-    // Extract the actual item from row if needed. `getRowData` already returns
-    // the argument untouched when it is not a table row, so a plain item that
-    // happens to have a `data` property is not mistaken for one.
+    // Extract the actual item from row if needed. Note `getRowData`'s check is
+    // structural, so a plain item carrying both `data` and `table` is still
+    // unwrapped as though it were a row — pass `Row` objects here wherever the
+    // keys have to line up with the rendered rows.
     const item = this.getRowData(itemOrRow as Row<T>);
 
     // Use provided getKey function if available
@@ -338,8 +339,11 @@ class Table<
   // selection - and to the first row when nothing is selected.
   @cached
   get rovingRowKey(): string | undefined {
-    // `sortedItems` is what feeds the headless table, so this is row order.
-    const keys = this.sortedItems.map((item) => this.getKey(item));
+    // Key off the same `Row` objects the template iterates, so this and
+    // `rowTabIndex` always agree. Mapping `sortedItems` instead would diverge
+    // for an item carrying both `data` and `table`, which `getRowData` unwraps
+    // — leaving the table with no tab stop at all.
+    const keys = [...this.headlessRows].map((row) => this.getKey(row));
 
     if (this.activeRowKey !== undefined && keys.includes(this.activeRowKey)) {
       return this.activeRowKey;

--- a/test-app/tests/integration/components/collections/table-selection-test.gts
+++ b/test-app/tests/integration/components/collections/table-selection-test.gts
@@ -1,6 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, click, triggerKeyEvent } from '@ember/test-helpers';
+import {
+  render,
+  settled,
+  click,
+  focus,
+  triggerKeyEvent
+} from '@ember/test-helpers';
+import { on } from '@ember/modifier';
 import { Table, type ColumnConfig } from 'frontile';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -942,6 +949,334 @@ module(
         row2,
         'Second row should be focused after ArrowUp'
       );
+    });
+
+    test('it does not hijack Enter or Space from a button inside a cell', async function (assert) {
+      const columns = [
+        { key: 'name', name: 'Name' },
+        { key: 'email', name: 'Email' }
+      ] as const satisfies ColumnConfig<TestItem>[];
+
+      const items: TestItem[] = [
+        { id: '1', name: 'John Doe', email: 'john@example.com', role: 'admin' },
+        { id: '2', name: 'Jane Smith', email: 'jane@example.com', role: 'user' }
+      ];
+
+      let clicks = 0;
+      const handleClick = () => {
+        clicks += 1;
+      };
+
+      await render(
+        <template>
+          <TestHelper as |selectedKeys onSelectionChange|>
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @selectionMode="multiple"
+              @selectedKeys={{selectedKeys}}
+              @onSelectionChange={{onSelectionChange}}
+            >
+              <:cell as |c|>
+                <c.For @key="name">
+                  <button
+                    type="button"
+                    data-test-id="cell-button"
+                    {{on "click" handleClick}}
+                  >{{c.value}}</button>
+                </c.For>
+                <c.Default>{{c.value}}</c.Default>
+              </:cell>
+            </Table>
+          </TestHelper>
+        </template>
+      );
+
+      // The keydown bubbles past the <tr> up to here, so `defaultPrevented`
+      // tells us whether the row handler swallowed the key. A prevented Enter
+      // or Space would stop the browser from activating the button.
+      const prevented: boolean[] = [];
+      this.element.addEventListener('keydown', (event) => {
+        prevented.push((event as KeyboardEvent).defaultPrevented);
+      });
+
+      await focus('[data-test-id="cell-button"]');
+      await triggerKeyEvent('[data-test-id="cell-button"]', 'keydown', 'Enter');
+      await triggerKeyEvent('[data-test-id="cell-button"]', 'keydown', ' ');
+
+      assert.deepEqual(
+        prevented,
+        [false, false],
+        'Enter and Space are left for the button to handle'
+      );
+
+      assert
+        .dom('[data-test-id="table-row"][data-key="1"]')
+        .hasAttribute(
+          'data-selected',
+          'false',
+          'row selection is not toggled by Enter/Space on the button'
+        );
+
+      // The button itself still works.
+      await click('[data-test-id="cell-button"]');
+      assert.strictEqual(clicks, 1, "the button's own handler fires on click");
+    });
+
+    test('it does not hijack arrow keys from an input inside a cell', async function (assert) {
+      const columns = [
+        { key: 'name', name: 'Name' },
+        { key: 'email', name: 'Email' }
+      ] as const satisfies ColumnConfig<TestItem>[];
+
+      const items: TestItem[] = [
+        { id: '1', name: 'John Doe', email: 'john@example.com', role: 'admin' },
+        {
+          id: '2',
+          name: 'Jane Smith',
+          email: 'jane@example.com',
+          role: 'user'
+        },
+        { id: '3', name: 'Bob Wilson', email: 'bob@example.com', role: 'user' }
+      ];
+
+      await render(
+        <template>
+          <TestHelper as |selectedKeys onSelectionChange|>
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @selectionMode="multiple"
+              @selectedKeys={{selectedKeys}}
+              @onSelectionChange={{onSelectionChange}}
+            >
+              <:cell as |c|>
+                <c.For @key="name">
+                  <input data-test-id="cell-input" value={{c.value}} />
+                </c.For>
+                <c.Default>{{c.value}}</c.Default>
+              </:cell>
+            </Table>
+          </TestHelper>
+        </template>
+      );
+
+      const prevented: boolean[] = [];
+      this.element.addEventListener('keydown', (event) => {
+        prevented.push((event as KeyboardEvent).defaultPrevented);
+      });
+
+      // Focus the input in the SECOND row, so a buggy handler that jumps to the
+      // first row is unmistakable.
+      const cellInput = this.element.querySelectorAll<HTMLInputElement>(
+        '[data-test-id="cell-input"]'
+      )[1];
+      cellInput?.focus();
+
+      await triggerKeyEvent(cellInput!, 'keydown', 'ArrowDown');
+      await triggerKeyEvent(cellInput!, 'keydown', 'ArrowUp');
+
+      assert.strictEqual(
+        document.activeElement,
+        cellInput,
+        'focus stays in the input instead of jumping to a row'
+      );
+
+      assert.deepEqual(
+        prevented,
+        [false, false],
+        'arrow keys are left for the input caret'
+      );
+    });
+
+    test('it uses a roving tabindex so the table has a single tab stop', async function (assert) {
+      const columns = [
+        { key: 'id', name: 'ID' },
+        { key: 'name', name: 'Name' }
+      ] as const satisfies ColumnConfig<TestItem>[];
+
+      const items: TestItem[] = [
+        { id: '1', name: 'John Doe', email: 'john@example.com', role: 'admin' },
+        {
+          id: '2',
+          name: 'Jane Smith',
+          email: 'jane@example.com',
+          role: 'user'
+        },
+        { id: '3', name: 'Bob Wilson', email: 'bob@example.com', role: 'user' }
+      ];
+
+      await render(
+        <template>
+          <TestHelper as |selectedKeys onSelectionChange|>
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @selectionMode="multiple"
+              @selectedKeys={{selectedKeys}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </TestHelper>
+        </template>
+      );
+
+      const tabbableKeys = () =>
+        Array.from(
+          this.element.querySelectorAll<HTMLElement>(
+            '[data-test-id="table-row"][tabindex="0"]'
+          )
+        ).map((row) => row.dataset.key);
+
+      assert.dom('[data-test-id="table-row"]').exists({ count: 3 });
+      assert.deepEqual(
+        tabbableKeys(),
+        ['1'],
+        'only the first row is tabbable initially'
+      );
+      assert
+        .dom('[data-test-id="table-row"][data-key="2"]')
+        .hasAttribute(
+          'tabindex',
+          '-1',
+          'other rows are removed from tab order'
+        );
+
+      const row1 = this.element.querySelector<HTMLElement>(
+        '[data-test-id="table-row"][data-key="1"]'
+      );
+      row1?.focus();
+
+      await triggerKeyEvent(
+        '[data-test-id="table-row"][data-key="1"]',
+        'keydown',
+        'ArrowDown'
+      );
+
+      assert.deepEqual(
+        tabbableKeys(),
+        ['2'],
+        'the tab stop moves with focus on ArrowDown'
+      );
+      assert
+        .dom('[data-test-id="table-row"][data-key="1"]')
+        .hasAttribute(
+          'tabindex',
+          '-1',
+          'the previous row leaves the tab order'
+        );
+    });
+
+    test('it puts the roving tabindex on the first selected row', async function (assert) {
+      const columns = [
+        { key: 'id', name: 'ID' },
+        { key: 'name', name: 'Name' }
+      ] as const satisfies ColumnConfig<TestItem>[];
+
+      const items: TestItem[] = [
+        { id: '1', name: 'John Doe', email: 'john@example.com', role: 'admin' },
+        {
+          id: '2',
+          name: 'Jane Smith',
+          email: 'jane@example.com',
+          role: 'user'
+        },
+        { id: '3', name: 'Bob Wilson', email: 'bob@example.com', role: 'user' }
+      ];
+
+      const initialKeys = new Set(['2']);
+
+      await render(
+        <template>
+          <TestHelper
+            @initialKeys={{initialKeys}}
+            as |selectedKeys onSelectionChange|
+          >
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @selectionMode="multiple"
+              @selectedKeys={{selectedKeys}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </TestHelper>
+        </template>
+      );
+
+      assert
+        .dom('[data-test-id="table-row"][data-key="2"]')
+        .hasAttribute('tabindex', '0', 'the selected row owns the tab stop');
+      assert
+        .dom('[data-test-id="table-row"][tabindex="0"]')
+        .exists({ count: 1 });
+    });
+
+    test('it does not add row tab stops when selection is disabled', async function (assert) {
+      const columns = [
+        { key: 'id', name: 'ID' },
+        { key: 'name', name: 'Name' }
+      ] as const satisfies ColumnConfig<TestItem>[];
+
+      const items: TestItem[] = [
+        { id: '1', name: 'John Doe', email: 'john@example.com', role: 'admin' },
+        { id: '2', name: 'Jane Smith', email: 'jane@example.com', role: 'user' }
+      ];
+
+      await render(
+        <template><Table @columns={{columns}} @items={{items}} /></template>
+      );
+
+      assert
+        .dom('[data-test-id="table-row"][tabindex="0"]')
+        .doesNotExist('no row is tabbable without selection');
+    });
+
+    test('it derives keys correctly for items that have their own `data` property', async function (assert) {
+      interface PayloadItem {
+        id: string;
+        name: string;
+        data: string;
+        table: string;
+      }
+
+      const columns = [
+        { key: 'id', name: 'ID' },
+        { key: 'name', name: 'Name' }
+      ] as const satisfies ColumnConfig<PayloadItem>[];
+
+      const items: PayloadItem[] = [
+        { id: '1', name: 'John Doe', data: 'payload-1', table: 'users' },
+        { id: '2', name: 'Jane Smith', data: 'payload-2', table: 'users' }
+      ];
+
+      await render(
+        <template>
+          <TestHelper as |selectedKeys onSelectionChange|>
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @selectionMode="multiple"
+              @selectedKeys={{selectedKeys}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </TestHelper>
+        </template>
+      );
+
+      assert
+        .dom('[data-test-id="table-row"][data-key="1"]')
+        .exists(
+          'a plain item with `data`/`table` properties still keys off `id`'
+        );
+      assert.dom('[data-test-id="table-row"][data-key="2"]').exists();
+
+      const checkboxes = document.querySelectorAll<HTMLInputElement>(
+        '[data-test-id="table-row"] input[type="checkbox"]'
+      );
+      await click(checkboxes[0]!);
+
+      assert
+        .dom('[data-test-id="table-row"][data-key="1"]')
+        .hasAttribute('data-selected', 'true', 'selection uses the item key');
     });
   }
 );

--- a/test-app/tests/integration/components/collections/table-selection-test.gts
+++ b/test-app/tests/integration/components/collections/table-selection-test.gts
@@ -1277,6 +1277,13 @@ module(
       assert
         .dom('[data-test-id="table-row"][data-key="1"]')
         .hasAttribute('data-selected', 'true', 'selection uses the item key');
+
+      assert
+        .dom('[data-test-id="table-row"][tabindex="0"]')
+        .exists(
+          { count: 1 },
+          'the table keeps exactly one tab stop for items shaped like rows'
+        );
     });
   }
 );


### PR DESCRIPTION
## Problems

**1. The row keydown handler hijacked keys from interactive cell content.** `handleRowKeydown` is installed on the `<tr>` and read `event.target` without checking it was the row.

- A button or link in a cell: Tab to it, press Enter or Space → `preventDefault()` ran and the **row's** selection toggled instead of the control activating.
- A text input in a cell: ArrowUp/ArrowDown were `preventDefault()`ed so the caret couldn't move, and because `allRows.indexOf(currentElement)` is `-1` for a non-row target, focus **jumped to the first row of the table**.

**2. Every row was a tab stop.** `tabindex={{if this.hasSelection "0" "-1"}}` — a 200-row selectable table added 200 tab stops. The WAI-ARIA grid pattern requires exactly one tabbable element per composite widget.

## Fixes

- `handleRowKeydown` returns early unless `event.target === event.currentTarget`, so anything bubbling from cell content belongs to that control. The guard sits above both the arrow-navigation and the selection branches.
- Roving tabindex: `tabindex="0"` goes to **the first selected row, falling back to the first row** when nothing is selected, and arrow navigation carries it along with focus. Tabbing back into a table should land you where your work is, not restart at the top. It's derived from `sortedItems`, so it respects sort order rather than raw `@items` order. `handleRowKeydown` also claims the tab stop on a Space/Enter selection, so an external selection change can't yank it away from the row the user is standing on. `data-selectable="true"` and the arrow-navigation query are untouched.

## One reported finding was not real

I had also flagged `getKey`'s `(itemOrRow as Row<T>).data ? ...` branch as misclassifying plain items that happen to have a `data` property. **That was wrong** — the old branch and `getRowData` are logically identical in every case: when `.data` is falsy you get the item; when `.data` is truthy, `getRowData` still requires `.table` and otherwise returns the item unchanged.

`getKey` now delegates to `getRowData` anyway, as a consistency refactor with a truthful comment — but this PR fixes no behavior there, and the test for it is a guard, not a reproduction.

Genuinely still open (deliberately not done here): to mis-key an item you'd need it to carry **both** `data` and `table`, and `getRowData` misfires on that too. Hardening row detection properly needs a brand/`instanceof` check.

## Tests

6 added to the existing Selection module; the 4 bug reproductions confirmed failing first.

- does not hijack Enter or Space from a button inside a cell — **failed** with `defaultPrevented` `true,true`; now `false,false`, the row's `data-selected` stays `false`, and the button's own handler still fires
- does not hijack arrow keys from an input inside a cell — **failed** with `document.activeElement` being an `HTMLTableRowElement` (focus had jumped to row 1)
- uses a roving tabindex so the table has a single tab stop — **failed** with all three rows at `tabindex="0"`; now row 1 only, and the `0` moves to row 2 after ArrowDown
- puts the roving tabindex on the first selected row — **failed** with 3 tabbable rows
- does not add row tab stops when selection is disabled — regression guard
- derives keys correctly for items that have their own `data` property — guard (see above)

On technique: `triggerKeyEvent` does not perform a native button activation, so tests 1–2 prove the fix by capturing `event.defaultPrevented` on a listener above the `<tr>` (the row handler runs first), plus focus and selection state — that is the actual mechanism that would break the control.

Pre-existing coverage verified rather than duplicated: single + multiple selection, select-all (none→all, all→none, indeterminate, with disabled rows), disabled keys, controlled/uncontrolled, row Space/Enter toggling, arrow navigation between rows, and sorting. **No existing assertion was modified** — nothing asserted the buggy behavior.

Full suite: **903 tests, 900 pass, 3 skip, 0 fail** (897 baseline + 6 new), run twice clean. `lint:types` clean.

## Known limitation

Click-focusing a row does **not** move its tab stop — there is no `focusin` sync, deliberately. This component family has a history of focus-during-render flakes (writing tracked state from a handler that also moves focus, where the synchronous `focusout`/`focusin` can land mid-render), and a `focusin` listener is the highest-risk place for exactly that. Arrow navigation moving the tab stop is what the pattern requires; the mouse case is a smaller ergonomic gap left for a follow-up. For the same reason `activeRowKey` is assigned *after* `focus()` in the handler.

`nextRow.dataset['key']` uses bracket access because glint's `TS4111` rejects the dot form — please don't "clean it up".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
