### PR TITLE
fix(forms): render group description after the label

### DIFF
--- a/packages/frontile/src/components/forms/checkbox-group.gts
+++ b/packages/frontile/src/components/forms/checkbox-group.gts
@@ -66,7 +66,6 @@ class CheckboxGroup extends Component<CheckboxGroupSignature> {
     <FormControl
       @size={{@size}}
       @isRequired={{@isRequired}}
-      @description={{@description}}
       @errors={{@errors}}
       @isInvalid={{@isInvalid}}
       @class={{this.classes.base class=@classes.base}}
@@ -76,6 +75,11 @@ class CheckboxGroup extends Component<CheckboxGroupSignature> {
       <c.Label @class={{this.classes.label class=@classes.label}}>
         {{@label}}
       </c.Label>
+
+      {{#if @description}}
+        <c.Description>{{@description}}</c.Description>
+      {{/if}}
+
       <div
         class={{this.classes.optionsContainer class=@classes.optionsContainer}}
         data-orientation={{if @orientation @orientation "vertical"}}

--- a/packages/frontile/src/components/forms/radio-group.gts
+++ b/packages/frontile/src/components/forms/radio-group.gts
@@ -71,7 +71,6 @@ class RadioGroup<T extends string | number | boolean> extends Component<
     <FormControl
       @size={{@size}}
       @isRequired={{@isRequired}}
-      @description={{@description}}
       @errors={{@errors}}
       @isInvalid={{@isInvalid}}
       @class={{this.classes.base class=@classes.base}}
@@ -81,6 +80,11 @@ class RadioGroup<T extends string | number | boolean> extends Component<
       <c.Label @class={{this.classes.label class=@classes.label}}>
         {{@label}}
       </c.Label>
+
+      {{#if @description}}
+        <c.Description>{{@description}}</c.Description>
+      {{/if}}
+
       <div
         class={{this.classes.optionsContainer class=@classes.optionsContainer}}
         data-orientation={{if @orientation @orientation "vertical"}}

--- a/test-app/tests/integration/components/forms/checkbox-group-test.gts
+++ b/test-app/tests/integration/components/forms/checkbox-group-test.gts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { find, render, settled } from '@ember/test-helpers';
 
 import { CheckboxGroup, type CheckboxGroupSignature } from 'frontile';
 import { cell } from 'ember-resources';
@@ -83,6 +83,37 @@ module(
       assert.dom('.my-base-class').exists();
       assert.dom('.my-options-container').exists();
       assert.dom('.my-label-class').exists();
+    });
+
+    test('it renders the description after the label', async function (assert) {
+      await render(
+        <template>
+          <CheckboxGroup
+            @label="Interests"
+            @description="Choose all that apply"
+            as |Checkbox|
+          >
+            <Checkbox @name="music" @label="Music" />
+          </CheckboxGroup>
+        </template>
+      );
+
+      assert
+        .dom('[data-component="form-description"]')
+        .hasText('Choose all that apply');
+
+      const label = find('[data-component="label"]') as HTMLElement;
+      const description = find(
+        '[data-component="form-description"]'
+      ) as HTMLElement;
+
+      assert.true(
+        !!(
+          label.compareDocumentPosition(description) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+        ),
+        'description is rendered after the label'
+      );
     });
   }
 );

--- a/test-app/tests/integration/components/forms/radio-group-test.gts
+++ b/test-app/tests/integration/components/forms/radio-group-test.gts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, click } from '@ember/test-helpers';
+import { find, render, settled, click } from '@ember/test-helpers';
 
 import { RadioGroup, type RadioGroupSignature } from 'frontile';
 import { cell } from 'ember-resources';
@@ -90,6 +90,37 @@ module(
       assert.dom('.my-base-class').exists();
       assert.dom('.my-options-container').exists();
       assert.dom('.my-label-class').exists();
+    });
+
+    test('it renders the description after the label', async function (assert) {
+      await render(
+        <template>
+          <RadioGroup
+            @label="Interests"
+            @description="Choose one option"
+            as |Radio|
+          >
+            <Radio @value="music" @label="Music" />
+          </RadioGroup>
+        </template>
+      );
+
+      assert
+        .dom('[data-component="form-description"]')
+        .hasText('Choose one option');
+
+      const label = find('[data-component="label"]') as HTMLElement;
+      const description = find(
+        '[data-component="form-description"]'
+      ) as HTMLElement;
+
+      assert.true(
+        !!(
+          label.compareDocumentPosition(description) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+        ),
+        'description is rendered after the label'
+      );
     });
   }
 );


### PR DESCRIPTION
## Problem

`CheckboxGroup` renders its `@description` **above** the label:

```
Choose how you would like to receive notifications
Notification Preferences *
  [ ] Email notifications
```

`RadioGroup` has the exact same bug — both components render their label inside `FormControl`'s default block, but `FormControl` emits `@description` *before* that block.

## Fix

Stop passing `@description` down to `FormControl`, and render the yielded `c.Description` explicitly right after `c.Label`:

```hbs
<c.Label …>{{@label}}</c.Label>

{{#if @description}}
  <c.Description>{{@description}}</c.Description>
{{/if}}
```

The description keeps the same `-description` id, so `describedBy` is unaffected, and the order now matches what `Input` and `Textarea` already produce.

## Tests

Added `it renders the description after the label` to both group test files, asserting DOM order via `compareDocumentPosition`. Confirmed red before the fix, green after.

- Full suite: 899 tests — 896 pass, 3 skip, 0 fail
- `pnpm lint:js`: 0 errors
- `pnpm --filter frontile lint:types`: clean

No doc updates needed; the public API is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)