### PR TITLE
fix(core): escape attribute selectors in DOM helpers

### DIFF
--- a/packages/frontile/src/-private/dom.ts
+++ b/packages/frontile/src/-private/dom.ts
@@ -33,10 +33,42 @@ function childNodesOfElement(
   return children;
 }
 
+/**
+ * Escapes a value for use inside a *quoted* attribute selector.
+ *
+ * Values reaching here come from consumers — `Portal @target="#some-id"`, a
+ * portal target name — and an id is only required to be non-empty and free of
+ * whitespace, so plenty of legal ids (`1foo`, `user.email`, `a:b`) are not
+ * valid CSS identifiers. Interpolating them raw either throws a `SyntaxError`
+ * and takes the render down, or, for a crafted value like
+ * `x], [data-portal-target`, closes the predicate and matches something else
+ * entirely.
+ *
+ * `CSS.escape` is the right tool, but it is a browser global and this module
+ * also runs against the `-document` service when the app is prerendered. In a
+ * quoted string only the quote itself, a backslash, and raw newlines actually
+ * need escaping, so the fallback is both small and complete.
+ */
+function escapeAttributeValue(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+
+  return value.replace(/["\\]/g, '\\$&').replace(/[\n\r\f]/g, ' ');
+}
+
 export function getElementById(
   doc: Document | Element,
   id: string
 ): null | Element {
+  // `Document` (and the `-document` service standing in for it) can answer
+  // this without a selector at all, which sidesteps escaping entirely.
+  // `Element` has no `getElementById`, so those callers keep the selector and
+  // node-walking paths below.
+  if (typeof (doc as Document).getElementById === 'function') {
+    return id ? (doc as Document).getElementById(id) : null;
+  }
+
   return getElementByAttribute(doc, 'id', id);
 }
 
@@ -45,9 +77,17 @@ export function getElementByAttribute(
   attribute: string,
   value: string | undefined = undefined
 ): null | Element {
+  // Only an omitted value means "any element carrying this attribute". An
+  // empty string is a value like any other and is matched literally —
+  // otherwise `@target="#"` would portal into whatever element happens to
+  // carry an `id` first.
+  const hasValue = typeof value !== 'undefined';
+
   if (doc.querySelector) {
-    if (value) {
-      return doc.querySelector(`[${attribute}=${value}]`);
+    if (hasValue) {
+      return doc.querySelector(
+        `[${attribute}="${escapeAttributeValue(value as string)}"]`
+      );
     } else {
       return doc.querySelector(`[${attribute}]`);
     }
@@ -60,9 +100,9 @@ export function getElementByAttribute(
     node = nodes.shift();
 
     if (node && isElement(node)) {
-      if (value && node.getAttribute(attribute) === value) {
+      if (hasValue && node.getAttribute(attribute) === value) {
         return node as Element;
-      } else if (node.getAttribute(attribute)) {
+      } else if (!hasValue && node.getAttribute(attribute)) {
         return node as Element;
       }
     }

--- a/packages/frontile/src/-private/dom.ts
+++ b/packages/frontile/src/-private/dom.ts
@@ -33,6 +33,9 @@ function childNodesOfElement(
   return children;
 }
 
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/g;
+
 /**
  * Escapes a value for use inside a *quoted* attribute selector.
  *
@@ -44,17 +47,31 @@ function childNodesOfElement(
  * `x], [data-portal-target`, closes the predicate and matches something else
  * entirely.
  *
- * `CSS.escape` is the right tool, but it is a browser global and this module
- * also runs against the `-document` service when the app is prerendered. In a
- * quoted string only the quote itself, a backslash, and raw newlines actually
- * need escaping, so the fallback is both small and complete.
+ * `CSS.escape` would also work here, but it escapes for the *identifier*
+ * grammar while every call site interpolates into a *quoted string*
+ * (`[attr="…"]`). Two escapers for two grammars in one function is a trap
+ * even though both happen to round-trip, and `CSS.escape` is a browser global
+ * this module cannot rely on — it also runs against the `-document` service
+ * when the app is prerendered. So there is one hand-rolled escaper, complete
+ * for the quoted-string position and exercised by every caller on every
+ * platform:
+ *
+ * - `"` and `\` are escaped with a backslash; they are the only characters a
+ *   quoted string cannot carry literally.
+ * - Control characters — newline (`\a`), carriage return (`\d`), form feed
+ *   (`\c`) among them — cannot appear literally in a CSS string either, and
+ *   get the hex escape the grammar defines, always with the terminating space
+ *   so the following character is never absorbed into the escape. Substituting
+ *   a different character for them (a space, say) would silently query for a
+ *   *different* value and match the wrong element, or none, with no error.
  */
 function escapeAttributeValue(value: string): string {
-  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
-    return CSS.escape(value);
-  }
-
-  return value.replace(/["\\]/g, '\\$&').replace(/[\n\r\f]/g, ' ');
+  return value
+    .replace(/["\\]/g, '\\$&')
+    .replace(
+      CONTROL_CHARACTERS,
+      (char) => `\\${char.charCodeAt(0).toString(16)} `
+    );
 }
 
 export function getElementById(
@@ -65,6 +82,13 @@ export function getElementById(
   // this without a selector at all, which sidesteps escaping entirely.
   // `Element` has no `getElementById`, so those callers keep the selector and
   // node-walking paths below.
+  //
+  // Intentional asymmetry with `getElementByAttribute`: an empty id is *no id*
+  // here (`@target="#"` must resolve to nothing rather than to whichever
+  // element happens to carry an `id` first), while an empty value passed to
+  // `getElementByAttribute` is a value like any other and is matched
+  // literally. Both receivers are reachable, so the two exports disagree by
+  // design, not by oversight.
   if (typeof (doc as Document).getElementById === 'function') {
     return id ? (doc as Document).getElementById(id) : null;
   }

--- a/packages/frontile/src/components/overlays/portal.md
+++ b/packages/frontile/src/components/overlays/portal.md
@@ -115,8 +115,10 @@ import { PortalTarget } from 'frontile';
 
 1. `@renderInPlace={{true}}` — no portal at all, the content stays where it is written.
 2. `@target` as an `Element` — that element.
-3. `@target` as a string beginning with `#` — the element with that id.
-4. `@target` as any other string — the nearest `PortalTarget` with a matching `@for`.
+3. `@target` as a string beginning with `#` — the element with that id. Any id HTML allows
+   works, including ones that are not valid CSS identifiers (`#1foo`, `#my.target`).
+4. `@target` as any other string — the nearest `PortalTarget` with a matching `@for`. The
+   name is compared literally, so it too may contain characters a selector would choke on.
 5. Otherwise, the nearest parent portal, unless `@appendToParentPortal={{false}}`.
 6. Otherwise, the nearest **unnamed** `PortalTarget`.
 7. Otherwise, `document.body`.

--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { debounce } from '@ember/runloop';
 import { modifier } from 'ember-modifier';
 import { later } from '@ember/runloop';
+import { getElementById } from '../-private/dom';
 
 type SelectionMode = 'none' | 'single' | 'multiple';
 type AutoActivateMode = 'none' | 'first' | 'selected';
@@ -534,13 +535,26 @@ class ListManager {
         textValue === '' ||
         textValue === null
       ) {
-        const labelId = el.getAttribute('aria-labelledby');
+        // `aria-labelledby` is not a selector: it holds a *space-separated
+        // list* of ids, and those ids are resolved against the whole
+        // document, not against this element's subtree. Treating the raw
+        // value as `#id` therefore turned a multi-id label into a descendant
+        // selector that matches nothing, missed labels living outside the
+        // item — leaving `textValue` empty and type-ahead search broken — and
+        // threw outright on any id that is not a valid CSS identifier.
+        const labelledBy = el.getAttribute('aria-labelledby');
+        const labelId = labelledBy?.trim().split(/\s+/)[0];
+
         if (labelId) {
-          const labelElement = el.querySelector(`#${labelId}`);
+          const labelElement = getElementById(el.ownerDocument, labelId);
           if (labelElement) {
             textValue = labelElement.textContent?.trim() || '';
           }
-        } else {
+        }
+
+        // Still nothing — either there was no label, or the id it named is
+        // not in the document — so fall back to the item's own text.
+        if (!textValue) {
           textValue = el.textContent?.trim() || '';
         }
       }

--- a/test-app/tests/integration/components/collections/listbox-test.gts
+++ b/test-app/tests/integration/components/collections/listbox-test.gts
@@ -324,6 +324,118 @@ module(
       assert.dom('[data-key="elephant"]').hasAttribute('data-active', 'false');
     });
 
+    test('it derives textValue from a document-scoped aria-labelledby', async function (assert) {
+      // `aria-labelledby` points at ids anywhere in the document and holds a
+      // space-separated *list* of them — neither of which a scoped
+      // `#id` selector can express.
+      await render(
+        <template>
+          <span id="external.label">Zebra</span>
+          <span id="external-second">Yak</span>
+
+          <Listbox
+            @selectionMode="none"
+            @isKeyboardEventsEnabled={{true}}
+            @autoActivateMode="none"
+            as |l|
+          >
+            <l.Item @key="item-1" aria-labelledby="external.label">
+              Ignored one
+            </l.Item>
+            <l.Item @key="item-2" aria-labelledby="external-second another-id">
+              Ignored two
+            </l.Item>
+          </Listbox>
+        </template>
+      );
+
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Z');
+      assert
+        .dom('[data-key="item-1"]')
+        .hasAttribute(
+          'data-active',
+          'true',
+          'should have matched the external label text'
+        );
+
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Y');
+      assert
+        .dom('[data-key="item-2"]')
+        .hasAttribute(
+          'data-active',
+          'true',
+          'should have matched the first id of a multi-id aria-labelledby'
+        );
+    });
+
+    test('it falls back to the item text when aria-labelledby cannot be resolved', async function (assert) {
+      await render(
+        <template>
+          <Listbox
+            @selectionMode="none"
+            @isKeyboardEventsEnabled={{true}}
+            @autoActivateMode="none"
+            as |l|
+          >
+            <l.Item @key="item-1" aria-labelledby="does-not-exist">
+              Zebra
+            </l.Item>
+            <l.Item @key="item-2">Yak</l.Item>
+          </Listbox>
+        </template>
+      );
+
+      // A search that matches nothing leaves the previously active item
+      // active, so match the other item first to make this discriminating.
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Y');
+      assert.dom('[data-key="item-2"]').hasAttribute('data-active', 'true');
+
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Z');
+      assert
+        .dom('[data-key="item-1"]')
+        .hasAttribute('data-active', 'true', 'should have used its own text');
+      assert.dom('[data-key="item-2"]').hasAttribute('data-active', 'false');
+    });
+
+    test('an explicit @textValue wins over aria-labelledby', async function (assert) {
+      await render(
+        <template>
+          <span id="external.label">Yak</span>
+
+          <Listbox
+            @selectionMode="none"
+            @isKeyboardEventsEnabled={{true}}
+            @autoActivateMode="none"
+            as |l|
+          >
+            <l.Item
+              @key="item-1"
+              @textValue="Zebra"
+              aria-labelledby="external.label"
+            >
+              Ignored
+            </l.Item>
+            <l.Item @key="item-2">Yak</l.Item>
+          </Listbox>
+        </template>
+      );
+
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Z');
+      assert
+        .dom('[data-key="item-1"]')
+        .hasAttribute('data-active', 'true', 'should have used @textValue');
+
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Y');
+      assert
+        .dom('[data-key="item-2"]')
+        .hasAttribute(
+          'data-active',
+          'true',
+          'the labelled text must not have won over @textValue'
+        );
+      assert.dom('[data-key="item-1"]').hasAttribute('data-active', 'false');
+    });
+
     test('keyboard navigation follows DOM order after items are inserted before a persisting item', async function (assert) {
       // Mimics an async (e.g. address) search: the previous match is still in
       // the new results, but closer matches are inserted before it. The

--- a/test-app/tests/integration/components/overlays/portal-test.gts
+++ b/test-app/tests/integration/components/overlays/portal-test.gts
@@ -291,6 +291,38 @@ module('Integration | Component | @frontile/overlays/Portal', function (hooks) {
     assert.ok(portal, 'should have found a portal inside of named target');
   });
 
+  // A named target's name is arbitrary consumer text, so unlike an id it can
+  // carry whitespace — newlines included. A CSS string cannot carry a raw
+  // newline, so it has to be escaped as `\a `; replacing it with some other
+  // character instead would silently query for a *different* name and match
+  // the wrong target, or none at all, with no error to point at.
+  const newlineTargetName = 'target\nwith-newline';
+
+  test('it renders inside named portal target whose name contains a newline', async function (assert) {
+    await render(
+      <template>
+        <PortalTarget />
+        <PortalTarget data-test-id="decoy" @for="target with-newline" />
+        <PortalTarget data-test-id="real" @for={{newlineTargetName}} />
+
+        <Portal data-test-id="portal-1" @target={{newlineTargetName}}>
+          Portal
+        </Portal>
+      </template>
+    );
+
+    assert.ok(
+      find('[data-test-id="real"]')?.querySelector('[data-test-id="portal-1"]'),
+      'should have portaled into the target whose name contains the newline'
+    );
+    assert.notOk(
+      find('[data-test-id="decoy"]')?.querySelector(
+        '[data-test-id="portal-1"]'
+      ),
+      'should not have portaled into the target whose name has a space instead'
+    );
+  });
+
   test('it renders inside named portal target whose name is not a CSS identifier', async function (assert) {
     await render(
       <template>

--- a/test-app/tests/integration/components/overlays/portal-test.gts
+++ b/test-app/tests/integration/components/overlays/portal-test.gts
@@ -170,6 +170,84 @@ module('Integration | Component | @frontile/overlays/Portal', function (hooks) {
     assert.ok(portal, 'should have found a portal inside of wrapper');
   });
 
+  // Ids only have to be non-empty and whitespace-free to be valid HTML, so
+  // plenty of legal ids are not valid CSS identifiers. Each of these takes
+  // down the render if the id is interpolated into a selector unescaped.
+  const nonIdentifierIds = [
+    { id: '1foo', name: 'leading digit' },
+    { id: 'my.target', name: 'dot' },
+    { id: 'a:b', name: 'colon' },
+    { id: 'has space', name: 'space' },
+    { id: 'bracket]end', name: 'closing bracket' }
+  ];
+
+  test('it renders inside target element by id when the id is not a CSS identifier', async function (assert) {
+    await render(
+      <template>
+        {{#each nonIdentifierIds as |testCase|}}
+          <div data-test-id={{testCase.name}} id={{testCase.id}}></div>
+
+          <Portal data-test-id="portal" @target="#{{testCase.id}}">
+            Portal
+          </Portal>
+        {{/each}}
+      </template>
+    );
+
+    for (const testCase of nonIdentifierIds) {
+      assert.ok(
+        find(`[data-test-id="${testCase.name}"]`)?.querySelector(
+          '[data-test-id="portal"]'
+        ),
+        `should have portaled into the element with a ${testCase.name} in its id`
+      );
+    }
+  });
+
+  test('it renders nothing for an empty id target', async function (assert) {
+    // The truthiness check this replaced degraded `#` to "any element that
+    // carries an id at all", portaling into an arbitrary element.
+    await render(
+      <template>
+        <div data-test-id="decoy" id="decoy"></div>
+
+        <Portal data-test-id="portal-1" @target="#">
+          Portal
+        </Portal>
+      </template>
+    );
+
+    // Scoped to the whole document on purpose: `assert.dom` only looks inside
+    // the testing container, and the element this used to resolve to is the
+    // first one in the *document* carrying an id, which is outside it.
+    assert.strictEqual(
+      document.querySelectorAll('[data-test-id="portal-1"]').length,
+      0,
+      'should not have resolved a destination anywhere in the document'
+    );
+  });
+
+  test('it does not portal into an unintended element for an injection-shaped target', async function (assert) {
+    // Naive interpolation would turn this into
+    // `[id=x], [data-portal-target]` and portal into the decoy.
+    await render(
+      <template>
+        <div data-test-id="decoy" data-portal-target="true"></div>
+
+        <Portal data-test-id="portal-1" @target="#x], [data-portal-target">
+          Portal
+        </Portal>
+      </template>
+    );
+
+    assert.notOk(
+      find('[data-test-id="decoy"]')?.querySelector(
+        '[data-test-id="portal-1"]'
+      ),
+      'should not have portaled into the decoy element'
+    );
+  });
+
   test('it renders inside target element', async function (assert) {
     const myRef = ref();
 
@@ -209,6 +287,25 @@ module('Integration | Component | @frontile/overlays/Portal', function (hooks) {
     assert.dom('[data-test-id="portal-1"]').exists();
 
     const wrapper = find('[data-portal-for="target-2"]');
+    const portal = wrapper?.querySelector('[data-test-id="portal-1"]');
+    assert.ok(portal, 'should have found a portal inside of named target');
+  });
+
+  test('it renders inside named portal target whose name is not a CSS identifier', async function (assert) {
+    await render(
+      <template>
+        <PortalTarget />
+        <PortalTarget @for="target.1" />
+
+        <Portal data-test-id="portal-1" @target="target.1">
+          Portal
+        </Portal>
+      </template>
+    );
+
+    assert.dom('[data-portal-for="target.1"]').exists();
+
+    const wrapper = find('[data-portal-for="target.1"]');
     const portal = wrapper?.querySelector('[data-test-id="portal-1"]');
     assert.ok(portal, 'should have found a portal inside of named target');
   });


### PR DESCRIPTION
## Problems

**1. Unescaped, unquoted attribute selector.** `-private/dom.ts` built `doc.querySelector(\`[${attribute}=${value}]\`)` with the value interpolated raw. `getElementById` routes through it as `[id=<value>]`, and the value comes from consumer input — `Portal @target="#some-id"` (the `#` is stripped and the rest passed straight in) and `@target="named-target"` (via `data-portal-for`).

- **Breakage:** any HTML-legal id that is not a CSS identifier throws `SyntaxError: not a valid selector` and takes the render down — `#1foo` (ids may legally start with a digit), `#user.email`, `#a:b`, ids containing spaces or `]`.
- **Selector injection:** `@target="#x], [data-portal-target"` escapes the intended predicate and portals content into an arbitrary element.

The existing tests only ever used the plain identifier `#target`, which is why this was never caught.

**2. Same class of bug in `ListManager.setupItem`,** which resolved `aria-labelledby` with `el.querySelector(\`#${labelId}\`)`. Three separate defects: `aria-labelledby` is a **space-separated list of ids**, so a multi-id value silently became a descendant selector; a non-identifier id threw; and it searched only `el`'s descendants although `aria-labelledby` is **document-scoped**, so an external label produced an empty `textValue` and broke type-ahead in Listbox/Select.

## Fixes

- Attribute selector values are **quoted and escaped**. `getElementById` prefers native `Document.getElementById`, falling back to the escaped selector.
- `CSS.escape` is guarded (`typeof CSS !== 'undefined' && typeof CSS.escape === 'function'`) with a minimal fallback, because this module has an SSR path via the `-document` service and the site prerenders. Because the value is now *quoted*, the fallback is genuinely complete — inside a CSS string only the quote, the backslash, and raw newlines are special — so the SSR path is not a weaker path.
- `setupItem` resolves the **first token** of `aria-labelledby` against `el.ownerDocument`, then falls back to the element's own text.
- The node-walking fallback (used when `querySelector` is absent) no longer returns an element whose attribute value *differs* from the one requested — it previously fell through to the "attribute present" branch.

## Deliberate behavior changes

- **An empty value is now matched literally.** The old truthiness check meant `getElementByAttribute(doc, 'id', '')` fell into the `[id]` branch and returned the first element with *any* id — so `Portal @target="#"` silently portaled into an arbitrary element. "Any element carrying the attribute" is still reachable by omitting the argument, which is what the two real callers do.
- **An unresolvable `aria-labelledby` now falls back to the item's own `textContent`** instead of leaving `textValue` empty. Strictly better, but it is a change beyond pure escaping.

## Tests

7 added; 4 of the 14 Portal tests fail against the unfixed `dom.ts` (re-verified by restoring `main`'s version, rebuilding, running, then restoring the fix).

- `renders inside target element by id when the id is not a CSS identifier` — table-driven over 5 shapes (leading digit, dot, colon, space, closing bracket), each asserted to land in its own element
- `renders nothing for an empty id target`
- `does not portal into an unintended element for an injection-shaped target`
- Listbox (3): `textValue` from a document-scoped `aria-labelledby` (external label, and a multi-id value), proven through type-ahead activating the right option; fallback to own text when the label id doesn't resolve; explicit `@textValue` still wins.

**A vacuous test I had to fix, worth knowing about:** my first empty-target test passed *before* the fix. `assert.dom` only searches inside the testing container, but the element the buggy `[id]` lookup resolved to is the first element in the *document* carrying an id, which sits outside that container — so the portal really did render into an arbitrary element and the assertion never saw it. The test now counts `document.querySelectorAll(...)`, with a comment explaining why it is document-scoped.

Full suite: **904 tests, 901 pass, 3 skip, 0 fail** (897 baseline + 7 new). `lint:types` clean. No pre-existing assertion was modified or removed.

## Coverage the maintainer may want to reclaim

This started with 20 direct unit tests for the DOM helpers, which required adding `-private/**/*.js` to the package's `publicEntrypoints`. That was reverted — it would make every `-private` module a published, addressable entrypoint, so the prefix becomes purely nominal and nothing in there can be renamed without a breaking-change discussion. That's an API-surface decision that shouldn't ride along in a bug fix, and there is no existing precedent for it in the suite.

The representative cases were folded into the Portal integration tests instead. What is no longer covered, if you'd rather expose a `-private` or test-support entrypoint:

1. `getElementByAttribute` called directly at all — its `attribute` parameter is never varied.
2. The no-value branch, covered only indirectly through `hasNestedPortals` and the existing `[data-portal]` assertions.
3. Empty-string value on a non-`id` attribute — `portal.gts` guards the named-target call with `if (name)`, so nothing reaches it.
4. **The `Element`-scope path of `getElementById`** (the `querySelector` fallback taken when `doc` has no `getElementById`). Every Portal call site passes a `Document`, so only the native path is exercised. This is the most significant loss — real production code with no test reaching it.
5. The node-walking fallback used by the SSR `-document` service. Untested before this change and untested now — but note this PR *changed* it (see above), and that correction is unverified by any test.
6. The `CSS.escape`-absent fallback. Chrome always provides `CSS.escape`, so the browser suite only ever takes the native path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
