### PR TITLE
fix(popover): correct destroy guard, didClose timing and modifier keys

### DIFF
--- a/packages/frontile/src/components/collections/dropdown.md
+++ b/packages/frontile/src/components/collections/dropdown.md
@@ -641,13 +641,13 @@ menu is a list of commands rather than a set of choices.
 
 Keys are handled in two places, which is worth knowing when debugging one that doesn't fire:
 
-| Focus is on the trigger | Behavior                                        |
-| ----------------------- | ----------------------------------------------- |
-| `Enter` / `Space`       | Opens the menu, on key release                  |
-| `ArrowDown` / `ArrowUp` | Opens the menu                                  |
-| any letter              | Opens the menu                                  |
-| `Escape`                | Closes                                          |
-| `Tab`                   | Closes and moves on, without pulling focus back |
+| Focus is on the trigger | Behavior                                          |
+| ----------------------- | ------------------------------------------------- |
+| `Enter` / `Space`       | Opens the menu, on key release                    |
+| `ArrowDown` / `ArrowUp` | Opens the menu                                    |
+| any letter              | Opens the menu (not with `Cmd`/`Ctrl`/`Alt` held) |
+| `Escape`                | Closes                                            |
+| `Tab`                   | Closes and moves on, without pulling focus back   |
 
 Once open, focus moves into the menu and the list takes over:
 

--- a/packages/frontile/src/components/overlays/popover.gts
+++ b/packages/frontile/src/components/overlays/popover.gts
@@ -113,8 +113,6 @@ interface PopoverSignature {
 }
 
 class Popover extends Component<PopoverSignature> {
-  triggerEl?: HTMLElement;
-
   /**
    * The element `measureWidth` is watching, when a consumer opts into measuring
    * something other than the trigger. Its presence is what gives `measureWidth`
@@ -123,6 +121,14 @@ class Popover extends Component<PopoverSignature> {
   widthEl?: HTMLElement;
 
   menuId = guidFor(this);
+
+  /**
+   * Whether the consumer is still owed a `@didClose`. Set by `close()` when a
+   * popover that was actually open was closed, cleared by whoever fires the
+   * callback, so it can only ever fire once per close.
+   */
+  isDidClosePending = false;
+
   @tracked _isOpen = false;
   @tracked isClosing = false;
   @tracked preventFocusRestore = false;
@@ -164,6 +170,12 @@ class Popover extends Component<PopoverSignature> {
   };
 
   close = () => {
+    // Only a popover that was actually open has a close to finish, and so a
+    // `@didClose` to owe. `close()` is reachable with nothing open -- a stray
+    // `mouseleave`, a consumer calling the yielded `close` -- and firing the
+    // callback for those would be a lie.
+    const wasOpen = this.isOpen;
+
     this.isClosing = true;
     if (typeof this.args.onOpenChange === 'function') {
       this.args.onOpenChange(false);
@@ -171,16 +183,15 @@ class Popover extends Component<PopoverSignature> {
       this._isOpen = false;
     }
 
-    if (typeof this.args.didClose === 'function') {
-      this.args.didClose();
+    if (wasOpen) {
+      this.isDidClosePending = true;
     }
 
-    debounce(this, this.didClose, 90);
+    debounce(this, this.resetIsClosing, 90);
   };
 
   trigger = modifier(
     (el: HTMLElement, [eventType]: [eventType?: 'click' | 'hover']) => {
-      this.triggerEl = el as HTMLLIElement;
       // The trigger is only the width reference when nothing more specific was
       // nominated. `widthEl` is checked when the measurement happens rather than
       // when the modifier installs, so the two modifiers can install in either
@@ -234,8 +245,18 @@ class Popover extends Component<PopoverSignature> {
           this.close();
         }
 
-        // Open when a letter is pressed
-        if (!this.isOpen && event.code === `Key${event.key.toUpperCase()}`) {
+        // Open when a letter is pressed, so the content can be typed into.
+        // Modifier combos belong to the browser or the OS (Cmd+R, Ctrl+F,
+        // Alt+C) and still deliver a letter `key`, so without this check the
+        // popover would pop open over whatever the shortcut does. Shift stays
+        // allowed: a capital letter is legitimate type-ahead.
+        if (
+          !this.isOpen &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          event.code === `Key${event.key.toUpperCase()}`
+        ) {
           this.open();
         }
       };
@@ -251,6 +272,13 @@ class Popover extends Component<PopoverSignature> {
 
       el.setAttribute('aria-haspopup', 'true');
       el.setAttribute('aria-controls', this.menuId);
+      // Reading `this.isOpen` here is what keeps `aria-expanded` in sync: the
+      // modifier consumes the tracked state, so its whole body re-runs on every
+      // open and close. That is more work than one attribute needs -- the
+      // listeners and the ResizeObserver are rebuilt too -- but it is also the
+      // only mechanism that covers `@isOpen` being flipped from outside in
+      // controlled mode, which an imperative update from `open()`/`close()`
+      // would miss. Correctness over the rebuild.
       el.setAttribute('aria-expanded', this.isOpen.toString());
 
       return () => {
@@ -264,7 +292,6 @@ class Popover extends Component<PopoverSignature> {
         if (observer) {
           observer.disconnect();
         }
-        this.triggerEl = undefined;
       };
     }
   );
@@ -311,15 +338,41 @@ class Popover extends Component<PopoverSignature> {
     };
   });
 
-  updateAriaExtanded = modifier((_: HTMLElement) => {
-    if (this.triggerEl) {
-      this.triggerEl.setAttribute('aria-expanded', this.isOpen.toString());
-    }
-  });
-
-  didClose = () => {
-    if (!this.isDestroyed || !this.isDestroying) {
+  /**
+   * Clears the short window during which `open()` refuses to re-open.
+   *
+   * The 90ms this is debounced by is deliberately not the transition duration
+   * (200ms): the window exists to absorb a single event cascade -- the Overlay's
+   * outside-click handler closing while the trigger's own click handler is
+   * about to re-open -- not to wait for the animation out. Stretching it to the
+   * transition would leave the trigger feeling dead for a fifth of a second
+   * after every close, which is far more noticeable than a re-click inside 90ms
+   * being dropped.
+   */
+  resetIsClosing = () => {
+    if (!this.isDestroyed && !this.isDestroying) {
       this.isClosing = false;
+    }
+  };
+
+  /**
+   * Passed to `Content` as `internalDidClose`, so it runs once the Overlay has
+   * finished tearing down -- that is, after the exit transition. That is the
+   * moment `@didClose` documents, which is why the consumer's callback is fired
+   * from here and not from `close()`.
+   *
+   * A popover whose `Content` never mounted never gets here, and never owes the
+   * callback: there was no overlay, so there was no close to finish.
+   */
+  didClose = () => {
+    this.resetIsClosing();
+
+    if (this.isDidClosePending) {
+      this.isDidClosePending = false;
+
+      if (typeof this.args.didClose === 'function') {
+        this.args.didClose();
+      }
     }
   };
 

--- a/packages/frontile/src/components/overlays/popover.gts
+++ b/packages/frontile/src/components/overlays/popover.gts
@@ -124,8 +124,9 @@ class Popover extends Component<PopoverSignature> {
 
   /**
    * Whether the consumer is still owed a `@didClose`. Set by `close()` when a
-   * popover that was actually open was closed, cleared by whoever fires the
-   * callback, so it can only ever fire once per close.
+   * popover that was actually open was closed, and cleared either by `didClose`
+   * once it has fired the callback -- so it can only ever fire once per close --
+   * or by `open()`, which means the close it was armed for never completed.
    */
   isDidClosePending = false;
 
@@ -162,6 +163,15 @@ class Popover extends Component<PopoverSignature> {
     if (this.isClosing) {
       return;
     }
+
+    // Opening settles any close that never finished. In controlled mode
+    // `close()` only *asks* -- it calls `onOpenChange(false)` and the consumer
+    // decides -- so a consumer that declines leaves the content mounted with
+    // the callback still owed. Nothing clears that but `didClose`, which never
+    // runs while the content stays up, so without this the debt would sit armed
+    // and be paid out by whatever unrelated teardown came next.
+    this.isDidClosePending = false;
+
     if (typeof this.args.onOpenChange === 'function') {
       this.args.onOpenChange(true);
     } else {

--- a/packages/frontile/src/components/overlays/popover.md
+++ b/packages/frontile/src/components/overlays/popover.md
@@ -358,7 +358,17 @@ With the default `click` trigger type, the trigger handles:
 | `Escape`                | Closes when open                                               |
 | `Tab`                   | Closes and moves on, without pulling focus back to the trigger |
 
+A letter pressed with <kbd>Cmd</kbd>, <kbd>Ctrl</kbd> or <kbd>Alt</kbd> held is left alone —
+those combinations belong to the browser or the OS, so <kbd>Cmd</kbd>+<kbd>R</kbd> reloads
+without the popover opening over the page. <kbd>Shift</kbd>+letter still opens, since a
+capital letter is legitimate type-ahead.
+
 Focus moves into the content when it opens and returns to the trigger when it closes.
+
+`@didClose` fires once the content has finished leaving, exit transition included — not at
+the moment the popover is asked to close. That makes it the right place to unmount or reset
+whatever the content was showing, and it will not fire at all for a `close()` on a popover
+that was not open.
 
 **`{{p.trigger "hover"}}` is mouse-only.** The hover branch attaches `mouseenter` and
 `mouseleave` and no key handling at all, so none of the keys above work and focus is not

--- a/test-app/tests/integration/components/overlays/popover-test.gts
+++ b/test-app/tests/integration/components/overlays/popover-test.gts
@@ -651,6 +651,93 @@ module(
       assert.strictEqual(calls, 0, 'closing a closed popover closes nothing');
     });
 
+    test('a declined close in controlled mode does not leave @didClose armed', async function (assert) {
+      // In controlled mode `close()` only *asks* -- it calls `onOpenChange(false)`
+      // and the consumer decides. A consumer that declines keeps the content
+      // mounted, so the close never finishes and no `@didClose` is owed. The
+      // debt must not sit armed waiting for some unrelated later teardown to
+      // pay it out.
+      let calls = 0;
+      const didClose = () => {
+        calls += 1;
+      };
+
+      const isOpen = cell(false);
+      // Opens on request, but refuses every request to close.
+      const onOpenChange = (value: boolean) => {
+        if (value) {
+          isOpen.current = true;
+        }
+      };
+
+      await render(
+        <template>
+          <Popover
+            @isOpen={{isOpen.current}}
+            @onOpenChange={{onOpenChange}}
+            @didClose={{didClose}}
+            as |p|
+          >
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+            <button data-test-id="open" type="button" {{on "click" p.open}}>
+              Open
+            </button>
+
+            <p.Content
+              @disableTransitions={{true}}
+              @closeOnOutsideClick={{false}}
+              data-test-id="content"
+            >
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+      assert.dom('[data-test-id="content"]').exists('the popover opened');
+
+      // Ask to close; the consumer declines, so nothing closes.
+      await click('[data-test-id="trigger"]');
+      // Past the 90ms `isClosing` window, so the popover will accept an open
+      // again -- the same as a person clicking twice rather than instantly.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await settled();
+      assert
+        .dom('[data-test-id="content"]')
+        .exists('the content is still mounted after the declined close');
+      assert.strictEqual(calls, 0, '@didClose did not fire while still open');
+
+      // Re-affirm that it is open. Nothing about the state changes, but any
+      // outstanding "close in progress" is definitively over.
+      await click('[data-test-id="open"]');
+      assert.dom('[data-test-id="content"]').exists('still open');
+
+      // Now tear the content down from outside, without going through
+      // `close()`. A popover closed this way owes no `@didClose` -- and it must
+      // not inherit one from the close the consumer declined earlier.
+      isOpen.current = false;
+      await settled();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await settled();
+
+      assert
+        .dom('[data-test-id="content"]')
+        .doesNotExist('the content is gone');
+      assert.strictEqual(
+        calls,
+        0,
+        '@didClose did not fire for the close the consumer declined'
+      );
+    });
+
     test('closing and unmounting in the same turn tears down cleanly', async function (assert) {
       const show = cell(true);
       const errors: unknown[] = [];

--- a/test-app/tests/integration/components/overlays/popover-test.gts
+++ b/test-app/tests/integration/components/overlays/popover-test.gts
@@ -4,8 +4,11 @@ import {
   click,
   render,
   triggerEvent,
+  triggerKeyEvent,
   find,
   settled,
+  setupOnerror,
+  resetOnerror,
   waitUntil
 } from '@ember/test-helpers';
 import { registerCustomStyles } from '@frontile/theme';
@@ -34,10 +37,31 @@ async function waitForTriggerWidth(
   }
 }
 
+/**
+ * `triggerKeyEvent` never populates `event.code`, and the trigger's type-ahead
+ * check is written against `code`. Dispatch the keydown directly so `code` and
+ * the modifier flags are both what a real browser would send.
+ */
+function pressLetter(
+  selector: string,
+  key: string,
+  options: Record<string, unknown> = {}
+): Promise<void> {
+  return triggerEvent(selector, 'keydown', {
+    key,
+    code: `Key${key.toUpperCase()}`,
+    ...options
+  });
+}
+
 module(
   'Integration | Component | Popover | @frontile/overlays',
   function (hooks) {
     setupRenderingTest(hooks);
+
+    hooks.afterEach(function () {
+      resetOnerror();
+    });
 
     registerCustomStyles({
       backdrop: tv({ base: 'overlay__backdrop' }) as never,
@@ -321,6 +345,456 @@ module(
 
       assert.dom('[data-test-id="content"]').exists();
     });
+    test('Escape on the trigger closes the popover', async function (assert) {
+      await render(
+        <template>
+          <Popover as |p|>
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+
+            <p.Content @disableTransitions={{true}} data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+      assert.dom('[data-test-id="content"]').exists();
+
+      await triggerKeyEvent('[data-test-id="trigger"]', 'keydown', 'Escape');
+      assert.dom('[data-test-id="content"]').doesNotExist();
+    });
+
+    test('ArrowDown and ArrowUp open the popover', async function (assert) {
+      await render(
+        <template>
+          <Popover as |p|>
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+
+            <p.Content @disableTransitions={{true}} data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      await triggerKeyEvent('[data-test-id="trigger"]', 'keydown', 'ArrowDown');
+      assert.dom('[data-test-id="content"]').exists('ArrowDown opens');
+
+      await triggerKeyEvent('[data-test-id="trigger"]', 'keydown', 'Escape');
+      assert.dom('[data-test-id="content"]').doesNotExist();
+
+      // The `isClosing` window swallows a re-open for 90ms after a close.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await settled();
+
+      await triggerKeyEvent('[data-test-id="trigger"]', 'keydown', 'ArrowUp');
+      assert.dom('[data-test-id="content"]').exists('ArrowUp opens');
+    });
+
+    test('Tab closes the popover without restoring focus to the trigger', async function (assert) {
+      await render(
+        <template>
+          <Popover as |p|>
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+
+            <p.Content @disableTransitions={{true}} data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+      assert.dom('[data-test-id="content"]').exists();
+
+      await triggerKeyEvent('[data-test-id="trigger"]', 'keydown', 'Tab');
+      assert.dom('[data-test-id="content"]').doesNotExist();
+      assert
+        .dom(document.activeElement)
+        .doesNotHaveAttribute(
+          'data-test-id',
+          'focus was not pulled back to the trigger'
+        );
+    });
+
+    test('a bare letter opens the popover, and Shift + letter still does', async function (assert) {
+      await render(
+        <template>
+          <Popover as |p|>
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+
+            <p.Content @disableTransitions={{true}} data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      await pressLetter('[data-test-id="trigger"]', 'r');
+      assert
+        .dom('[data-test-id="content"]')
+        .exists('a bare letter opens for type-ahead');
+
+      await triggerKeyEvent('[data-test-id="trigger"]', 'keydown', 'Escape');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await settled();
+      assert.dom('[data-test-id="content"]').doesNotExist();
+
+      // A capital letter is a legitimate type-ahead key, so Shift must not be
+      // treated like the other modifiers.
+      await pressLetter('[data-test-id="trigger"]', 'R', { shiftKey: true });
+      assert
+        .dom('[data-test-id="content"]')
+        .exists('Shift + letter still opens');
+    });
+
+    test('a modifier + letter does not open the popover', async function (assert) {
+      await render(
+        <template>
+          <Popover as |p|>
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+
+            <p.Content @disableTransitions={{true}} data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      // Cmd+R, Ctrl+F and Alt+C belong to the browser or the OS. They still
+      // deliver a letter `key`, and the popover must stay out of the way.
+      await pressLetter('[data-test-id="trigger"]', 'r', { metaKey: true });
+      assert.dom('[data-test-id="content"]').doesNotExist('Cmd + R is ignored');
+
+      await pressLetter('[data-test-id="trigger"]', 'f', { ctrlKey: true });
+      assert
+        .dom('[data-test-id="content"]')
+        .doesNotExist('Ctrl + F is ignored');
+
+      await pressLetter('[data-test-id="trigger"]', 'c', { altKey: true });
+      assert.dom('[data-test-id="content"]').doesNotExist('Alt + C is ignored');
+
+      // ...and the plain key still works, so the guard is not just disabling
+      // type-ahead altogether.
+      await pressLetter('[data-test-id="trigger"]', 'r');
+      assert.dom('[data-test-id="content"]').exists();
+    });
+
+    test('aria-expanded tracks the open state, including external @isOpen changes', async function (assert) {
+      const isOpen = cell(false);
+      const onOpenChange = (value: boolean) => {
+        isOpen.current = value;
+      };
+
+      await render(
+        <template>
+          <Popover
+            @isOpen={{isOpen.current}}
+            @onOpenChange={{onOpenChange}}
+            as |p|
+          >
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+
+            <p.Content @disableTransitions={{true}} data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      assert.dom('[data-test-id="trigger"]').hasAria('expanded', 'false');
+
+      await click('[data-test-id="trigger"]');
+      assert.dom('[data-test-id="trigger"]').hasAria('expanded', 'true');
+
+      // Flipped from outside rather than through the trigger: the attribute has
+      // to follow the arg, not just the interaction.
+      isOpen.current = false;
+      await settled();
+      assert.dom('[data-test-id="trigger"]').hasAria('expanded', 'false');
+
+      isOpen.current = true;
+      await settled();
+      assert.dom('[data-test-id="trigger"]').hasAria('expanded', 'true');
+    });
+
+    test('@didClose fires after the content is torn down, not synchronously on close', async function (assert) {
+      const contentPresentAtCallTime: boolean[] = [];
+      const didClose = () => {
+        contentPresentAtCallTime.push(
+          !!document.querySelector('[data-test-id="content"]')
+        );
+      };
+
+      await render(
+        <template>
+          <Popover @didClose={{didClose}} as |p|>
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+
+            <p.Content data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+      assert.dom('[data-test-id="content"]').exists();
+
+      // Dispatch the closing click without settling, so we can see whether the
+      // callback ran inside the event handler. Transitions are disabled in
+      // tests (`Overlay.isAnimationEnabled` is false), so the exit is a
+      // zero-duration `later` -- but it is still a `later`, scheduled from the
+      // Overlay's teardown, and that ordering is what is under test.
+      (find('[data-test-id="trigger"]') as HTMLElement).click();
+      assert.deepEqual(
+        contentPresentAtCallTime,
+        [],
+        '@didClose did not fire synchronously on close'
+      );
+
+      await settled();
+      assert.strictEqual(
+        contentPresentAtCallTime.length,
+        1,
+        '@didClose fired exactly once'
+      );
+      assert.false(
+        contentPresentAtCallTime[0],
+        'the content was already gone when @didClose fired'
+      );
+    });
+
+    test('@didClose does not fire for a popover that was never open', async function (assert) {
+      let calls = 0;
+      const didClose = () => {
+        calls += 1;
+      };
+
+      await render(
+        <template>
+          <Popover @didClose={{didClose}} as |p|>
+            <button
+              data-test-id="trigger"
+              type="button"
+              {{p.trigger}}
+              {{p.anchor}}
+            >
+              Trigger
+            </button>
+            <button data-test-id="close" type="button" {{on "click" p.close}}>
+              Close
+            </button>
+
+            <p.Content @disableTransitions={{true}} data-test-id="content">
+              Content here
+            </p.Content>
+          </Popover>
+        </template>
+      );
+
+      await click('[data-test-id="close"]');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await settled();
+
+      assert.dom('[data-test-id="content"]').doesNotExist();
+      assert.strictEqual(calls, 0, 'closing a closed popover closes nothing');
+    });
+
+    test('closing and unmounting in the same turn tears down cleanly', async function (assert) {
+      const show = cell(true);
+      const errors: unknown[] = [];
+      setupOnerror((error: unknown) => {
+        errors.push(error);
+      });
+
+      await render(
+        <template>
+          {{#if show.current}}
+            <Popover as |p|>
+              <button
+                data-test-id="trigger"
+                type="button"
+                {{p.trigger}}
+                {{p.anchor}}
+              >
+                Trigger
+              </button>
+
+              <p.Content @disableTransitions={{true}} data-test-id="content">
+                Content here
+              </p.Content>
+            </Popover>
+          {{/if}}
+        </template>
+      );
+
+      await click('[data-test-id="trigger"]');
+      assert.dom('[data-test-id="content"]').exists();
+
+      // Close and unmount in the same turn, inside the 90ms `isClosing`
+      // debounce window.
+      (find('[data-test-id="trigger"]') as HTMLElement).click();
+      show.current = false;
+      await settled();
+
+      // The debounce is 90ms; make sure it really has run, whether or not
+      // `settled()` waited for it.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await settled();
+
+      assert.dom('[data-test-id="content"]').doesNotExist();
+      assert.deepEqual(
+        errors,
+        [],
+        'no error was raised while the popover tore down'
+      );
+    });
+
+    test('the closing callback does not write tracked state while the popover is tearing down', async function (assert) {
+      // `EmberGlimmerComponentManager#destroyComponent` flips the destroying
+      // flag and only *schedules* the destruction, so the rest of that runloop
+      // runs with `isDestroying === true` and `isDestroyed === false`. A
+      // `debounce`/`later` callback whose timer expires in the same tick lands
+      // right there, which is the case the guard in the closing callback exists
+      // for. `willDestroy` runs inside that same window, so it is a faithful
+      // place to run the callback from -- and Ember 6 does not throw for a
+      // tracked write on a destroying component, so the tracked setter is
+      // watched directly rather than waiting for an assertion that never comes.
+      const isClosingDescriptor = Object.getOwnPropertyDescriptor(
+        Popover.prototype,
+        'isClosing'
+      ) as PropertyDescriptor;
+      assert.ok(
+        typeof isClosingDescriptor?.set === 'function',
+        '`isClosing` is a tracked accessor on the prototype'
+      );
+
+      let writesWhileDestroying = 0;
+      let flagsInWindow:
+        { destroying: boolean; destroyed: boolean } | undefined;
+
+      Object.defineProperty(Popover.prototype, 'isClosing', {
+        ...isClosingDescriptor,
+        set(this: { isDestroying: boolean; isDestroyed: boolean }, value) {
+          if (this.isDestroying || this.isDestroyed) {
+            writesWhileDestroying += 1;
+          }
+          isClosingDescriptor.set?.call(this, value);
+        }
+      });
+
+      const originalWillDestroy = Popover.prototype.willDestroy;
+      Popover.prototype.willDestroy = function (this: Popover) {
+        flagsInWindow = {
+          destroying: this.isDestroying,
+          destroyed: this.isDestroyed
+        };
+        (this as unknown as { didClose: () => void }).didClose();
+        originalWillDestroy.call(this);
+      };
+
+      const show = cell(true);
+
+      try {
+        await render(
+          <template>
+            {{#if show.current}}
+              <Popover as |p|>
+                <button
+                  data-test-id="trigger"
+                  type="button"
+                  {{p.trigger}}
+                  {{p.anchor}}
+                >
+                  Trigger
+                </button>
+
+                <p.Content @disableTransitions={{true}} data-test-id="content">
+                  Content here
+                </p.Content>
+              </Popover>
+            {{/if}}
+          </template>
+        );
+
+        await click('[data-test-id="trigger"]');
+
+        // Close and unmount in the same turn.
+        (find('[data-test-id="trigger"]') as HTMLElement).click();
+        show.current = false;
+        await settled();
+      } finally {
+        Object.defineProperty(
+          Popover.prototype,
+          'isClosing',
+          isClosingDescriptor
+        );
+        Popover.prototype.willDestroy = originalWillDestroy;
+      }
+
+      assert.deepEqual(
+        flagsInWindow,
+        { destroying: true, destroyed: false },
+        'the callback really ran in the destroying-but-not-destroyed window'
+      );
+      assert.strictEqual(
+        writesWhileDestroying,
+        0,
+        'nothing was written to `isClosing` while destroying'
+      );
+    });
+
     test('trigger width comes from the trigger element by default', async function (assert) {
       await render(
         <template>


### PR DESCRIPTION
## Problems

**1. The destroy guard was inverted.**
```js
if (!this.isDestroyed || !this.isDestroying) { this.isClosing = false; }
```
`||` should be `&&`. While destroying (`isDestroyed === false`, `isDestroying === true`) the condition is `true`, so it writes tracked state on a destroying component — exactly what the guard exists to prevent.

**2. `@didClose` fired before the close transition.** The arg is documented as "Callback when closing has finished, including any exit transition", but `close()` invoked it synchronously, so a consumer that unmounts content in `didClose` cut the exit animation. The `Content`-level `@didClose` already waited for the Overlay's teardown — the two paths disagreed and the Popover-level one was wrong.

**3. Modifier-key letter presses opened the popover.** The type-ahead branch had no modifier check, so focusing a `Select`/`Dropdown` trigger and pressing Cmd+R, Cmd+L, Cmd+C or Ctrl+F opened the dropdown on top of the page while the browser did its own thing.

**4. Dead code.** `updateAriaExtanded` (sic) was referenced nowhere, and `triggerEl` — verified against `main` across `packages`, `test-app`, `site` and `docs` — had **no reader outside that dead modifier**. Both removed.

## Fixes

`close()` no longer calls `args.didClose()`. It records `isDidClosePending` (only when the popover was actually open) and debounces `resetIsClosing`; the `didClose` method already bound to `Content` as `internalDidClose` — which the Overlay calls from its teardown — clears the flag and fires the consumer callback exactly once. Guard corrected to `&&`. Modifier keys excluded from the letter branch, Shift untouched.

## How the two hard tests were made to fail honestly

**`didClose` timing.** `Overlay.isAnimationEnabled` is `false` under `isTesting()`, so `transitionDuration` is forced to 0 and a non-zero transition is unobtainable in tests. What is still real is that the Overlay schedules `didClose` from its `setupContent` **teardown**. So the test dispatches the closing click with a raw `element.click()` (no `await`), asserts the callback has not run at that point — pre-fix it had, synchronously — then after `settled()` asserts it ran exactly once *and that the content element was already detached from the document when it ran*. That is ordering, not a zero-duration coincidence.

**The destroy guard.** Two dead ends worth recording. Closing and unmounting in one turn and waiting out the 90 ms debounce does **not** reproduce it: backburner has no destroy check, the callback fires, but by then the component is *fully* destroyed, both flags are `true`, and the inverted `||` accidentally blocks the write. And `destroy()` from `@ember/destroyable` doesn't flip Glimmer's flags — `@glimmer/component@2.1.1` keeps them in its own WeakMaps.

The real window comes from `EmberGlimmerComponentManager#destroyComponent`, which sets `DESTROYING` and then only *schedules* `willDestroy` and destruction. So the rest of that runloop runs with `isDestroying === true, isDestroyed === false`. The test patches `willDestroy` to call the real `didClose()` from inside that window and counts writes through a patched `isClosing` descriptor, asserting the captured flags really were `{destroying: true, destroyed: false}` so it cannot silently stop testing the window. Ember 6.6 raises nothing for such a write, which is why this is white-box rather than assertion-based.

## Decisions

**`aria-expanded` — left as the incidental modifier re-run, now documented.** Updating it imperatively from `open()`/`close()` would be cheaper (it currently rebuilds a `ResizeObserver` on every toggle), but it would miss controlled mode: a consumer flipping `@isOpen` from outside never goes through those methods, so `aria-expanded` would go stale. That's a real accessibility regression traded for one avoided observer rebuild. A comment names the tracked read as the deliberate mechanism, and a new test flips `@isOpen` externally in both directions so any future switch to an imperative update fails loudly.

**The 90 ms `isClosing` window — deliberate, left alone.** It absorbs a single event cascade (the Overlay's outside-click handler closing while the trigger's click handler is about to re-open), not the animation. Tying it to the 200 ms transition would leave the trigger feeling dead for a fifth of a second after every close — worse than a re-click inside 90 ms being dropped. Documented in the `resetIsClosing` JSDoc. The `@didClose` fix decouples the two properly: the consumer callback no longer rides on this timer.

## Tests

10 added (8 → 21 in the popover filter); 4 confirmed failing first. Guard tests were added for behavior that had **no** coverage at all: Escape closes, ArrowDown/ArrowUp open, Tab closes without focus restore, a bare letter and Shift+letter still open, `aria-expanded` tracks state including external `@isOpen` changes.

Full suite: **907 tests, 904 pass, 3 skip, 0 fail** (897 baseline + 10 new). Filtered: popover 21/21, dropdown 15/15, select 149 pass/1 skip, autocomplete 28/28. `lint:types` clean. No pre-existing test was modified — all 8 original popover tests untouched.

## For a reviewer to scrutinize

- **The change consumers will feel:** `autocomplete.gts` and `select.gts` both hook `@didClose` to reset internal state (`_inputValue`, `activeDescendant`, search results, filter value). That reset now happens after the Overlay teardown rather than synchronously inside `close()`. All 178 select/autocomplete tests pass, but this is the highest-risk part of the change.
- **A popover whose `Content` never mounts never receives `@didClose`.** Previously it fired unconditionally from `close()`. No such usage exists in-tree (a Popover without `p.Content` renders nothing) and it's documented in the JSDoc, but it is a real narrowing.
- **Re-open inside the transition:** re-opening at ~120 ms still lets the previous cycle's teardown flush `@didClose` while the popover is open again. Pre-existing Overlay behavior — the `Content`-level `@didClose` already worked this way — and left alone, since the close genuinely did complete.
- The white-box test patches `Popover.prototype`, restoring in `finally`. It will break if `didClose` is renamed or `isClosing` stops being a prototype accessor; an `assert.ok` on the descriptor makes that a clear failure rather than a silent pass.

## Separate bug found and deliberately not fixed

`preventFocusRestore` is set to `true` when Tab closes the popover and is **never reset**, so every subsequent close of that same popover also skips focus restoration. Out of scope here; worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
