### PR TITLE
docs: keep "New" label on components introduced in 0.18

### DIFF
--- a/packages/frontile/src/components/forms/autocomplete.md
+++ b/packages/frontile/src/components/forms/autocomplete.md
@@ -1,4 +1,5 @@
 ---
+label: New
 imports:
   - import Signature from 'site/components/signature';
 ---

--- a/packages/frontile/src/components/forms/form-control.md
+++ b/packages/frontile/src/components/forms/form-control.md
@@ -1,4 +1,5 @@
 ---
+label: New
 imports:
   - import Signature from 'site/components/signature';
 ---

--- a/packages/frontile/src/components/forms/native-select.md
+++ b/packages/frontile/src/components/forms/native-select.md
@@ -1,4 +1,5 @@
 ---
+label: New
 imports:
   - import Signature from 'site/components/signature';
 ---

--- a/packages/frontile/src/components/utilities/skeleton.md
+++ b/packages/frontile/src/components/utilities/skeleton.md
@@ -1,4 +1,5 @@
 ---
+label: New
 imports:
   - import Signature from 'site/components/signature';
 ---


### PR DESCRIPTION
Follow-up to josemarluedke/frontile#530, which removed the `label: New` frontmatter a bit too broadly.

Autocomplete, FormControl, NativeSelect and Skeleton did not exist at v0.17.1 — they are genuinely new in 0.18, so their "New" sidebar badge is restored. Everything else that already carried the badge in the last release stays without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)