### PR TITLE
fix(notifications): make timer pause idempotent and removal single-shot

### DIFF
--- a/packages/frontile/docs/notifications-usage.md
+++ b/packages/frontile/docs/notifications-usage.md
@@ -315,6 +315,8 @@ export default class PersistentExample extends Component {
 
 Track notification dismissals for analytics, backend updates, or cleanup. When using a global container, set up callbacks in your application template:
 
+`@onDismiss` is called **exactly once per notification**, after it has actually been removed — repeated dismissals of the same notification (e.g. a double-click on the close button) do not call it again. The callback is always read from the current `@onDismiss` argument, so changing it at runtime takes effect immediately.
+
 ```hbs
 {{! app/templates/application.hbs }}
 <NotificationsContainer
@@ -527,8 +529,12 @@ Options for the NotificationsContainer component:
   - `'top-left'` | `'top-center'` | `'top-right'`
   - `'bottom-left'` | `'bottom-center'` | `'bottom-right'`
 - **`spacing`**: Gap between notifications in pixels (default: `16`)
-- **`onDismiss`**: Callback function called when notifications are dismissed
+- **`onDismiss`**: Callback function called once per notification, after it is removed
 - **`class`**: Custom CSS classes for styling
+
+> **Note**: The notifications service holds a single `onDismiss` slot. If more than one
+> `NotificationsContainer` is rendered at the same time, the most recently rendered one
+> owns the callback — another reason to render a single global container.
 
 ## Accessibility
 

--- a/packages/frontile/src/-private/manager.ts
+++ b/packages/frontile/src/-private/manager.ts
@@ -65,7 +65,9 @@ export default class NotificationsManager {
   }
 
   remove(notification?: Notification<Record<string, unknown>>): void {
-    if (!notification) {
+    // Removal is single-shot: a notification already on its way out must not
+    // schedule a second removal, otherwise `onRemove` is called twice for it.
+    if (!notification || notification.isRemoving) {
       return;
     }
 

--- a/packages/frontile/src/-private/timer.ts
+++ b/packages/frontile/src/-private/timer.ts
@@ -27,11 +27,22 @@ export default class Timer {
   }
 
   @action pause(): void {
+    // Pausing an already paused timer would subtract the elapsed time twice,
+    // eventually driving `remaining` to zero or below.
+    if (!this.isRunning) {
+      return;
+    }
+
     this.clear();
-    this.remaining -= Date.now() - this.start;
+    this.remaining = Math.max(0, this.remaining - (Date.now() - this.start));
   }
 
   @action resume(): void {
+    // Already counting down; resuming again would restart the remaining time.
+    if (this.isRunning) {
+      return;
+    }
+
     this.clear();
     this.setup();
   }

--- a/packages/frontile/src/components/notifications/notification-card.gts
+++ b/packages/frontile/src/components/notifications/notification-card.gts
@@ -4,7 +4,7 @@ import { modifier } from 'ember-modifier';
 import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
-import { later } from '@ember/runloop';
+import { later, cancel } from '@ember/runloop';
 import { on } from '@ember/modifier';
 import { fn, concat } from '@ember/helper';
 import { CloseButton } from '../buttons/close-button';
@@ -54,23 +54,37 @@ class NotificationCard extends Component<NotificationCardSignature> {
     const expectedHeight = element.offsetHeight + spacing;
     const duration = this.args.notification.transitionDuration / 2;
 
-    requestAnimationFrame(() => {
+    let innerFrame: number | undefined;
+    const outerFrame = requestAnimationFrame(() => {
       element.style.height = '0';
       const transition = `height ${duration}ms ease-in ${duration}ms`;
       element.style.transition = transition;
 
-      requestAnimationFrame(() => {
+      innerFrame = requestAnimationFrame(() => {
         element.style.height = `${expectedHeight}px`;
       });
     });
 
-    later(
+    const timer = later(
       this,
       () => {
         this.hasEntered = true;
       },
       this.args.notification.transitionDuration
     );
+
+    // The card can be destroyed while the enter transition is still in flight;
+    // cancel the pending work so we never touch the element or write tracked
+    // state after teardown.
+    return () => {
+      cancelAnimationFrame(outerFrame);
+
+      if (typeof innerFrame !== 'undefined') {
+        cancelAnimationFrame(innerFrame);
+      }
+
+      cancel(timer);
+    };
   });
 
   transitionOut = modifier(

--- a/packages/frontile/src/components/notifications/notifications-container.gts
+++ b/packages/frontile/src/components/notifications/notifications-container.gts
@@ -43,14 +43,23 @@ class NotificationsContainer extends Component<NotificationsContainerSignature> 
   constructor(owner: Owner, args: NotificationsContainerSignature['Args']) {
     super(owner, args);
 
-    // Set the onDismiss callback on the service
-    this.notifications.setOnRemoveCallback(this.args.onDismiss);
+    // Register a stable callback that delegates to the current `@onDismiss`,
+    // so a change to the argument is picked up without re-registering.
+    this.notifications.setOnRemoveCallback(this.handleDismiss);
 
-    // Clean up when component is destroyed
+    // Clean up when component is destroyed, but only if we are still the
+    // registered owner: the service holds a single callback slot, so another
+    // container might have taken it over in the meantime.
     registerDestructor(this, () => {
-      this.notifications.setOnRemoveCallback(undefined);
+      if (this.notifications.onRemoveCallback === this.handleDismiss) {
+        this.notifications.setOnRemoveCallback(undefined);
+      }
     });
   }
+
+  handleDismiss = (notification: Notification<Record<string, unknown>>) => {
+    this.args.onDismiss?.(notification);
+  };
 
   get isTopPlacement(): boolean {
     return !!(this.args.placement && this.args.placement.includes('top'));
@@ -76,9 +85,14 @@ class NotificationsContainer extends Component<NotificationsContainerSignature> 
   setupSpacing = modifier((element: HTMLElement) => {
     const spacing =
       typeof this.args.spacing === 'undefined' ? 16 : this.args.spacing;
-    if (this.isTopPlacement) {
-      element.style.marginTop = `${spacing}px`;
-    }
+
+    // Always assign, so switching from a top to a bottom placement does not
+    // leave a stale margin behind.
+    element.style.marginTop = this.isTopPlacement ? `${spacing}px` : '';
+
+    return () => {
+      element.style.marginTop = '';
+    };
   });
 
   <template>

--- a/test-app/tests/integration/components/notifications/notification-card-test.gts
+++ b/test-app/tests/integration/components/notifications/notification-card-test.gts
@@ -1,6 +1,14 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, clearRender, triggerEvent } from '@ember/test-helpers';
+import {
+  render,
+  click,
+  clearRender,
+  find,
+  getSettledState,
+  triggerEvent,
+  waitUntil
+} from '@ember/test-helpers';
 import { NotificationCard } from 'frontile';
 import {
   Notification,
@@ -260,22 +268,68 @@ module(
       );
     });
 
-    // NOTE: this is a smoke test. Ember does not raise on tracked writes to a
-    // destroyed component in this version, so it passes with or without the
-    // teardown cancellation in `transitionIn`; it guards against a future
-    // regression that does raise (or leaves a pending timer behind).
-    test('it can be destroyed while the enter transition is in flight', async function (assert) {
+    // `getSettledState().hasPendingTimers` cannot be used here: the card also
+    // renders `{{cssTransition}}`, and ember-css-transitions schedules its own
+    // runloop timer for the (transition-delay + transition-duration) window, so
+    // a timer is pending after teardown either way. Backburner's `cancel`
+    // counter is narrow enough to see only the card's own cancellation.
+    function backburnerCancelCount(): number {
+      const debugInfo = getSettledState().debugInfo as
+        { _debugInfo?: { counters?: { cancel?: number } } } | undefined;
+
+      return debugInfo?._debugInfo?.counters?.cancel ?? 0;
+    }
+
+    test('it cancels the in-flight enter transition when destroyed', async function (assert) {
       notification.current = new Notification({}, 'My message', {
-        transitionDuration: 300
+        transitionDuration: 4000
       });
 
-      await render(template);
+      const nativeCancelAnimationFrame = window.cancelAnimationFrame;
+      let cancelledFrames = 0;
+      window.cancelAnimationFrame = function (handle: number) {
+        cancelledFrames += 1;
+        return nativeCancelAnimationFrame.call(window, handle);
+      };
 
-      assert.dom('[data-test-notification]').exists();
+      let cancelledTimers = 0;
 
-      await clearRender();
+      try {
+        // Intentionally not awaited: the enter transition (the rAF pair and the
+        // `later` that flips `hasEntered`) has to still be in flight when the
+        // card is torn down.
+        const renderPromise = render(template);
+        await waitUntil(() => !!find('[data-test-notification]'));
 
-      assert.dom('[data-test-notification]').doesNotExist();
+        cancelledFrames = 0;
+        const cancelsBeforeTeardown = backburnerCancelCount();
+
+        // Also not awaited: `clearRender()` only resolves once everything has
+        // settled, which waits out the very timers we are asserting on. Poll
+        // for the DOM going away instead — that is when the modifier
+        // destructor has run.
+        const clearRenderPromise = clearRender();
+        await waitUntil(() => !find('[data-test-notification]'));
+
+        cancelledTimers = backburnerCancelCount() - cancelsBeforeTeardown;
+
+        await clearRenderPromise;
+        await renderPromise;
+      } finally {
+        window.cancelAnimationFrame = nativeCancelAnimationFrame;
+      }
+
+      assert.ok(
+        cancelledTimers >= 1,
+        `teardown should cancel the pending enter timer; ${cancelledTimers} ` +
+          `runloop timer(s) were cancelled`
+      );
+
+      assert.ok(
+        cancelledFrames >= 1,
+        `teardown should cancel the pending animation frame(s) of the enter ` +
+          `transition; cancelAnimationFrame was called ${cancelledFrames} time(s)`
+      );
     });
   }
 );

--- a/test-app/tests/integration/components/notifications/notification-card-test.gts
+++ b/test-app/tests/integration/components/notifications/notification-card-test.gts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, triggerEvent } from '@ember/test-helpers';
+import { render, click, clearRender, triggerEvent } from '@ember/test-helpers';
 import { NotificationCard } from 'frontile';
 import {
   Notification,
@@ -258,6 +258,24 @@ module(
         1234567890,
         'timestamp should match'
       );
+    });
+
+    // NOTE: this is a smoke test. Ember does not raise on tracked writes to a
+    // destroyed component in this version, so it passes with or without the
+    // teardown cancellation in `transitionIn`; it guards against a future
+    // regression that does raise (or leaves a pending timer behind).
+    test('it can be destroyed while the enter transition is in flight', async function (assert) {
+      notification.current = new Notification({}, 'My message', {
+        transitionDuration: 300
+      });
+
+      await render(template);
+
+      assert.dom('[data-test-notification]').exists();
+
+      await clearRender();
+
+      assert.dom('[data-test-notification]').doesNotExist();
     });
   }
 );

--- a/test-app/tests/integration/components/notifications/notifications-container-test.gts
+++ b/test-app/tests/integration/components/notifications/notifications-container-test.gts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find, findAll } from '@ember/test-helpers';
 import {
   NotificationsContainer,
   type NotificationsService,
@@ -137,6 +137,137 @@ module(
       assert
         .dom('[data-test-notifications]')
         .hasAttribute('aria-atomic', 'true');
+    });
+    test('it sets and clears margin-top based on placement', async function (assert) {
+      (this.owner.lookup('service:notifications') as NotificationsService).add(
+        'Message 1',
+        options
+      );
+
+      placement.current = 'top-left';
+
+      await render(template);
+
+      assert
+        .dom('[data-test-notifications]')
+        .hasStyle(
+          { marginTop: '16px' },
+          'top placements receive the spacing as margin-top'
+        );
+
+      placement.current = 'bottom-left';
+      await settled();
+
+      assert.equal(
+        (
+          find('[data-test-notifications]') as HTMLElement
+        ).style.marginTop.trim(),
+        '',
+        'switching to a bottom placement clears the stale margin-top'
+      );
+    });
+
+    test('top placements render notifications in reverse order', async function (assert) {
+      const service = this.owner.lookup(
+        'service:notifications'
+      ) as NotificationsService;
+
+      service.add('Message 1', options);
+      service.add('Message 2', options);
+
+      placement.current = 'bottom-right';
+      await render(template);
+
+      let cards = findAll('[data-test-notifications] > div');
+      assert.dom(cards[0]).containsText('Message 1');
+      assert.dom(cards[1]).containsText('Message 2');
+
+      placement.current = 'top-right';
+      await settled();
+
+      cards = findAll('[data-test-notifications] > div');
+      assert.dom(cards[0]).containsText('Message 2');
+      assert.dom(cards[1]).containsText('Message 1');
+    });
+
+    test('it uses the current @onDismiss when the argument changes', async function (assert) {
+      const service = this.owner.lookup(
+        'service:notifications'
+      ) as NotificationsService;
+
+      const calls: string[] = [];
+      const onDismiss = cell<
+        NotificationsContainerSignature['Args']['onDismiss']
+      >(() => calls.push('first'));
+
+      placement.current = 'bottom-right';
+
+      await render(
+        <template>
+          <NotificationsContainer
+            @onDismiss={{onDismiss.current}}
+            data-test-notifications
+          />
+        </template>
+      );
+
+      onDismiss.current = () => calls.push('second');
+      await settled();
+
+      const notification = service.add('Message 1', options);
+      await settled();
+
+      service.remove(notification);
+      await settled();
+
+      assert.deepEqual(calls, ['second'], 'the updated callback is used');
+    });
+
+    test('destroying one container does not disable another one', async function (assert) {
+      const service = this.owner.lookup(
+        'service:notifications'
+      ) as NotificationsService;
+
+      const calls: string[] = [];
+      const onDismissFirst = () => {
+        calls.push('first');
+      };
+      const onDismissSecond = () => {
+        calls.push('second');
+      };
+      const showFirst = cell<boolean>(true);
+
+      await render(
+        <template>
+          {{#if showFirst.current}}
+            <NotificationsContainer
+              @onDismiss={{onDismissFirst}}
+              data-test-first
+            />
+          {{/if}}
+          <NotificationsContainer
+            @onDismiss={{onDismissSecond}}
+            data-test-second
+          />
+        </template>
+      );
+
+      // Tear down the first container; the second one is still mounted and must
+      // keep receiving dismiss callbacks.
+      showFirst.current = false;
+      await settled();
+
+      const notification = service.add('Message 1', options);
+      await settled();
+
+      service.remove(notification);
+      await settled();
+
+      assert.deepEqual(
+        calls,
+        ['second'],
+        'the surviving container still receives the callback'
+      );
     });
   }
 );

--- a/test-app/tests/unit/notifications/services/notifications-test.ts
+++ b/test-app/tests/unit/notifications/services/notifications-test.ts
@@ -2,7 +2,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { NotificationsService, Timer } from 'frontile/notifications';
-import { waitUntil } from '@ember/test-helpers';
+import { waitUntil, settled } from '@ember/test-helpers';
 
 module(
   'Unit | Service | @frontile/notifications/notifications',
@@ -150,6 +150,115 @@ module(
         },
         { timeout: 500 }
       );
+    });
+    test('removing the same notification twice only calls onRemove once', async function (assert) {
+      const service = this.owner.lookup(
+        'service:notifications'
+      ) as NotificationsService;
+
+      let calls = 0;
+      service.setOnRemoveCallback(() => {
+        calls++;
+      });
+
+      const notification = service.add('My Notification', {
+        duration: 1,
+        transitionDuration: 0,
+        preserve: true
+      });
+
+      service.remove(notification);
+      service.remove(notification);
+
+      await settled();
+
+      assert.equal(service.notifications.length, 0);
+      assert.equal(calls, 1, 'onRemove is called exactly once');
+    });
+
+    test('removeAll after remove does not call onRemove twice', async function (assert) {
+      const service = this.owner.lookup(
+        'service:notifications'
+      ) as NotificationsService;
+
+      let calls = 0;
+      service.setOnRemoveCallback(() => {
+        calls++;
+      });
+
+      const first = service.add('My Notification', {
+        transitionDuration: 0,
+        preserve: true
+      });
+      service.add('My Notification 2', {
+        transitionDuration: 0,
+        preserve: true
+      });
+
+      service.remove(first);
+      service.removeAll();
+
+      await settled();
+
+      assert.equal(service.notifications.length, 0);
+      assert.equal(calls, 2, 'onRemove is called once per notification');
+    });
+
+    test('it calls onRemove with the removed notification after auto removal', async function (assert) {
+      const service = this.owner.lookup(
+        'service:notifications'
+      ) as NotificationsService;
+
+      const removed: string[] = [];
+      service.setOnRemoveCallback((notification) => {
+        removed.push(notification.message);
+      });
+
+      service.add('My Notification', {
+        duration: 10,
+        transitionDuration: 0
+      });
+
+      await waitUntil(
+        () => {
+          return service.notifications.length === 0;
+        },
+        { timeout: 500 }
+      );
+      await settled();
+
+      assert.deepEqual(removed, ['My Notification']);
+    });
+    test('the skipTimer config option preserves notifications', async function (assert) {
+      const env = this.owner.resolveRegistration(
+        'config:environment'
+      ) as Record<string, unknown>;
+      const original = env['@frontile/notifications'];
+      env['@frontile/notifications'] = { skipTimer: true };
+
+      try {
+        const service = this.owner.lookup(
+          'service:notifications'
+        ) as NotificationsService;
+
+        const notification = service.add('My Notification', {
+          duration: 1,
+          transitionDuration: 0
+        });
+
+        assert.equal(
+          typeof notification.timer,
+          'undefined',
+          'no timer is created when skipTimer is configured'
+        );
+        assert.equal(service.notifications.length, 1);
+      } finally {
+        if (typeof original === 'undefined') {
+          delete env['@frontile/notifications'];
+        } else {
+          env['@frontile/notifications'] = original;
+        }
+      }
     });
   }
 );

--- a/test-app/tests/unit/notifications/timer-test.ts
+++ b/test-app/tests/unit/notifications/timer-test.ts
@@ -3,6 +3,9 @@ import { setupTest } from 'ember-qunit';
 import { Timer } from 'frontile/notifications';
 import { waitUntil } from '@ember/test-helpers';
 
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 module('Unit | @frontile/notifications/Timer', function (hooks) {
   setupTest(hooks);
 
@@ -50,6 +53,65 @@ module('Unit | @frontile/notifications/Timer', function (hooks) {
         return timer.isRunning === false;
       },
       { timeout: timer.remaining + 1 } // eslint-disable-line
+    );
+  });
+
+  test('pause is idempotent and does not double-subtract remaining', async function (assert) {
+    const timer = new Timer(2000, () => {
+      // nothing
+    });
+
+    await sleep(100);
+
+    timer.pause();
+    const remainingAfterFirstPause = timer.remaining;
+
+    await sleep(100);
+
+    timer.pause();
+
+    assert.equal(
+      timer.remaining,
+      remainingAfterFirstPause,
+      'a second pause does not subtract the elapsed time again'
+    );
+    assert.ok(timer.remaining > 0, 'remaining is still positive');
+  });
+
+  test('pause never leaves remaining negative', async function (assert) {
+    const timer = new Timer(10, () => {
+      // nothing
+    });
+
+    // Let the duration fully elapse before pausing.
+    await sleep(100);
+
+    timer.pause();
+
+    assert.ok(
+      timer.remaining >= 0,
+      `remaining should never be negative, got ${timer.remaining}`
+    );
+
+    // A resume must not fire immediately because of a negative remaining.
+    timer.resume();
+    assert.ok(timer.isRunning);
+    timer.clear();
+  });
+
+  test('resume while running does not restart the remaining time', async function (assert) {
+    const timer = new Timer(2000, () => {
+      // nothing
+    });
+
+    await sleep(200);
+    timer.resume();
+    await sleep(200);
+    timer.pause();
+
+    assert.ok(
+      timer.remaining <= 1700,
+      `remaining should account for all elapsed time, got ${timer.remaining}`
     );
   });
 });


### PR DESCRIPTION
## Problems

**1. `Timer.pause()` was not idempotent.** `this.remaining -= Date.now() - this.start` with no guard. The card wires `pause` to `mouseenter` and `resume` to `mouseleave`, so a re-render or a nested enter double-subtracts; enough of it drives `remaining` negative and the next `resume()` fires the timer immediately.

**2. A notification could be removed twice.** `manager.remove()` didn't check `isRemoving`, so a double-click on the close button scheduled two removals and the `later` callback invoked `onRemove` — and therefore the consumer's `@onDismiss` — **twice for one notification**.

**3. `later` writing tracked state after teardown.** The `later` in `notification-card.gts`'s `transitionIn` (setting `hasEntered`) was never cancelled, nor were the two `requestAnimationFrame` callbacks that touch `element`.

**4. The container's `@onDismiss` was bound once and clobbered other containers.** The constructor registered `this.args.onDismiss` a single time, so a later change to the argument was ignored; and the destructor cleared the service's single callback slot unconditionally, so with two containers mounted the second clobbered the first and the first's teardown silently disabled the second's.

**5. Stale `marginTop`.** `setupSpacing` set `marginTop` only for top placements and never cleared it, so switching `@placement` from `top-*` to `bottom-*` left a stale margin.

## Fixes

- `pause()` no-ops when not running and clamps `remaining` at 0. `resume()` no-ops when already running — it previously called `clear()` + `setup()`, resetting `start` and rescheduling the full undecremented `remaining`, so repeated `mouseleave` without `mouseenter` could keep a notification alive indefinitely.
- `remove()` bails when the notification is already being removed, making removal and `onRemove` single-shot.
- `transitionIn` returns a teardown that `cancel()`s the `later` and `cancelAnimationFrame`s both frames.
- The container registers a **stable** `handleDismiss` that delegates to the current `this.args.onDismiss`, so argument changes are picked up without re-registering; the destructor clears the service slot only if it still owns it.
- `setupSpacing` always assigns `marginTop` (empty string for bottom placements) and clears it on teardown.

## Tests

12 added (35 in the notifications filter); 9 confirmed failing first, with the actual wrong values: `remaining` 1697 vs 1899 for the double-pause, `remaining` of **-92** for the negative case, 1799 for the restarted resume, 2 and 3 `onRemove` calls where 1 and 2 were expected, a stale `16px` margin, the old callback being used, and a surviving container getting nothing.

Also added coverage for behavior that had none: the auto-removal `onRemove` path, the `skipTimer` config option, and top-placement reverse ordering (all three passed before — they are guards).

**One honest caveat.** `it can be destroyed while the enter transition is in flight` **passes both before and after the fix.** Ember 6.6 does not raise on tracked writes to a destroyed component, and I could not construct a teardown that races the pending `later` through the test helpers — a timing-based attempt was contaminated by `ember-css-transitions`' own waiter. The test is labelled in-file as a smoke test, and **fix 3 is correct-by-construction rather than test-proven.** Cancelling a timer you own on teardown is unambiguously right, but it is not demonstrated by a failing-then-passing test like the others.

Full suite: **909 tests, 906 pass, 3 skip, 0 fail** (897 baseline + 12 new). `lint:types` clean. No pre-existing test asserted the buggy behavior, so nothing was modified or deleted.

## Scope note on the multi-container case

Staleness is fully fixed, and tearing down a *non-owning* container no longer disables the owner. The reverse — destroying the owning container while another is still mounted — still leaves no callback registered. Fixing that properly needs a multi-subscriber service, i.e. the redesign that was out of scope here. Documented in `packages/frontile/docs/notifications-usage.md` instead, along with `@onDismiss` firing exactly once per notification and the argument being read live.

(`packages/notifications/docs/notifications-usage.md` is a stale wrapper copy that Docfy does not render; left alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
