### PR TITLE
fix(collections): coalesce ListManager batch work and refresh Listbox callbacks

### DIFF
--- a/packages/frontile/src/components/collections/dropdown.md
+++ b/packages/frontile/src/components/collections/dropdown.md
@@ -639,6 +639,10 @@ Menu items deliberately carry no `aria-selected`: it is invalid on a plain `menu
 conveys state through `aria-checked` and only as `menuitemcheckbox` or `menuitemradio`. A
 menu is a list of commands rather than a set of choices.
 
+Menu items share the Listbox's roving `tabindex`: exactly one item carries `tabindex="0"` —
+the active one, falling back to the first selected item and then to the first item that is not
+disabled — and every other item is `-1`.
+
 Keys are handled in two places, which is worth knowing when debugging one that doesn't fire:
 
 | Focus is on the trigger | Behavior                                          |

--- a/packages/frontile/src/components/collections/listbox.md
+++ b/packages/frontile/src/components/collections/listbox.md
@@ -546,6 +546,13 @@ export default class EmptySelection extends Component {
 | Items    | `role="option"` (or `menuitem`), `aria-labelledby` pointing at the item's label                |
 |          | `aria-selected` reflecting selection — options only, since it is invalid on a plain `menuitem` |
 |          | `aria-disabled="true"` for keys in `@disabledKeys`                                             |
+|          | a roving `tabindex` — exactly one option carries `0`, every other one `-1`                      |
+
+The options form a composite you step into once and then navigate with the arrow keys, so only
+one of them is ever in the tab order. That one is the active option; with nothing active it is
+the first selected option, and failing that the first option that is not disabled. A
+multiple-selection list with eight selections is therefore still a single stop for `Tab`, not
+eight.
 
 Keyboard, handled on the list itself:
 

--- a/packages/frontile/src/components/collections/listbox/item.gts
+++ b/packages/frontile/src/components/collections/listbox/item.gts
@@ -101,11 +101,14 @@ class ListboxItem extends Component<ListboxItemSignature> {
     }
   }
 
+  /**
+   * A roving tabindex: the manager nominates one option as the composite's tab
+   * stop and every other option stays out of the tab order, as the ARIA
+   * listbox pattern requires. Giving a `0` to each active *or selected* option
+   * turned a multi-select with eight selections into eight tab stops.
+   */
   get tabindex() {
-    if (this.listItem?.isActive || this.listItem?.isSelected) {
-      return 0;
-    }
-    return -1;
+    return this.manager.isTabStop(this.key) ? 0 : -1;
   }
 
   get classNames() {

--- a/packages/frontile/src/components/collections/listbox/listbox.gts
+++ b/packages/frontile/src/components/collections/listbox/listbox.gts
@@ -40,7 +40,7 @@ interface ListboxSignature<T> {
     elementToAddKeyboardEvents?: HTMLElement;
 
     /**
-     * @edefaultValue 'frist'
+     * @defaultValue 'first'
      */
     autoActivateMode?: 'none' | 'first' | 'selected';
 
@@ -106,7 +106,7 @@ class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
       }
     } else {
       if (
-        ['Enter', ' ', 'Space'].includes(event.key) &&
+        ['Enter', ' '].includes(event.key) &&
         this.listManager.searchKeys == ''
       ) {
         this.listManager.selectActiveItem();
@@ -213,11 +213,17 @@ class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
       tabindex="0"
       role={{this.role}}
       aria-multiselectable={{this.ariaMultiselectable}}
+      {{! The callbacks travel through setup, not only through the manager's
+      field initializer above: that initializer runs once, so an onAction
+      rebuilt on a later render would otherwise never reach the manager. }}
       {{this.listManager.setup
         selectedKeys=@selectedKeys
         disabledKeys=@disabledKeys
         selectionMode=@selectionMode
         allowEmpty=@allowEmpty
+        onAction=@onAction
+        onSelectionChange=@onSelectionChange
+        onActiveItemChange=@onActiveItemChange
         autoActivateMode=(if
           (isUndefined @autoActivateMode) "first" @autoActivateMode
         )

--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -1,8 +1,8 @@
 /* eslint-disable ember/no-runloop */
 import { tracked } from '@glimmer/tracking';
-import { debounce } from '@ember/runloop';
+import { cancel, debounce, later } from '@ember/runloop';
 import { modifier } from 'ember-modifier';
-import { later } from '@ember/runloop';
+import type { Timer } from '@ember/runloop';
 import { getElementById } from '../-private/dom';
 
 type SelectionMode = 'none' | 'single' | 'multiple';
@@ -101,9 +101,21 @@ class ListItem {
     }
   }
 
-  /** `isActive` read without consuming its tag, for write decisions. */
+  /**
+   * The three flags read without consuming their tags, for write decisions and
+   * for `ListManager`'s tab-stop bookkeeping -- which has to look at every
+   * sibling and must not drag every sibling's tag into the frame that does so.
+   */
   get isActiveUntracked(): boolean {
     return this.isActiveMirror;
+  }
+
+  get isSelectedUntracked(): boolean {
+    return this.isSelectedMirror;
+  }
+
+  get isDisabledUntracked(): boolean {
+    return this.isDisabledMirror;
   }
 
   constructor(
@@ -134,6 +146,59 @@ interface ListManagerArgs {
 
 class ListManager {
   #items: ListItem[] = [];
+
+  /**
+   * The one pending "the list changed" task, and what the batch behind it did.
+   *
+   * Registration is per item, but everything that follows it -- ordering the
+   * list against the document, telling the consumer what the list now holds,
+   * and moving the active item -- belongs to the *batch*. Doing it per
+   * registration made a 500-option Select order 500 nodes 500 times over and
+   * queue 500 timers, each ordering them again, none of them cancelled. One
+   * timer, replaced whenever another item registers or unregisters, does the
+   * work once against the finished DOM.
+   *
+   * Deferring is not only cheaper, it is more accurate: mid-batch the document
+   * still holds the elements Glimmer is about to tear down, so the orders
+   * computed then were partly garbage (see `#orderedItems`).
+   */
+  #pendingTimer?: Timer;
+  #pendingAdd = false;
+  #pendingRemove = false;
+  #pendingAction?: 'add' | 'remove';
+
+  /**
+   * Whether the `setup` modifier has been torn down without being re-installed.
+   *
+   * Destructors normally run children first, so every item has unregistered by
+   * the time `setup` tears down and cancelling there is enough. This flag
+   * covers the other order: once `setup` has gone, a late unregister records
+   * what it did but queues nothing, so no flush can fire against a tree that
+   * no longer exists. `setup` clears it, which is what makes a re-run -- where
+   * the destructor runs purely as a prelude to the body -- harmless.
+   */
+  #isTornDown = false;
+
+  /**
+   * The item that owns the composite's tab stop, by key.
+   *
+   * The ARIA listbox pattern allows exactly one tabbable option: the options
+   * are stepped *into* once and then navigated with the arrow keys. Every
+   * selected option carrying `tabindex="0"` turned an eight-selection
+   * multi-select into eight tab stops. The active item owns the stop, falling
+   * back to the first selection, then to the first option a user can act on --
+   * so a list nobody has touched yet is still reachable by Tab.
+   *
+   * Held as one tracked value rather than derived inside each option's getter:
+   * a getter that had to look at every sibling would consume every sibling's
+   * `isActive` tag, and the writes this class makes while Glimmer renders
+   * would then dirty tags the same frame had just consumed. `#refreshTabStop`
+   * reads the plain mirrors for the same reason, and this field is written
+   * through a mirror guard of its own -- see `ListItem` above for the whole
+   * story.
+   */
+  @tracked private _tabStopKey?: string;
+  private tabStopKeyMirror?: string;
 
   searchKeys: string = '';
   args: ListManagerArgs = {
@@ -176,24 +241,40 @@ class ListManager {
     return this.#items.some((item) => item.el.isConnected);
   }
 
-  /**
-   * The registered item that comes first in the document, found in a single
-   * pass so callers that need only one item do not pay to order the whole
-   * list.
-   */
-  get #firstVisibleItem(): ListItem | undefined {
-    let first: ListItem | undefined;
-    for (const item of this.#items) {
-      if (!item.el.isConnected) continue;
-      if (
-        !first ||
-        item.el.compareDocumentPosition(first.el) &
-          Node.DOCUMENT_POSITION_FOLLOWING
-      ) {
-        first = item;
-      }
+  /** Whether `key` is the single option that carries `tabindex="0"`. */
+  isTabStop(key: string): boolean {
+    return this._tabStopKey === key;
+  }
+
+  private set tabStopKey(value: string | undefined) {
+    if (this.tabStopKeyMirror !== value) {
+      this.tabStopKeyMirror = value;
+      this._tabStopKey = value;
     }
-    return first;
+  }
+
+  /**
+   * Work out which option owns the tab stop, reading only the untracked
+   * mirrors so nothing is consumed on a path that can run mid-render.
+   *
+   * Only called from places where the answer can actually have changed and
+   * where the DOM is worth ordering once: an activation, a selection update,
+   * and the batch flush. Notably *not* from `unregister` -- see there.
+   */
+  #refreshTabStop(): void {
+    let active: ListItem | undefined;
+    let selected: ListItem | undefined;
+    let first: ListItem | undefined;
+
+    for (const item of this.#orderedItems) {
+      if (item.isDisabledUntracked) continue;
+      if (!first) first = item;
+      if (!selected && item.isSelectedUntracked) selected = item;
+      if (!active && item.isActiveUntracked) active = item;
+      if (active) break;
+    }
+
+    this.tabStopKey = (active || selected || first)?.key;
   }
 
   register(
@@ -211,37 +292,109 @@ class ListManager {
     }
     this.#items.push(newItem);
 
-    if (typeof this.args.onListItemsChange === 'function') {
-      this.args.onListItemsChange(this.#orderedItems, 'add');
+    // A first, cheap guess at the tab stop, so a freshly rendered list has a
+    // tabbable option before the batch flush gets to work out the real answer.
+    // Deliberately no `#refreshTabStop()` here: that orders the document, and
+    // ordering it once per registration is the cost this batching removes.
+    if (typeof this.tabStopKeyMirror === 'undefined' && !args.isDisabled) {
+      this.tabStopKey = newItem.key;
     }
 
-    if (this.args.autoActivateMode != 'none' && this.#items.length > 1) {
-      later(() => {
-        if (this.args.autoActivateMode == 'first') {
-          this.setFirstOptionActive();
-        } else {
-          this.setSelectedOptionActive();
-        }
-      }, 1);
-    }
+    this.#scheduleListChange('add');
   }
 
   unregister(el: HTMLLIElement | HTMLOptionElement): void {
     this.#items = this.#items.filter((item) => item.el !== el);
 
-    if (this.args.autoActivateMode == 'first') {
-      // Deferred for the same reason as the activation in `register`: unregister
-      // runs while Glimmer tears down the elements it is replacing, which is the
-      // same render pass in which item templates have already consumed
-      // `isActive`. Activating synchronously here would write to that tracked
-      // state after it was read, tripping a backtracking-rerender assertion.
-      later(() => {
-        this.activateItem(this.#firstVisibleItem);
-      }, 1);
+    // The tab stop is left pointing at the item that just went, and the flush
+    // below corrects it a tick later. Clearing it here would write tracked
+    // state while Glimmer tears down the elements it is replacing -- the same
+    // render pass in which the surviving options have already read it for
+    // their `tabindex` -- which is exactly the backtracking-rerender hazard
+    // `ListItem` documents. For the tick in between, no option is tabbable;
+    // the alternative is an assertion.
+
+    this.#scheduleListChange('remove');
+  }
+
+  /**
+   * Note what the batch did and make sure exactly one flush is queued for it.
+   *
+   * Always queued, even with no `onListItemsChange` and no auto-activation:
+   * the tab stop has to be re-derived after any change to the membership, and
+   * the flush is the only place the document is ordered once per batch rather
+   * than once per item.
+   */
+  #scheduleListChange(action: 'add' | 'remove'): void {
+    if (action === 'add') {
+      this.#pendingAdd = true;
+    } else {
+      this.#pendingRemove = true;
+    }
+    this.#pendingAction = action;
+
+    if (this.#isTornDown) {
+      return;
     }
 
-    if (typeof this.args.onListItemsChange === 'function') {
-      this.args.onListItemsChange(this.#orderedItems, 'remove');
+    cancel(this.#pendingTimer);
+    this.#pendingTimer = later(this, this.#flushListChange, 1);
+  }
+
+  #flushListChange(): void {
+    this.#pendingTimer = undefined;
+
+    const added = this.#pendingAdd;
+    const removed = this.#pendingRemove;
+    const action = this.#pendingAction;
+    this.#pendingAdd = false;
+    this.#pendingRemove = false;
+    this.#pendingAction = undefined;
+
+    if (action && typeof this.args.onListItemsChange === 'function') {
+      this.args.onListItemsChange(this.#orderedItems, action);
+    }
+
+    if (this.args.autoActivateMode === 'none' || !this.#hasVisibleItems) {
+      this.#refreshTabStop();
+      return;
+    }
+
+    if (added) {
+      if (this.args.autoActivateMode === 'first') {
+        this.setFirstOptionActive();
+      } else {
+        this.setSelectedOptionActive();
+      }
+    } else if (removed && this.args.autoActivateMode === 'first') {
+      // The active item may have been the one that went.
+      this.setFirstOptionActive();
+    }
+
+    this.#refreshTabStop();
+  }
+
+  /**
+   * Drop whatever the current batch had queued.
+   *
+   * `ListManager` is a plain class, so the only teardown it can hook is the
+   * destructor of the `setup` modifier that installed it -- which is where
+   * this is called from. That destructor also runs when `setup`'s arguments
+   * change, so `setup` re-queues a flush that was still pending; only a real
+   * teardown never reaches the body again, and there the timer stays cancelled.
+   */
+  teardown(): void {
+    cancel(this.#pendingTimer);
+    this.#pendingTimer = undefined;
+    this.#isTornDown = true;
+  }
+
+  /** Re-queue a batch that `teardown` cancelled but that has not run yet. */
+  #resumePendingListChange(): void {
+    this.#isTornDown = false;
+
+    if (this.#pendingAction && !this.#pendingTimer) {
+      this.#pendingTimer = later(this, this.#flushListChange, 1);
     }
   }
 
@@ -269,21 +422,38 @@ class ListManager {
       this.args.selectionMode = args.selectionMode;
     }
 
-    if (args.onAction) {
+    // Callbacks are replaced whenever the caller *mentions* them, rather than
+    // whenever it passes a truthy one.
+    //
+    // A manager is built once, in a component's field initializer, and only
+    // `setup` runs again when arguments change -- so a callback that `setup`
+    // does not carry can never be refreshed, and a `Listbox` whose `@onAction`
+    // is rebuilt each render (`{{fn this.pick group.id}}` inside an
+    // `{{#each}}`) went on calling the closure from its first render forever.
+    //
+    // The key has to decide it, not the value: `setup` names every callback it
+    // owns, passing undefined when the consumer gave none, and that undefined
+    // must win. A caller that owns only some of them -- NativeSelect hands its
+    // own `onSelectionChange` to the constructor and only `onListItemsChange`
+    // to `setup` -- leaves the rest unmentioned, and those keep what they have.
+    if ('onAction' in args) {
       this.args.onAction = args.onAction;
     }
 
-    if (args.onSelectionChange) {
+    if ('onSelectionChange' in args) {
       this.args.onSelectionChange = args.onSelectionChange;
     }
 
-    if (args.onListItemsChange) {
+    if ('onListItemsChange' in args) {
       this.args.onListItemsChange = args.onListItemsChange;
     }
 
-    if (args.onActiveItemChange) {
+    if ('onActiveItemChange' in args) {
       this.args.onActiveItemChange = args.onActiveItemChange;
     }
+
+    // The selection this just wrote onto the items may have moved the tab stop.
+    this.#refreshTabStop();
   }
 
   selectActiveItem(): void {
@@ -318,11 +488,16 @@ class ListManager {
     if (item && !item.isActiveUntracked) {
       this.#clearActive();
       item.isActive = true;
+      this.#refreshTabStop();
       this.args.onActiveItemChange?.(item.key, item);
 
       // Ensure the item is scrolled into view
       requestAnimationFrame(() => {
-        item.el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        // The list may have been torn down between the write above and the
+        // frame; scrolling a detached element to nowhere is pointless.
+        if (item.el.isConnected) {
+          item.el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        }
       });
     }
   }
@@ -390,7 +565,7 @@ class ListManager {
   }
 
   search(key: string): void {
-    debounce(this, this.#clearSeaerch, 500);
+    debounce(this, this.#clearSearch, 500);
     this.searchKeys += key.toLowerCase();
 
     const items = this.#orderedItems;
@@ -491,7 +666,7 @@ class ListManager {
     return this.#orderedItems.find((item) => item.isActive);
   }
 
-  #clearSeaerch(): void {
+  #clearSearch(): void {
     this.searchKeys = '';
   }
 
@@ -510,13 +685,16 @@ class ListManager {
       _: unknown[],
       args: ListManagerArgs
     ) => {
-      this.updateArgs({
-        selectionMode: args.selectionMode,
-        disabledKeys: args.disabledKeys,
-        selectedKeys: args.selectedKeys,
-        allowEmpty: args.allowEmpty,
-        autoActivateMode: args.autoActivateMode
-      });
+      this.updateArgs(args);
+
+      // This modifier's destructor also runs before every re-invocation, so a
+      // flush it cancelled while the list was still very much alive has to be
+      // put back. Only a real teardown never reaches this line again.
+      this.#resumePendingListChange();
+
+      return (): void => {
+        this.teardown();
+      };
     }
   );
 

--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -260,8 +260,23 @@ class ListManager {
    * Only called from places where the answer can actually have changed and
    * where the DOM is worth ordering once: an activation, a selection update,
    * and the batch flush. Notably *not* from `unregister` -- see there.
+   *
+   * Pass `activated` when the caller already knows which item just became
+   * active: the answer is then that item, with no need to order the document
+   * at all. `setNextOptionActive` and friends have already paid for one
+   * ordered scan to find it, and a second one would put the per-keypress cost
+   * of `compareDocumentPosition` over the whole list -- the very cost this
+   * batching removes from render -- straight back into arrow navigation.
    */
-  #refreshTabStop(): void {
+  #refreshTabStop(activated?: ListItem): void {
+    // The scan below settles on the active item whenever there is one, so a
+    // just-activated item *is* the answer -- unless it is disabled, which the
+    // scan skips, in which case fall through and work it out properly.
+    if (activated && !activated.isDisabledUntracked) {
+      this.tabStopKey = activated.key;
+      return;
+    }
+
     let active: ListItem | undefined;
     let selected: ListItem | undefined;
     let first: ListItem | undefined;
@@ -488,7 +503,10 @@ class ListManager {
     if (item && !item.isActiveUntracked) {
       this.#clearActive();
       item.isActive = true;
-      this.#refreshTabStop();
+      // The tab stop is this item, by definition -- named directly rather
+      // than re-derived, so an arrow keypress orders the list only the once
+      // its caller already did. See `#refreshTabStop`.
+      this.#refreshTabStop(item);
       this.args.onActiveItemChange?.(item.key, item);
 
       // Ensure the item is scrolled into view

--- a/packages/frontile/src/utils/listManager.ts
+++ b/packages/frontile/src/utils/listManager.ts
@@ -513,6 +513,13 @@ class ListManager {
       requestAnimationFrame(() => {
         // The list may have been torn down between the write above and the
         // frame; scrolling a detached element to nowhere is pointless.
+        //
+        // This guard is not part of the batching fix and nothing reported it:
+        // it is a latent bug this work made easy to see, because deferring
+        // the batch widened the window in which a list can be torn down
+        // between an activation and its frame. Kept here rather than left for
+        // later, since it is two lines and the alternative is a stray
+        // `scrollIntoView` on a detached node.
         if (item.el.isConnected) {
           item.el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
         }

--- a/test-app/tests/integration/components/collections/listbox-test.gts
+++ b/test-app/tests/integration/components/collections/listbox-test.gts
@@ -5,7 +5,7 @@ import { registerCustomStyles } from '@frontile/theme';
 import { tv } from 'tailwind-variants';
 import { modifier } from 'ember-modifier';
 import { Listbox, type ListboxSignature } from 'frontile';
-import { array } from '@ember/helper';
+import { array, get } from '@ember/helper';
 import { cell } from 'ember-resources';
 import { settled } from '@ember/test-helpers';
 
@@ -1044,6 +1044,257 @@ module(
           selectedKeys.current,
           ['elephant'],
           'single selection still replaces, it does not accumulate'
+        );
+      });
+    });
+    /**
+     * `Listbox` builds its `ListManager` in a field initializer, so every
+     * callback it hands over is captured once, at construction. The `setup`
+     * modifier is the only thing that runs again when arguments change, so
+     * unless the callbacks travel through it too, a `Listbox` whose
+     * `@onAction` is rebuilt each render -- `{{fn this.pick group.id}}` inside
+     * an `{{#each}}`, the shape that makes this visible -- keeps calling the
+     * closure from the very first render, with the very first `group.id`.
+     */
+    module('callbacks replaced between renders', function () {
+      test('a replaced @onAction is the one invoked', async function (assert) {
+        const calls: string[] = [];
+        const handlers = {
+          first: (key: string) => calls.push(`first:${key}`),
+          second: (key: string) => calls.push(`second:${key}`)
+        };
+        const which = cell<'first' | 'second'>('first');
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="none"
+              @autoActivateMode="none"
+              @items={{array "cheetah"}}
+              @onAction={{get handlers which.current}}
+            />
+          </template>
+        );
+
+        await click('[data-key="cheetah"]');
+        assert.deepEqual(calls, ['first:cheetah'], 'the first closure ran');
+
+        which.current = 'second';
+        await settled();
+
+        await click('[data-key="cheetah"]');
+        assert.deepEqual(
+          calls,
+          ['first:cheetah', 'second:cheetah'],
+          'the replacement closure ran, not the captured original'
+        );
+      });
+
+      test('a replaced @onSelectionChange is the one invoked', async function (assert) {
+        const calls: string[] = [];
+        const handlers = {
+          first: (keys: string[]) => calls.push(`first:${keys.join()}`),
+          second: (keys: string[]) => calls.push(`second:${keys.join()}`)
+        };
+        const which = cell<'first' | 'second'>('first');
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="multiple"
+              @autoActivateMode="none"
+              @items={{array "cheetah"}}
+              @onSelectionChange={{get handlers which.current}}
+            />
+          </template>
+        );
+
+        await click('[data-key="cheetah"]');
+        assert.deepEqual(calls, ['first:cheetah'], 'the first closure ran');
+
+        which.current = 'second';
+        await settled();
+
+        await click('[data-key="cheetah"]');
+        assert.deepEqual(
+          calls,
+          ['first:cheetah', 'second:cheetah'],
+          'the replacement closure ran, not the captured original'
+        );
+      });
+
+      test('a replaced @onActiveItemChange is the one invoked', async function (assert) {
+        const calls: string[] = [];
+        const handlers = {
+          first: (key?: string) => calls.push(`first:${key}`),
+          second: (key?: string) => calls.push(`second:${key}`)
+        };
+        const which = cell<'first' | 'second'>('first');
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="none"
+              @autoActivateMode="none"
+              @isKeyboardEventsEnabled={{true}}
+              @items={{array "cheetah" "crocodile"}}
+              @onActiveItemChange={{get handlers which.current}}
+            />
+          </template>
+        );
+
+        await triggerKeyEvent(
+          '[data-test-id="listbox"]',
+          'keydown',
+          'ArrowDown'
+        );
+        assert.deepEqual(calls, ['first:cheetah'], 'the first closure ran');
+
+        which.current = 'second';
+        await settled();
+
+        await triggerKeyEvent(
+          '[data-test-id="listbox"]',
+          'keydown',
+          'ArrowDown'
+        );
+        assert.deepEqual(
+          calls,
+          ['first:cheetah', 'second:crocodile'],
+          'the replacement closure ran, not the captured original'
+        );
+      });
+    });
+
+    /**
+     * The WAI-ARIA listbox pattern allows exactly one tabbable option: the
+     * options form a composite the user steps *into* once and then navigates
+     * with the arrow keys. Handing `tabindex="0"` to every selected option
+     * turned an eight-selection multi-select into eight tab stops.
+     */
+    module('roving tabindex', function () {
+      const tabbableKeys = () =>
+        [
+          ...document.querySelectorAll(
+            '[data-component="listbox-item"][tabindex="0"]'
+          )
+        ].map((el) => (el as HTMLElement).dataset['key']);
+
+      test('several selected options still make a single tab stop', async function (assert) {
+        const animals = ['cheetah', 'crocodile', 'elephant', 'flamingo'];
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="multiple"
+              @autoActivateMode="none"
+              @items={{animals}}
+              @selectedKeys={{array "crocodile" "elephant" "flamingo"}}
+            />
+          </template>
+        );
+
+        assert
+          .dom('[data-key="crocodile"]')
+          .hasAttribute('data-selected', 'true');
+        assert
+          .dom('[data-key="elephant"]')
+          .hasAttribute('data-selected', 'true');
+        assert
+          .dom('[data-key="flamingo"]')
+          .hasAttribute('data-selected', 'true');
+
+        assert.deepEqual(
+          tabbableKeys(),
+          ['crocodile'],
+          'only the first selected option is tabbable'
+        );
+      });
+
+      test('the tab stop follows the active option', async function (assert) {
+        const animals = ['cheetah', 'crocodile', 'elephant'];
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="multiple"
+              @autoActivateMode="none"
+              @isKeyboardEventsEnabled={{true}}
+              @items={{animals}}
+              @selectedKeys={{array "crocodile"}}
+            />
+          </template>
+        );
+
+        assert.deepEqual(
+          tabbableKeys(),
+          ['crocodile'],
+          'the selection owns the tab stop while nothing is active, ahead of the first option'
+        );
+
+        // Navigation starts from the selection when nothing is active yet, so
+        // this steps onto the option after it.
+        await triggerKeyEvent(
+          '[data-test-id="listbox"]',
+          'keydown',
+          'ArrowDown'
+        );
+        assert.dom('[data-key="elephant"]').hasAttribute('data-active', 'true');
+        assert.deepEqual(
+          tabbableKeys(),
+          ['elephant'],
+          'the active option takes the tab stop over from the selection'
+        );
+
+        await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'ArrowUp');
+        assert
+          .dom('[data-key="crocodile"]')
+          .hasAttribute('data-active', 'true');
+        assert.deepEqual(
+          tabbableKeys(),
+          ['crocodile'],
+          'the tab stop moves with the active option'
+        );
+      });
+
+      test('the first option owns the tab stop when nothing is active or selected', async function (assert) {
+        const animals = ['cheetah', 'crocodile', 'elephant'];
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="none"
+              @autoActivateMode="none"
+              @items={{animals}}
+            />
+          </template>
+        );
+
+        assert.deepEqual(
+          tabbableKeys(),
+          ['cheetah'],
+          'a list nobody has touched yet is still reachable by Tab'
+        );
+      });
+
+      test('a disabled option is skipped by the tab stop fallback', async function (assert) {
+        const animals = ['cheetah', 'crocodile', 'elephant'];
+
+        await render(
+          <template>
+            <Listbox
+              @selectionMode="none"
+              @autoActivateMode="none"
+              @disabledKeys={{array "cheetah"}}
+              @items={{animals}}
+            />
+          </template>
+        );
+
+        assert.deepEqual(
+          tabbableKeys(),
+          ['crocodile'],
+          'the tab stop lands on the first option a user can actually act on'
         );
       });
     });

--- a/test-app/tests/unit/collections/list-manager-test.ts
+++ b/test-app/tests/unit/collections/list-manager-test.ts
@@ -1,5 +1,8 @@
 import { module, test } from 'qunit';
 import { ListManager, canDeselectKey } from 'frontile/utils/listManager';
+// eslint-disable-next-line ember/no-runloop
+import { run } from '@ember/runloop';
+import { settled, getSettledState } from '@ember/test-helpers';
 
 module('Unit | Utils | ListManager', function (hooks) {
   let container: HTMLUListElement;
@@ -260,6 +263,143 @@ module('Unit | Utils | ListManager', function (hooks) {
         ['filtered-out'],
         'a selection hidden by a filter still counts as a second selection, so `a` goes'
       );
+    });
+  });
+  /**
+   * Registration is per item, but the work that follows it -- ordering the
+   * list against the document and telling the consumer what the list now
+   * holds -- is per *batch*. Doing it once per registration made a 500-option
+   * Select order 500 nodes 500 times over and queue 500 timers, each ordering
+   * them again, none of them cancelled.
+   */
+  module('coalescing the work a batch of registrations causes', function () {
+    type Report = { count: number; action: string; keys: string[] };
+
+    const buildReporting = (
+      autoActivateMode: 'none' | 'first' | 'selected'
+    ): { manager: ListManager; reports: Report[] } => {
+      const reports: Report[] = [];
+      const manager = new ListManager({
+        selectionMode: 'single',
+        autoActivateMode,
+        onListItemsChange: (items, action): void => {
+          reports.push({
+            count: items.length,
+            action,
+            keys: items.map((item) => item.key)
+          });
+        }
+      });
+      return { manager, reports };
+    };
+
+    test('a batch of registrations reports the list once, in DOM order', async function (assert) {
+      const { manager, reports } = buildReporting('none');
+      const keys = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+
+      run(() => {
+        keys.forEach((key) => addItem(manager, key));
+      });
+      await settled();
+
+      assert.strictEqual(
+        reports.length,
+        1,
+        'eight registrations produced one report, not eight'
+      );
+      assert.deepEqual(reports[0]?.keys, keys, 'the report is in DOM order');
+      assert.strictEqual(reports[0]?.action, 'add');
+    });
+
+    test('a batch of unregistrations reports the remaining list once', async function (assert) {
+      const { manager, reports } = buildReporting('none');
+      const els = ['a', 'b', 'c', 'd'].map((key) => addItem(manager, key));
+      await settled();
+      reports.length = 0;
+
+      run(() => {
+        els.slice(0, 2).forEach((el) => {
+          el.remove();
+          manager.unregister(el);
+        });
+      });
+      await settled();
+
+      assert.strictEqual(reports.length, 1, 'one report for the whole batch');
+      assert.deepEqual(reports[0]?.keys, ['c', 'd']);
+      assert.strictEqual(reports[0]?.action, 'remove');
+    });
+
+    test('a batch that replaces the list reports it once', async function (assert) {
+      const { manager, reports } = buildReporting('none');
+      const oldEls = ['old-1', 'old-2'].map((key) => addItem(manager, key));
+      await settled();
+      reports.length = 0;
+
+      // The real shape of a Glimmer update: the new elements are inserted and
+      // their modifiers installed before the old ones are torn down.
+      run(() => {
+        oldEls.forEach((el) => el.remove());
+        ['new-1', 'new-2', 'new-3'].forEach((key) => addItem(manager, key));
+        oldEls.forEach((el) => manager.unregister(el));
+      });
+      await settled();
+
+      assert.strictEqual(reports.length, 1, 'one report for the whole batch');
+      assert.deepEqual(
+        reports[0]?.keys,
+        ['new-1', 'new-2', 'new-3'],
+        'and it holds only what is in the document once the batch has settled'
+      );
+    });
+
+    test('the deferred activation runs once for the whole batch', async function (assert) {
+      const activations: (string | undefined)[] = [];
+      const manager = new ListManager({
+        selectionMode: 'single',
+        autoActivateMode: 'first',
+        onActiveItemChange: (key): void => {
+          activations.push(key);
+        }
+      });
+
+      run(() => {
+        ['a', 'b', 'c', 'd'].forEach((key) => addItem(manager, key));
+      });
+      await settled();
+
+      assert.deepEqual(
+        activations,
+        ['a'],
+        'the first item was activated once, not once per registration'
+      );
+      assert.true(manager.atKey('a')?.isActive);
+    });
+
+    test('teardown drops the work a batch had queued', async function (assert) {
+      const { manager, reports } = buildReporting('first');
+
+      // `ListManager` is a plain class, so the only teardown hook it has is
+      // the destructor of the `setup` modifier that installed it. What that
+      // destructor calls is this.
+      run(() => {
+        ['a', 'b', 'c'].forEach((key) => addItem(manager, key));
+      });
+
+      assert.true(
+        getSettledState().hasPendingTimers,
+        'the batch queued work for after the render'
+      );
+
+      manager.teardown();
+
+      assert.false(
+        getSettledState().hasPendingTimers,
+        'teardown cancelled it rather than leaving it to fire against a torn-down tree'
+      );
+
+      await settled();
+      assert.deepEqual(reports, [], 'the cancelled work never ran');
     });
   });
 });

--- a/test-app/tests/unit/collections/list-manager-test.ts
+++ b/test-app/tests/unit/collections/list-manager-test.ts
@@ -402,4 +402,132 @@ module('Unit | Utils | ListManager', function (hooks) {
       assert.deepEqual(reports, [], 'the cancelled work never ran');
     });
   });
+
+  module('the cost of moving the active item', function () {
+    /**
+     * How many times `fn` ordered the list against the document.
+     *
+     * Ordering starts by filtering the registered items on
+     * `el.isConnected`, so one ordered scan reads `isConnected` exactly once
+     * per registered item -- an exact, engine-independent count, where the
+     * number of `compareDocumentPosition` calls a sort makes is not. Both are
+     * recorded; only the scan count is asserted on.
+     */
+    const measureOrderedScans = (
+      fn: () => void,
+      itemCount: number
+    ): { reads: number; comparisons: number; scans: number } => {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        Node.prototype,
+        'isConnected'
+      ) as PropertyDescriptor;
+      const readIsConnected = descriptor.get as () => boolean;
+      const compare = Element.prototype.compareDocumentPosition;
+      let reads = 0;
+      let comparisons = 0;
+
+      Object.defineProperty(Node.prototype, 'isConnected', {
+        ...descriptor,
+        get(this: Node): boolean {
+          reads++;
+          return readIsConnected.call(this);
+        }
+      });
+      Element.prototype.compareDocumentPosition = function (
+        this: Element,
+        other: Node
+      ): number {
+        comparisons++;
+        return compare.call(this, other);
+      };
+
+      try {
+        fn();
+      } finally {
+        Object.defineProperty(Node.prototype, 'isConnected', descriptor);
+        Element.prototype.compareDocumentPosition = compare;
+      }
+
+      return { reads, comparisons, scans: reads / itemCount };
+    };
+
+    // `activateItem` schedules a frame to scroll the new item into view, and
+    // that callback reads `isConnected` too. Draining it before measuring
+    // keeps it out of the count; a frame queued *during* the measured window
+    // cannot pollute it, because rAF never runs synchronously.
+    const nextFrame = (): Promise<void> =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    test('an arrow keypress orders the document once, not twice', async function (assert) {
+      const manager = buildManager();
+      const itemCount = 50;
+      for (let i = 0; i < itemCount; i++) {
+        addItem(manager, `item-${i}`);
+      }
+      await settled();
+
+      // Get to steady-state navigation, so the measured keypress is a plain
+      // move rather than the first activation.
+      manager.setFirstOptionActive();
+      await settled();
+      await nextFrame();
+
+      const { reads, comparisons, scans } = measureOrderedScans(() => {
+        manager.setNextOptionActive();
+      }, itemCount);
+
+      assert.strictEqual(
+        scans,
+        1,
+        `one keypress ordered the list once (${reads} isConnected reads over ` +
+          `${itemCount} items, ${comparisons} compareDocumentPosition calls); ` +
+          `deriving the tab stop from the item being activated is what keeps ` +
+          `this off a second ordered scan`
+      );
+      assert.true(
+        manager.atKey('item-1')?.isActive,
+        'and the active item still moved'
+      );
+      assert.true(
+        manager.isTabStop('item-1'),
+        'and the tab stop still followed it'
+      );
+
+      await settled();
+      await nextFrame();
+    });
+
+    test('the tab stop still falls back to an ordered scan with nothing active', async function (assert) {
+      const manager = buildManager();
+      const itemCount = 20;
+      for (let i = 0; i < itemCount; i++) {
+        addItem(manager, `item-${i}`);
+      }
+      await settled();
+
+      // No active item, so the shortcut cannot apply and the ordered scan is
+      // genuinely needed to find the first option a user can act on.
+      assert.true(
+        manager.isTabStop('item-0'),
+        'the first option owns the stop while nothing is active'
+      );
+
+      const { scans } = measureOrderedScans(() => {
+        manager.updateArgs({ selectedKeys: ['item-3'] });
+      }, itemCount);
+
+      assert.strictEqual(
+        scans,
+        1,
+        'the fallback path still orders the list, once'
+      );
+      assert.true(
+        manager.isTabStop('item-3'),
+        'and the stop moved to the selection'
+      );
+
+      await settled();
+      await nextFrame();
+    });
+  });
 });


### PR DESCRIPTION
## Problems

**1. Quadratic work and uncancelled timers on every list render.** `ListManager.register` ran once per item and each time:
- called `onListItemsChange(this.#orderedItems, 'add')`, where `#orderedItems` is an uncached getter that filters and `sort()`s every registered item via `compareDocumentPosition`;
- scheduled a `later(…, 1)` that activated the first/selected option, sorting again.

None were cancelled, and `unregister` scheduled another. A `Select` with 500 options performed ~500 sorts of 500 DOM nodes during render, then queued ~500 timers each sorting again — visible jank, and every timer had to drain before `settled()` resolved in consumers' test suites.

**2. Callbacks were captured once and went stale.** `Listbox` constructed `new ListManager({...})` reading `onSelectionChange`/`onAction`/`onActiveItemChange` in a field initializer, and the `setup` modifier never passed them, so `updateArgs` could not replace them. `<Listbox @onAction={{fn this.pick group.id}}>` inside an `{{#each}}` kept calling the **original** closure with the **original** `group.id` forever. Frontile's own callers pass stable arrows, which is why nothing internal caught it.

**3. Multiple tab stops inside the listbox.** `item.gts` returned `tabindex="0"` for every item that was active **or selected**, so a multi-select with 8 selections was 8 tab stops.

Plus small dead/misspelled things in the same files: the `['Enter',' ','Space']` branch (`'Space'` is an `event.code` value and can never match `event.key`), `@edefaultValue 'frist'`, and the private `#clearSeaerch`.

## Fixes

Registration work is **coalesced into one cancellable flush per batch**: one `onListItemsChange` call and one deferred activation per batch instead of N of each. The sort now runs once per batch (O(n log n)) rather than once per registration (O(n² log n)), and it runs after the render against the settled DOM, where the answer is also more accurate.

Callbacks are threaded through the `setup` modifier so `updateArgs` replaces them. Tab stop is a single tracked decision on the manager, which `item.gts` consults.

### `#orderedItems` was deliberately *not* memoized

The suggestion to memoize per render pass was investigated and rejected. The file's own comments explain why: Glimmer **moves** the element of a persisting item with no registration to invalidate a cache, and does so *inside the same synchronous render pass* in which new items register. Any cache keyed on registration or on a render pass can be read after a move that didn't invalidate it — precisely the stale-order bug those comments warn about, and there is no cheap key that tracks DOM moves. Coalescing removed the *need* to recompute instead.

### Teardown

`ListManager` is a plain class, so the hook is the `setup` modifier's destructor calling a new `teardown()`. Two complications handled: a function modifier's destructor also runs *before every re-invocation*, so `teardown()` only cancels the timer and leaves the pending flags, with the `setup` body re-queueing a still-pending flush; and an `#isTornDown` flag covers the reverse destructor order, so a late `unregister` records what it did but queues nothing.

### Roving tabindex vs. the render-timing hazard

This file has a documented history of backtracking-rerender assertions (writing `tabindex` onto the focused item blurs it and dispatches `focusout` synchronously inside the frame that just consumed `isActive`). The change was structured to avoid the hazard rather than tested into safety:

- The decision is **one tracked field on the manager**, not a per-item getter scanning siblings — a scanning getter would consume every item's `isActive` tag, so any mid-render write would dirty tags the frame had just consumed.
- The refresh reads only untracked mirrors (`isSelectedUntracked`/`isDisabledUntracked` added alongside the existing `isActiveUntracked`), consuming nothing.
- The field is written through the same mirror guard as `ListItem`'s fields, so a no-op write never dirties a tag.
- `unregister` deliberately does **not** clear the tab stop; that write would land while Glimmer tears down elements whose surviving siblings have already read it for `tabindex`. The flush corrects it a tick later, during which no option is tabbable — chosen over an assertion, and commented in place.

Both render-safety scenarios pass unchanged; that file needed no modification.

## Tests

12 added; 11 confirmed failing first.

- a replaced `@onAction`/`@onSelectionChange`/`@onActiveItemChange` is the one invoked (Bug 2)
- several selected options still make a single tab stop; the tab stop follows the active option; the first option owns it when nothing is active or selected; a disabled option is skipped by the fallback (Bug 3)
- a batch of registrations reports the list once, in DOM order (was 8 calls); a batch of unregistrations reports once (was 2); a batch that replaces the list reports once (was 5) (Bug 1's observable)
- `teardown` drops the work a batch had queued — asserts `getSettledState().hasPendingTimers` true after a batch, false after `teardown()`

**Honest caveat:** `the deferred activation runs once for the whole batch` **passed before the fix too.** Activation count is not observable — the redundant timers all activated the same item and `activateItem` no-ops when already active. It is kept as a regression guard, not offered as proof.

Full suite: **909 tests, 906 pass, 3 skip, 0 fail** (897 baseline + 12 new). Filters: listbox 28/28, ListManager 14/14, select 153 (1 pre-existing skip), autocomplete 28/28, dropdown 15/15. `lint:types` clean; `lint:js` and `lint:hbs` byte-identical to a stashed baseline. No pre-existing test modified or deleted.

## For a reviewer to scrutinize

- **`onListItemsChange` timing changed** from synchronous-during-`register` to one deferred call per batch, and a batch that both adds and removes reports the *last* action once rather than one call per mutation. No caller reads the action, and all consumer tests pass, but it is an observable API change. Worth an eye on whether a `Select` with a preselected value can now show its placeholder for an extra tick before the label resolves.
- **`'onAction' in args`** relies on Glimmer's captured named-args dict containing keys written literally in the template even when the value is `undefined`. It works, but it is the load-bearing assumption of the Bug 2 fix.
- `setup` now forwards its whole named-args object to `updateArgs` instead of a hand-picked subset.
- **Two behavior unifications beyond the stated bugs:** the removal path now uses `setFirstOptionActive()` (skips disabled) where it used `activateItem(#firstVisibleItem)` (did not), and the `#items.length > 1` guard was dropped, so a one-item list in `autoActivateMode="selected"` is now auto-activated where it previously was not.

## Not claimed

**"Exactly one tabbable element in the composite" is *not* achieved.** `<ul tabindex="0">` was left in place: `Dropdown`/`Select`/`Autocomplete` render the listbox inside a focus trap with no `fallbackFocus`, and an empty menu with no tabbable node makes `focus-trap` throw. Tab therefore sees two stops (container + one option), down from 1 + N. The roving invariant is now in place, making the container a one-line follow-up once focus-trap fallback focus is sorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
