### PR TITLE
fix(forms): preserve numeric segments in validation error paths

### DIFF
--- a/packages/frontile/src/components/forms/field.md
+++ b/packages/frontile/src/components/forms/field.md
@@ -10,6 +10,12 @@ A component wrapper that provides conveniences for form fields when using built-
 
 **Important:** The Field component is designed specifically for use with the Form component's built-in validation system (`@schema` or `@validate` props). It should only be used when implementing form validation.
 
+`@name` is looked up verbatim in the form's `errors` object and read out of the form data
+with Ember's `get`, so dotted paths work — including numeric segments for array elements.
+`@name='items.0.name'` picks up an issue whose path is `['items', 0, 'name']`; the index is
+part of the key, so `items.0.name` and `items.1.name` never collide, and neither collapses
+onto `items.name`.
+
 ## Import
 
 ```js

--- a/packages/frontile/src/components/forms/form-control.gts
+++ b/packages/frontile/src/components/forms/form-control.gts
@@ -4,6 +4,7 @@ import { hash } from '@ember/helper';
 import Feedback, { type FormFeedbackSignature } from './form-feedback';
 import Description, { type FormDescriptionSignature } from './form-description';
 import Label, { type LabelSignature } from './label';
+import VisuallyHidden from '../utilities/visually-hidden';
 import type { ComponentLike, WithBoundArgs } from '@glint/template';
 
 interface FormControlSharedArgs {
@@ -155,6 +156,20 @@ class FormControl extends Component<FormControlSignature> {
     }
   }
 
+  /**
+   * The error messages as a single string, used by the persistent live region.
+   * Matches how `FormFeedback` joins an array of messages.
+   */
+  get errorMessageText(): string {
+    const { errors } = this.args;
+
+    if (!errors) {
+      return '';
+    }
+
+    return typeof errors === 'string' ? errors : errors.join('; ');
+  }
+
   get showErrorFeedback(): boolean {
     if (!(this.args.preventErrorFeedback === true) && this.isInvalid) {
       return true;
@@ -191,6 +206,7 @@ class FormControl extends Component<FormControlSignature> {
             size=@size
             messages=@errors
             intent="danger"
+            announce=false
           )
         )
         to="default"
@@ -202,8 +218,22 @@ class FormControl extends Component<FormControlSignature> {
           @size={{@size}}
           @messages={{@errors}}
           @intent="danger"
+          @announce={{false}}
         />
       {{/if}}
+
+      {{!
+        The visible feedback is only rendered once the field is invalid, and a
+        live region that appears at the same moment as its content is not
+        reliably announced. This region is always in the DOM, visually hidden
+        and empty, so assistive technology is already observing it when the
+        messages arrive. It is intentionally not part of describedBy; the
+        visible feedback is what describes the control.
+      }}
+      <VisuallyHidden
+        aria-live="assertive"
+        data-component="form-feedback-live-region"
+      >{{this.errorMessageText}}</VisuallyHidden>
     </div>
   </template>
 }

--- a/packages/frontile/src/components/forms/form-control.gts
+++ b/packages/frontile/src/components/forms/form-control.gts
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { hash } from '@ember/helper';
-import Feedback, { type FormFeedbackSignature } from './form-feedback';
+import Feedback, {
+  feedbackMessageText,
+  type FormFeedbackSignature
+} from './form-feedback';
 import Description, { type FormDescriptionSignature } from './form-description';
 import Label, { type LabelSignature } from './label';
 import VisuallyHidden from '../utilities/visually-hidden';
@@ -158,16 +161,10 @@ class FormControl extends Component<FormControlSignature> {
 
   /**
    * The error messages as a single string, used by the persistent live region.
-   * Matches how `FormFeedback` joins an array of messages.
+   * Uses `FormFeedback`'s own join, so both render the same separator.
    */
   get errorMessageText(): string {
-    const { errors } = this.args;
-
-    if (!errors) {
-      return '';
-    }
-
-    return typeof errors === 'string' ? errors : errors.join('; ');
+    return feedbackMessageText(this.args.errors);
   }
 
   get showErrorFeedback(): boolean {

--- a/packages/frontile/src/components/forms/form-control.md
+++ b/packages/frontile/src/components/forms/form-control.md
@@ -81,6 +81,17 @@ and drop the corresponding argument. They arrive with `for`, `id`, `size` and (f
 `@preventErrorFeedback` suppresses the automatic feedback at the bottom so `c.Feedback`
 is the only copy rendered.
 
+Either way, FormControl also renders a visually hidden `aria-live='assertive'` region that
+is always in the DOM and holds the error messages when there are any. That region is what
+screen readers announce, so the visible `FormFeedback` inside a FormControl is rendered with
+`@announce={{false}}` and the message is not announced twice. `@preventErrorFeedback` does
+not remove the live region.
+
+Because that region only ever carries the `@errors` text, `c.Feedback` with its own block
+content announces nothing. When you render custom content there and want it announced, turn
+announcing back on for that invocation with `@announce={{true}}` — an argument passed at the
+invocation site wins over the one FormControl bound.
+
 ```gts preview
 import { FormControl } from 'frontile';
 

--- a/packages/frontile/src/components/forms/form-feedback.gts
+++ b/packages/frontile/src/components/forms/form-feedback.gts
@@ -30,6 +30,16 @@ interface FormFeedbackSignature {
     size?: FormFeedbackVariants['size'];
 
     /**
+     * Whether the element is itself an `aria-live` region. Set this to `false`
+     * when something else (such as `FormControl`, which keeps a persistent
+     * live region in the DOM) already announces the messages, so they are not
+     * announced twice.
+     *
+     * @defaultValue true
+     */
+    announce?: boolean;
+
+    /**
      * Class names for the feedback element, merged with the theme's.
      */
     class?: string;
@@ -58,6 +68,17 @@ class FormFeedback extends Component<FormFeedbackSignature> {
     });
   }
 
+  get announce(): boolean {
+    return this.args.announce !== false;
+  }
+
+  get ariaLive(): string | undefined {
+    if (!this.announce) {
+      return undefined;
+    }
+    return this.isError ? 'assertive' : 'polite';
+  }
+
   get messageText(): string {
     if (!this.args.messages) return '';
 
@@ -73,7 +94,7 @@ class FormFeedback extends Component<FormFeedbackSignature> {
       id={{@id}}
       class={{this.classes}}
       data-component="form-feedback"
-      aria-live={{if this.isError "assertive" "polite"}}
+      aria-live={{this.ariaLive}}
       ...attributes
     >
       {{this.messageText}}

--- a/packages/frontile/src/components/forms/form-feedback.gts
+++ b/packages/frontile/src/components/forms/form-feedback.gts
@@ -50,6 +50,21 @@ interface FormFeedbackSignature {
   };
 }
 
+/**
+ * Renders feedback messages as a single string. An array is joined with `; `.
+ *
+ * Shared with `FormControl`, whose persistent live region announces the same
+ * text, so both render an identical separator.
+ *
+ * @param messages A list of messages or a single message string.
+ * @returns The messages as one string, or an empty string when there are none.
+ */
+function feedbackMessageText(messages: string[] | string | undefined): string {
+  if (!messages) return '';
+
+  return typeof messages === 'string' ? messages : messages.join('; ');
+}
+
 class FormFeedback extends Component<FormFeedbackSignature> {
   get isError(): boolean {
     return (
@@ -80,13 +95,7 @@ class FormFeedback extends Component<FormFeedbackSignature> {
   }
 
   get messageText(): string {
-    if (!this.args.messages) return '';
-
-    if (typeof this.args.messages === 'string') {
-      return this.args.messages;
-    } else {
-      return this.args.messages.join('; ');
-    }
+    return feedbackMessageText(this.args.messages);
   }
 
   <template>
@@ -103,5 +112,5 @@ class FormFeedback extends Component<FormFeedbackSignature> {
   </template>
 }
 
-export { FormFeedback, type FormFeedbackSignature };
+export { FormFeedback, feedbackMessageText, type FormFeedbackSignature };
 export default FormFeedback;

--- a/packages/frontile/src/components/forms/form.gts
+++ b/packages/frontile/src/components/forms/form.gts
@@ -520,6 +520,8 @@ class Form<T = FormDataCompiled> extends Component<FormSignature<T>> {
  *
  * For example, an issue with path `['email']` will be converted
  * to a form error for the field `email`, `{"email": "error message" }`.
+ * Numeric path segments are kept, so an issue with path
+ * `['items', 0, 'name']` becomes `{"items.0.name": "error message"}`.
  *
  * @param errors - The validation issues to convert.
  * @returns A mapping of field names to their validation error messages.
@@ -530,10 +532,17 @@ function validatorToFormErrors(errors: Issues): FormErrors {
   for (const issue of errors) {
     if (!issue.path || issue.path.length === 0) continue;
 
-    // Extract keys from path segments to build field name
+    // Extract keys from path segments to build field name.
+    // Segments are coerced to strings so numeric array indexes (including
+    // `0`) survive, producing the dotted name a consumer writes as `@name`
+    // (e.g. `items.0.name`). This must stay in sync with
+    // `StandardValidator.filterFieldIssues`.
     const pathKeys = issue.path
-      .map((s) => (typeof s === 'object' && 'key' in s ? s.key : s))
-      .filter(Boolean) as string[];
+      .map((s) =>
+        typeof s === 'object' && s !== null && 'key' in s ? s.key : s
+      )
+      .filter((key) => key !== null && key !== undefined)
+      .map((key) => String(key));
 
     const fieldName = pathKeys.join('.');
     const message = issue.message;

--- a/packages/frontile/src/components/forms/form.gts
+++ b/packages/frontile/src/components/forms/form.gts
@@ -5,7 +5,10 @@ import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { ref } from '../../utils/ref';
 import { dataFrom } from 'form-data-utils';
-import { StandardValidator } from '../../utils/standard-validator';
+import {
+  StandardValidator,
+  issuePathToFieldName
+} from '../../utils/standard-validator';
 import { flattenData, unflattenData, deepEqual } from '../../utils/nested-data';
 import { Field } from './field';
 
@@ -532,19 +535,10 @@ function validatorToFormErrors(errors: Issues): FormErrors {
   for (const issue of errors) {
     if (!issue.path || issue.path.length === 0) continue;
 
-    // Extract keys from path segments to build field name.
-    // Segments are coerced to strings so numeric array indexes (including
-    // `0`) survive, producing the dotted name a consumer writes as `@name`
-    // (e.g. `items.0.name`). This must stay in sync with
-    // `StandardValidator.filterFieldIssues`.
-    const pathKeys = issue.path
-      .map((s) =>
-        typeof s === 'object' && s !== null && 'key' in s ? s.key : s
-      )
-      .filter((key) => key !== null && key !== undefined)
-      .map((key) => String(key));
-
-    const fieldName = pathKeys.join('.');
+    // `issuePathToFieldName` is shared with
+    // `StandardValidator.filterFieldIssues`, so the keys written here are
+    // by construction the dotted names field lookup resolves against.
+    const fieldName = issuePathToFieldName(issue);
     const message = issue.message;
 
     // Add message to the field's errors

--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -826,6 +826,18 @@ dotted path down to the leaf — `user.name.first`, never just `user`.
 segments is dropped from the form data rather than nested. Building those keys out of untrusted
 field names would let a form write onto `Object.prototype` and change every object in the
 application, so they are refused outright.
+Numeric segments are part of the path like any other, so a validation issue whose path is
+`['items', 0, 'name']` is keyed as `items.0.name` — exactly what you would write as
+`@name='items.0.name'`. Index `0` is not dropped, and per-field validation matches indexed
+names too.
+
+**Array schemas are not supported.** Form rebuilds nested data by splitting dotted names, and
+a numeric segment becomes an ordinary object key, so fields named `items.0.name` and
+`items.1.name` arrive at your validator as `{ items: { 0: … , 1: … } }` — an object, never an
+array. A schema that declares `items` as an array therefore fails on `items` itself with a
+type error, and no per-index issue is ever produced. Validate collections with `@validate`
+instead, reading the indexed paths off the object you are given. The same applies to the data
+handed to `@onChange` and `@onSubmit`.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1419,7 +1431,9 @@ export default class DisabledForm extends Component {
 ## Feedback Messages
 
 When a field fails validation, `Form`/`Field` render a `FormFeedback` with the `danger` intent
-and an assertive `aria-live` region — no wiring needed.
+— no wiring needed. The announcement comes from a separate, visually hidden `aria-live`
+region that `FormControl` always keeps in the DOM, so it is already being observed when the
+message arrives.
 
 For feedback that isn't a validation error — hints, confirmations, warnings — render
 `FormFeedback` yourself and pick an `@intent` from `primary`, `secondary`, `tertiary`,
@@ -1456,8 +1470,11 @@ Form renders a native `<form>`, so submission on <kbd>Enter</kbd>, field labelli
 
 - **Invalid fields** get `aria-invalid='true'` from `Field`, removed again once the field
   validates.
-- **Error messages** render in a `FormFeedback` with `aria-live='assertive'` and are associated
-  with the control, so a screen reader announces them as they appear.
+- **Error messages** render in a `FormFeedback` associated with the control through
+  `aria-describedby`, and are announced from a persistent, visually hidden
+  `aria-live='assertive'` region that `FormControl` renders whether or not the field is
+  currently invalid. A live region inserted at the same moment as its content is not
+  announced reliably, which is why the region is always present and merely filled.
 - **Disabled fields** carry the real `disabled` attribute rather than a styling-only state.
 - **Focus** is not managed or trapped by Form; it stays where the browser puts it. If you
   redirect focus to the first invalid field in `@onError`, see

--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -1439,6 +1439,13 @@ For feedback that isn't a validation error — hints, confirmations, warnings �
 `FormFeedback` yourself and pick an `@intent` from `primary`, `secondary`, `tertiary`,
 `success`, `warning`, or `danger`. Anything other than `danger` announces politely.
 
+A standalone `FormFeedback` is its own `aria-live` region. Pass `@announce={{false}}` when
+something else already announces the same text — that is exactly what `FormControl` does to
+the feedback it renders, since its persistent live region has already covered the message and
+announcing twice is worse than not at all. See
+[FormControl](/docs/components/forms/form-control) for the full explanation and the
+cases where you want to turn announcing back on.
+
 ```gts preview
 import { FormFeedback } from 'frontile';
 

--- a/packages/frontile/src/utils/standard-validator.ts
+++ b/packages/frontile/src/utils/standard-validator.ts
@@ -216,8 +216,8 @@ class StandardValidator {
    * Supports both simple field names and dotted notation for nested fields.
    *
    * @param issues The issues to filter.
-   * @param fieldName The name of the field to filter by (e.g., "email" or
-   *        "profile.contact.email").
+   * @param fieldName The name of the field to filter by (e.g., "email",
+   *        "profile.contact.email" or "items.0.name" for array elements).
    * @returns The issues related to the specified field, or undefined if
    *          there are none.
    */
@@ -230,10 +230,15 @@ class StandardValidator {
     const fieldIssues = issues.filter((issue) => {
       if (!issue.path) return false;
 
-      // Extract keys from path segments
+      // Extract keys from path segments.
+      // Segments are coerced to strings so numeric array indexes (including
+      // `0`) survive and can be compared against the dotted field name.
       const pathKeys = issue.path
-        .map((s) => (typeof s === 'object' && 'key' in s ? s.key : s))
-        .filter(Boolean);
+        .map((s) =>
+          typeof s === 'object' && s !== null && 'key' in s ? s.key : s
+        )
+        .filter((key) => key !== null && key !== undefined)
+        .map((key) => String(key));
 
       // For exact path matching:
       // The paths must be the same length and match exactly

--- a/packages/frontile/src/utils/standard-validator.ts
+++ b/packages/frontile/src/utils/standard-validator.ts
@@ -28,6 +28,42 @@ export type CustomValidatorFn<Input = unknown> = (
 ) => CustomValidatorReturn;
 
 /**
+ * Extracts the comparable keys from a Standard Schema issue path.
+ *
+ * Path segments may be plain keys or `{ key }` objects. Keys are coerced to
+ * strings so numeric array indexes (including `0`) survive and line up with
+ * the dotted field name a consumer writes as `@name` (e.g. `items.0.name`).
+ *
+ * This is the single source of truth for that format: both
+ * `StandardValidator.filterFieldIssues` and the form component's
+ * `FormErrors` conversion go through it, so field lookup and error keys
+ * cannot disagree.
+ *
+ * @param path The issue path to extract keys from.
+ * @returns The path keys as strings, with null/undefined segments dropped.
+ */
+function issuePathKeys(path: StandardSchemaV1.Issue['path']): string[] {
+  if (!path) return [];
+
+  return path
+    .map((s) => (typeof s === 'object' && s !== null && 'key' in s ? s.key : s))
+    .filter((key) => key !== null && key !== undefined)
+    .map((key) => String(key));
+}
+
+/**
+ * Builds the dotted field name for a Standard Schema issue, matching the
+ * `@name` a consumer gives a field (e.g. `items.0.name`).
+ *
+ * @param issue The issue to build the field name for.
+ * @returns The dotted field name, or an empty string when the issue has no
+ *          path.
+ */
+function issuePathToFieldName(issue: StandardSchemaV1.Issue): string {
+  return issuePathKeys(issue.path).join('.');
+}
+
+/**
  * Provides convenience methods for validating data using Standard Schema.
  * Also supports custom validator functions that return issues in the
  * Standard Schema format.
@@ -230,15 +266,7 @@ class StandardValidator {
     const fieldIssues = issues.filter((issue) => {
       if (!issue.path) return false;
 
-      // Extract keys from path segments.
-      // Segments are coerced to strings so numeric array indexes (including
-      // `0`) survive and can be compared against the dotted field name.
-      const pathKeys = issue.path
-        .map((s) =>
-          typeof s === 'object' && s !== null && 'key' in s ? s.key : s
-        )
-        .filter((key) => key !== null && key !== undefined)
-        .map((key) => String(key));
+      const pathKeys = issuePathKeys(issue.path);
 
       // For exact path matching:
       // The paths must be the same length and match exactly
@@ -252,5 +280,5 @@ class StandardValidator {
   }
 }
 
-export { StandardValidator };
+export { StandardValidator, issuePathKeys, issuePathToFieldName };
 export default StandardValidator;

--- a/test-app/tests/integration/components/forms/form-control-test.gts
+++ b/test-app/tests/integration/components/forms/form-control-test.gts
@@ -1,6 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
+import { array } from '@ember/helper';
+import { cell } from 'ember-resources';
 
 import { FormControl } from 'frontile';
 
@@ -73,6 +75,144 @@ module(
 
       assert.dom('[data-component="label"]').doesNotExist();
       assert.dom('[data-component="form-description"]').doesNotExist();
+    });
+
+    test('the error live region exists before the field becomes invalid', async function (assert) {
+      const errors = cell<string[] | string | undefined>();
+
+      await render(
+        <template>
+          <FormControl @label="Email" @errors={{errors.current}} as |c|>
+            <input id={{c.id}} />
+          </FormControl>
+        </template>
+      );
+
+      // The live region has to be in the DOM *before* it gets content,
+      // otherwise assistive technology is not observing it when the error
+      // arrives and the message is never announced.
+      assert
+        .dom('[data-component="form-feedback-live-region"]')
+        .exists('the live region is rendered while the field is still valid');
+      assert
+        .dom('[data-component="form-feedback-live-region"]')
+        .hasAria('live', 'assertive');
+      assert
+        .dom('[data-component="form-feedback-live-region"]')
+        .hasText('', 'the live region starts empty');
+      assert
+        .dom('[data-component="form-feedback"]')
+        .doesNotExist('no visible feedback while the field is valid');
+
+      errors.current = ['Email is required'];
+      await settled();
+
+      assert
+        .dom('[data-component="form-feedback-live-region"]')
+        .hasText(
+          'Email is required',
+          'the pre-existing live region is filled with the message'
+        );
+      assert
+        .dom('[data-component="form-feedback"]')
+        .hasText('Email is required', 'the visible feedback renders too');
+
+      // The visible feedback must not also be a live region, or the message
+      // would be announced twice.
+      assert
+        .dom('[data-component="form-feedback"]')
+        .doesNotHaveAttribute('aria-live');
+
+      errors.current = undefined;
+      await settled();
+
+      assert
+        .dom('[data-component="form-feedback-live-region"]')
+        .hasText('', 'the live region empties again when the field is valid');
+    });
+
+    test('the live region joins multiple messages', async function (assert) {
+      await render(
+        <template>
+          <FormControl
+            @label="Email"
+            @errors={{array "Email is required" "Email is invalid"}}
+          />
+        </template>
+      );
+
+      assert
+        .dom('[data-component="form-feedback-live-region"]')
+        .hasText('Email is required; Email is invalid');
+    });
+
+    test('the live region is still rendered with @preventErrorFeedback', async function (assert) {
+      await render(
+        <template>
+          <FormControl
+            @label="Email"
+            @errors={{array "Email is required"}}
+            @preventErrorFeedback={{true}}
+          />
+        </template>
+      );
+
+      assert
+        .dom('[data-component="form-feedback"]')
+        .doesNotExist('the automatic visible feedback is suppressed');
+      assert
+        .dom('[data-component="form-feedback-live-region"]')
+        .hasText(
+          'Email is required',
+          'the announcement is still made from the live region'
+        );
+    });
+
+    /**
+     * FormControl curries `announce=false` onto the yielded Feedback because its
+     * own live region covers the `@errors` text. Custom block content is not in
+     * that region, so the documented escape hatch is to pass `@announce={{true}}`
+     * at the invocation site, which has to win over the curried value.
+     */
+    test('an invocation-site @announce overrides the curried announce=false', async function (assert) {
+      await render(
+        <template>
+          <FormControl @label="Username" as |c|>
+            <input id={{c.id}} />
+            <c.Feedback @intent="success" @announce={{true}}>
+              That username is available.
+            </c.Feedback>
+          </FormControl>
+        </template>
+      );
+
+      assert
+        .dom('[data-component="form-feedback"]')
+        .hasAria(
+          'live',
+          'polite',
+          'custom block content can opt back in to being announced'
+        );
+    });
+
+    test('the yielded Feedback does not announce by default', async function (assert) {
+      await render(
+        <template>
+          <FormControl @label="Username" as |c|>
+            <input id={{c.id}} />
+            <c.Feedback @intent="success">
+              That username is available.
+            </c.Feedback>
+          </FormControl>
+        </template>
+      );
+
+      assert
+        .dom('[data-component="form-feedback"]')
+        .doesNotHaveAttribute(
+          'aria-live',
+          'FormControl owns the announcement, so the yielded Feedback is silent'
+        );
     });
   }
 );

--- a/test-app/tests/integration/components/forms/form-nested-test.gts
+++ b/test-app/tests/integration/components/forms/form-nested-test.gts
@@ -3,7 +3,13 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click, fillIn, settled } from '@ember/test-helpers';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
-import { Form, type FormResultData, type FormErrors } from 'frontile';
+import {
+  Form,
+  type FormResultData,
+  type FormErrors,
+  type FormDataCompiled,
+  type CustomValidatorReturn
+} from 'frontile';
 import * as v from 'valibot';
 import Component from '@glimmer/component';
 
@@ -767,6 +773,190 @@ module(
         'John',
         'First name reset to initial value'
       );
+    });
+
+    /**
+     * Reads a dotted path out of the nested form data the Form hands to a
+     * custom validator.
+     */
+    function readPath(data: unknown, path: string): unknown {
+      return path
+        .split('.')
+        .reduce<unknown>(
+          (acc, key) =>
+            acc && typeof acc === 'object'
+              ? (acc as Record<string, unknown>)[key]
+              : undefined,
+          data
+        );
+    }
+
+    /**
+     * Issue paths that contain array indexes must produce (and match) the
+     * dotted field name a consumer writes, e.g. `items.0.name`. The custom
+     * validator path is used here because it hands the Form plain Standard
+     * Schema issues, which is exactly what `validatorToFormErrors` and
+     * `StandardValidator.filterFieldIssues` consume.
+     */
+    test('it surfaces array element errors on the indexed field name', async function (assert) {
+      assert.expect(6);
+
+      const validator = (data: FormDataCompiled): CustomValidatorReturn => {
+        const issues = [];
+
+        if (!readPath(data, 'items.0.name')) {
+          issues.push({
+            message: 'First name is required',
+            path: [{ key: 'items' }, { key: 0 }, { key: 'name' }]
+          });
+        }
+
+        if (!readPath(data, 'items.1.name')) {
+          issues.push({
+            message: 'Second name is required',
+            path: [{ key: 'items' }, { key: 1 }, { key: 'name' }]
+          });
+        }
+
+        return issues.length > 0 ? issues : undefined;
+      };
+
+      let lastErrors: FormErrors | undefined;
+      let submitted = false;
+
+      class TestComponent extends Component {
+        handleSubmit = () => {
+          submitted = true;
+        };
+
+        handleError = (errors: FormErrors) => {
+          lastErrors = errors;
+        };
+
+        <template>
+          <Form
+            @validate={{validator}}
+            @onSubmit={{this.handleSubmit}}
+            @onError={{this.handleError}}
+            as |form|
+          >
+            <div data-test-item-0>
+              <form.Field @name="items.0.name" as |field|>
+                <field.Input data-test-item-0-input />
+              </form.Field>
+            </div>
+
+            <div data-test-item-1>
+              <form.Field @name="items.1.name" as |field|>
+                <field.Input data-test-item-1-input />
+              </form.Field>
+            </div>
+
+            <button type="submit" data-test-submit>Submit</button>
+          </Form>
+        </template>
+      }
+
+      await render(<template><TestComponent /></template>);
+
+      await click('[data-test-submit]');
+
+      assert.false(submitted, 'submission is blocked by the validation errors');
+      assert.ok(
+        lastErrors?.['items.0.name'],
+        'the index 0 error is keyed by the name a consumer writes'
+      );
+      assert.notOk(
+        lastErrors?.['items.name'],
+        'the index 0 error is not misfiled onto the unindexed field name'
+      );
+
+      assert
+        .dom('[data-test-item-0] [data-component="form-feedback"]')
+        .hasText(
+          'First name is required',
+          'the first element displays its own error'
+        );
+      assert
+        .dom('[data-test-item-1] [data-component="form-feedback"]')
+        .hasText(
+          'Second name is required',
+          'the second element displays its own error'
+        );
+
+      // Per-field validation (on change) has to match the indexed path too.
+      await fillIn('[data-test-item-1-input]', 'Second');
+
+      assert
+        .dom('[data-test-item-1] [data-component="form-feedback"]')
+        .doesNotExist(
+          'the second element error clears once that element is valid'
+        );
+    });
+
+    test('it validates a non-zero array element on change', async function (assert) {
+      assert.expect(3);
+
+      const validator = (data: FormDataCompiled): CustomValidatorReturn => {
+        const value = (readPath(data, 'items.1.name') as string) ?? '';
+
+        if (value.length > 0 && value.length < 3) {
+          return [
+            {
+              message: 'Name must be at least 3 characters',
+              path: [{ key: 'items' }, { key: 1 }, { key: 'name' }]
+            }
+          ];
+        }
+
+        return undefined;
+      };
+
+      class TestComponent extends Component {
+        handleSubmit = () => {
+          // noop
+        };
+
+        <template>
+          <Form
+            @validate={{validator}}
+            @onSubmit={{this.handleSubmit}}
+            as |form|
+          >
+            <div data-test-item-0>
+              <form.Field @name="items.0.name" as |field|>
+                <field.Input data-test-item-0-input />
+              </form.Field>
+            </div>
+
+            <div data-test-item-1>
+              <form.Field @name="items.1.name" as |field|>
+                <field.Input data-test-item-1-input />
+              </form.Field>
+            </div>
+          </Form>
+        </template>
+      }
+
+      await render(<template><TestComponent /></template>);
+
+      await fillIn('[data-test-item-1-input]', 'ab');
+
+      assert
+        .dom('[data-test-item-1] [data-component="form-feedback"]')
+        .hasText(
+          'Name must be at least 3 characters',
+          'the second element shows its own error'
+        );
+      assert
+        .dom('[data-test-item-0] [data-component="form-feedback"]')
+        .doesNotExist('the first element is unaffected');
+
+      await fillIn('[data-test-item-1-input]', 'abcd');
+
+      assert
+        .dom('[data-test-item-1] [data-component="form-feedback"]')
+        .doesNotExist('the error clears once the element becomes valid');
     });
 
     module('prototype pollution', function (hooks) {

--- a/test-app/tests/integration/components/forms/from-test.gts
+++ b/test-app/tests/integration/components/forms/from-test.gts
@@ -23,7 +23,8 @@ import {
   Select,
   type FormDataCompiled,
   type FormResultData,
-  type CustomValidatorReturn
+  type CustomValidatorReturn,
+  type FormErrors
 } from 'frontile';
 import { cell } from 'ember-resources';
 import * as v from 'valibot';
@@ -397,6 +398,54 @@ module('Integration | Component | @frontile/forms/Form', function (hooks) {
    * 4. onSubmit is not called when either validation fails
    * 5. When valid data is submitted, both validations pass and onSubmit is called
    */
+  /**
+   * Multiple issues on the same field are collapsed into an array of messages
+   * by `validatorToFormErrors`, and the feedback element joins them.
+   */
+  test('it collects multiple issues for the same field into a list of messages', async function (assert) {
+    assert.expect(3);
+
+    const customValidator = (): CustomValidatorReturn => [
+      { message: 'Email is required', path: [{ key: 'email' }] },
+      { message: 'Email is invalid', path: [{ key: 'email' }] }
+    ];
+
+    const onSubmitSpy = sinon.spy();
+    let lastErrors: FormErrors | undefined;
+    const onError = (errors: FormErrors) => {
+      lastErrors = errors;
+    };
+
+    await render(
+      <template>
+        <Form
+          @validate={{customValidator}}
+          @onSubmit={{onSubmitSpy}}
+          @onError={{onError}}
+          as |form|
+        >
+          <form.Field @name="email" as |field|>
+            <field.Input data-test-email />
+          </form.Field>
+
+          <button type="submit" data-test-submit>Submit</button>
+        </Form>
+      </template>
+    );
+
+    await click('[data-test-submit]');
+
+    assert.deepEqual(
+      lastErrors?.['email'],
+      ['Email is required', 'Email is invalid'],
+      'both messages are collected under the same field name'
+    );
+    assert
+      .dom('[data-component="form-feedback"]')
+      .hasText('Email is required; Email is invalid');
+    assert.false(onSubmitSpy.called, 'submission is prevented');
+  });
+
   test('it validates form using both schema and custom validator function', async function (assert) {
     assert.expect(11);
 

--- a/test-app/tests/unit/forms/utils/standard-validator-test.ts
+++ b/test-app/tests/unit/forms/utils/standard-validator-test.ts
@@ -1140,4 +1140,107 @@ module('Unit | Forms | StandardValidator', function (hooks) {
     );
     assert.strictEqual(nestedEmail?.[0]?.message, 'Email 3 invalid');
   });
+
+  test('filterFieldIssues matches array index path segments', function (assert) {
+    assert.expect(7);
+
+    const issues = [
+      // Numeric index as a bare path segment
+      { message: 'First name is required', path: ['items', 0, 'name'] },
+      // Numeric index wrapped in a path segment object
+      {
+        message: 'Third name is required',
+        path: [{ key: 'items' }, { key: 2 }, { key: 'name' }]
+      },
+      // A same-named field that is *not* under an index
+      {
+        message: 'Items name invalid',
+        path: [{ key: 'items' }, { key: 'name' }]
+      }
+    ];
+
+    const firstItem = StandardValidator.filterFieldIssues(
+      issues,
+      'items.0.name'
+    );
+    assert.strictEqual(
+      firstItem?.length,
+      1,
+      'index 0 is preserved and matched'
+    );
+    assert.strictEqual(firstItem?.[0]?.message, 'First name is required');
+
+    const thirdItem = StandardValidator.filterFieldIssues(
+      issues,
+      'items.2.name'
+    );
+    assert.strictEqual(thirdItem?.length, 1, 'a non-zero index is matched');
+    assert.strictEqual(thirdItem?.[0]?.message, 'Third name is required');
+
+    // The indexed issues must not leak onto the unindexed field name
+    const unindexed = StandardValidator.filterFieldIssues(issues, 'items.name');
+    assert.strictEqual(
+      unindexed?.length,
+      1,
+      'indexed issues are not misfiled onto items.name'
+    );
+    assert.strictEqual(unindexed?.[0]?.message, 'Items name invalid');
+
+    const missing = StandardValidator.filterFieldIssues(issues, 'items.1.name');
+    assert.notOk(missing, 'a valid element has no issues');
+  });
+
+  test('validateField works with array element field names', async function (assert) {
+    assert.expect(4);
+
+    const schema = v.object({
+      items: v.array(
+        v.object({
+          name: v.pipe(v.string(), v.nonEmpty('Name is required'))
+        })
+      )
+    });
+
+    const data = { items: [{ name: '' }, { name: 'ok' }, { name: '' }] };
+
+    const first = await StandardValidator.validateField(
+      data,
+      'items.0.name',
+      schema
+    );
+    assert.strictEqual(first?.length, 1, 'first element error is found');
+    assert.strictEqual(first?.[0]?.message, 'Name is required');
+
+    const second = await StandardValidator.validateField(
+      data,
+      'items.1.name',
+      schema
+    );
+    assert.notOk(second, 'valid element reports no errors');
+
+    const third = await StandardValidator.validateField(
+      data,
+      'items.2.name',
+      schema
+    );
+    assert.strictEqual(third?.length, 1, 'third element error is found');
+  });
+
+  test('filterFieldIssues ignores null and undefined path segments', function (assert) {
+    assert.expect(2);
+
+    const issues = [
+      {
+        message: 'Email invalid',
+        path: [{ key: 'profile' }, undefined, { key: 'email' }]
+      }
+    ];
+
+    const emailIssues = StandardValidator.filterFieldIssues(
+      issues as never,
+      'profile.email'
+    );
+    assert.ok(emailIssues, 'nullish segments are dropped from the path');
+    assert.strictEqual(emailIssues?.[0]?.message, 'Email invalid');
+  });
 });


### PR DESCRIPTION
## Problems

**1. Validation issue paths dropped numeric index `0` and never matched array fields.** Two places did the same thing — `filterFieldIssues` in `utils/standard-validator.ts` and `validatorToFormErrors` in `components/forms/form.gts` — mapping the Standard Schema `issue.path` segments and then calling `.filter(Boolean)`:

- `.filter(Boolean)` **removes the numeric index `0`** (and any empty-string key), so `['items', 0, 'name']` became `items.name`.
- `filterFieldIssues` then compared `key === fieldParts[i]`, i.e. `number === string`, which is never true for an index — so per-field validation for `items.0.name` could never match its issue.

**2. The error feedback live region was announced unreliably.** `aria-live` sat on the feedback element, but `FormControl` only renders that element *once the field becomes invalid*. A live region inserted at the same moment as its content is generally not announced — the region has to already exist for assistive technology to be observing it.

## Fixes

Each resolved path segment is coerced with `String(...)` and only `null`/`undefined` are dropped, in both places, with a comment noting the two must stay in sync. That fixes both defects at once: index `0` survives, and the comparison is string-vs-string so any index matches.

`FormControl` now owns a persistent, visually hidden `aria-live="assertive"` region that is always in the DOM and merely filled, and passes `@announce={{false}}` to both the automatic and the yielded `Feedback` so nothing is announced twice. `FormFeedback` gains an `@announce` arg (default `true`, so the standalone public component is unchanged).

**Why not simply always-render the existing feedback element**, which is the obvious reading of "keep the region present and empty":
1. **Layout.** The theme's `formFeedback` base includes `pt-1`, so an always-present empty div adds 4px of padding to every form control. Stripping classes when empty then breaks the block-content case.
2. **Blast radius.** 73 assertions across 11 test files use the presence/absence of `[data-component="form-feedback"]` as *the* idiom for "is there an error". Rewriting them to assert emptiness would have rewritten the meaning of the suite's error assertions and buried the actual fix.

The region is deliberately **not** part of `describedBy` — it is an announcement channel, not a description, and the visible feedback is what should describe the control. Always-rendering it removes a dangling-reference risk rather than adding one.

## Docs: one escape hatch worth knowing

Because the region only ever carries the `@errors` text, a yielded `c.Feedback` with custom *block* content would no longer be announced. The hatch is to pass `@announce={{true}}` at the invocation site, which beats the curried `announce=false`. That precedence claim was **verified with a throwaway probe test before being documented**, not taken on trust — and the probe was then promoted into two permanent tests, since a documented escape hatch with nothing guarding it is how docs rot.

## Tests

11 added; 7 confirmed failing first (re-verified afterwards by checking out just the two path fixes, rebuilding, and re-running: `# tests 3 / # pass 0 / # fail 3`).

- `filterFieldIssues matches array index path segments` — `['items',0,'name']` matches `items.0.name`; `[{key:'items'},{key:2},{key:'name'}]` matches `items.2.name`; indexed issues do not leak onto `items.name`
- `validateField works with array element field names` — through a real valibot schema, indices 0 and 2 report errors and index 1 reports none
- `filterFieldIssues ignores null and undefined path segments` — guards the `.filter(Boolean)` → explicit-nullish swap
- End-to-end `<Form>`: array element errors surface on the indexed field name and not on `items.name`, both `<form.Field>`s render their own message, and index 1's clears on change
- The live region exists and is empty *while valid*, then fills; the visible feedback has no `aria-live` (no double announcement); it empties again on return to valid; it joins multiple messages; it is still rendered with `@preventErrorFeedback`
- The `@announce` override and the curried default
- `it collects multiple issues for the same field into a list of messages` — a coverage gap found in review; passed before, documents existing correct behavior

Unit tests use **valibot**, already used throughout that file. Integration tests use the `@validate` custom-validator path. **No dependency added.**

Full suite: **908 tests, 905 pass, 3 skip, 0 fail** (897 baseline + 11 new). `lint:types` clean. **No pre-existing test was modified or deleted** — only appends and two import lines.

## A correction to how this bug was originally reported

I described the failure through a `z.object({ items: z.array(...) })` schema. **That scenario is unreachable, independent of this fix.** Integration tests written that way failed *even with the fix applied*: `Form` rebuilds nested data by splitting dotted names, and a numeric segment becomes an ordinary object key, so `items.0.name` / `items.1.name` arrive as `{ items: { 0: …, 1: … } }` — an object, never an array. A schema declaring `items` as an array fails on `items` itself with a type error and no per-index issue is ever produced.

The path fix is still correct and still matters — for the `@validate` path, and for any consumer emitting issues with index segments. But array *schemas* don't work end-to-end for a separate reason, and `form.md` now says so unambiguously rather than hedging. Making them work means teaching `unflattenData` to reconstruct arrays, which changes `@onChange`/`@onSubmit` payload shapes — a larger, potentially breaking change that deserves its own issue.

## Note

The error text is now duplicated in the DOM (visible + `sr-only`). That is the accepted cost of this pattern; no test regressed on it. `Checkbox`/`Radio`/`Switch` use `@preventErrorFeedback` plus a yielded `c.Feedback` and are covered by the new region with no change to those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
