### PR TITLE
fix(theme): transition the properties the Switch actually animates

### DIFF
--- a/packages/theme/src/components/close-button.ts
+++ b/packages/theme/src/components/close-button.ts
@@ -4,7 +4,7 @@ import { focusVisibleRing } from './shared';
 const closeButton = tv({
   slots: {
     base: [
-      'rounded-full transition transition-200 text-inherit',
+      'rounded-full transition duration-200 text-inherit',
       ...focusVisibleRing
     ],
     icon: 'size-[1em]'

--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -433,7 +433,10 @@ const switchInput = tv({
       'bg-neutral-soft',
       'rounded-full',
       'cursor-pointer touch-none tap-highlight-transparent select-none',
-      'transition-background',
+      // `transition-background` is not a Tailwind v4 utility -- it compiled to
+      // nothing. The wrapper's fill is swapped by `group-data-[selected]:bg-*`,
+      // so background-color is what needs to ease.
+      'transition-colors',
       ...focusVisibleWithinRing
     ],
     hiddenInput: [
@@ -470,14 +473,19 @@ const switchInput = tv({
       'z-0 absolute start-1.5 text-current',
       'opacity-0',
       'scale-50',
-      'transition-transform-opacity',
+      // Tailwind v4 compiles `scale-*` to the standalone `scale` property, not
+      // to `transform`; `transform` stays listed for consumers who override
+      // @classes.startContent and position with it.
+      'transition-[transform,scale,opacity]',
       'group-data-[selected=true]:scale-100',
       'group-data-[selected=true]:opacity-100'
     ],
     endContent: [
       'z-0 absolute end-1.5 text-neutral',
       'opacity-100',
-      'transition-transform-opacity',
+      // Likewise `translate-x-*` compiles to the standalone `translate`
+      // property -- without it listed, this content snapped instead of sliding.
+      'transition-[transform,translate,opacity]',
       'group-data-[selected=true]:translate-x-3',
       'group-data-[selected=true]:opacity-0'
     ]

--- a/packages/theme/src/components/notification-card.ts
+++ b/packages/theme/src/components/notification-card.ts
@@ -1,11 +1,11 @@
 import { tv } from '../tw';
 import { focusVisibleRing } from './shared';
 
-const btn = ['transition transition-200', ...focusVisibleRing];
+const btn = ['transition duration-200', ...focusVisibleRing];
 
 const notificationCard = tv({
   slots: {
-    base: 'py-3 px-4 overflow-hidden flex items-center justify-between relative min-h-16 font-body text-body-2xs rounded-xl shadow-sm transition-all transition-200 ease-in-out',
+    base: 'py-3 px-4 overflow-hidden flex items-center justify-between relative min-h-16 font-body text-body-2xs rounded-xl shadow-sm transition-all duration-200 ease-in-out',
     message: 'grow',
     customActions: 'flex flex-nowrap',
     customActionButton: [

--- a/test-app/tests/integration/components/forms/switch-test.gts
+++ b/test-app/tests/integration/components/forms/switch-test.gts
@@ -209,4 +209,151 @@ module('Integration | Component | @frontile/forms/Switch', function (hooks) {
     assert.dom('.my-start-content-class').exists();
     assert.dom('.my-end-content-class').exists();
   });
+  // Regression: Tailwind v4 compiles `translate-x-*` to the standalone CSS
+  // `translate` property and `scale-*` to `scale` -- not to `transform`. The
+  // Switch theme used `transition-transform-opacity` and
+  // `transition-background`, neither of which is a real Tailwind v4 utility,
+  // so they compiled to nothing at all and every one of these elements changed
+  // state in a single frame.
+  //
+  // These assertions read the *computed* transition and the transitions the
+  // browser actually starts. A class-presence assertion passes happily while
+  // the component is broken -- the class string was there the whole time.
+  //
+  // Note: `transition-property` computes to `all` even with no transition
+  // utility at all (that is its CSS initial value), so merely finding the
+  // property in the list proves nothing. What separates a real transition from
+  // none is a non-zero *duration* for that property.
+  test('each animated slot transitions the property it actually changes', async function (assert) {
+    const isSelected = cell(false);
+
+    await render(
+      <template>
+        <Switch @label="Airplane mode" @isSelected={{isSelected.current}}>
+          <:startContent>S</:startContent>
+          <:endContent>E</:endContent>
+        </Switch>
+      </template>
+    );
+
+    const wrapper = find('[data-component="switch"] > span') as HTMLElement;
+    const thumb = find('[data-test-id="switch-thumb-content"]') as HTMLElement;
+    const startContent = find(
+      '[data-test-id="switch-start-content"]'
+    ) as HTMLElement;
+    const endContent = find(
+      '[data-test-id="switch-end-content"]'
+    ) as HTMLElement;
+
+    // The duration the browser will actually use for `property` on `el`, in
+    // seconds. Zero means the element does not transition it, whatever the
+    // class string says.
+    const durationFor = (el: HTMLElement, property: string): number => {
+      const computed = window.getComputedStyle(el);
+      const properties = computed.transitionProperty
+        .split(',')
+        .map((entry) => entry.trim());
+      const durations = computed.transitionDuration
+        .split(',')
+        .map((entry) => entry.trim());
+
+      let seconds = 0;
+      properties.forEach((entry, index) => {
+        if (entry !== property && entry !== 'all') {
+          return;
+        }
+        // transition-duration repeats to cover a longer property list.
+        const duration = durations[index % durations.length] ?? '0s';
+        seconds = Math.max(seconds, parseFloat(duration) || 0);
+      });
+      return seconds;
+    };
+
+    const describe = (el: HTMLElement): string => {
+      const computed = window.getComputedStyle(el);
+      return `${computed.transitionProperty} / ${computed.transitionDuration}`;
+    };
+
+    // The property an element's geometry is actually written to. Tailwind v4
+    // puts `translate-x-*` on `translate` and `scale-*` on `scale`, so a
+    // transition naming only `transform` never fires.
+    const geometryProperty = (el: HTMLElement, fallback: string): string => {
+      const computed = window.getComputedStyle(el) as unknown as Record<
+        string,
+        string
+      >;
+      for (const property of ['translate', 'scale']) {
+        const value = computed[property];
+        if (value && value !== 'none') {
+          return property;
+        }
+      }
+      return fallback;
+    };
+
+    // The wrapper's fill changes via `group-data-[selected=true]:bg-*`.
+    assert.ok(
+      durationFor(wrapper, 'background-color') > 0,
+      `wrapper transitions background-color (${describe(wrapper)})`
+    );
+
+    // The thumb slides with `ms-*` (margin-inline-start).
+    assert.ok(
+      durationFor(thumb, 'margin-inline-start') > 0,
+      `thumb transitions margin-inline-start (${describe(thumb)})`
+    );
+
+    // startContent scales in (`scale-50` -> `scale-100`) and fades.
+    const startProperty = geometryProperty(startContent, 'scale');
+    assert.ok(
+      durationFor(startContent, startProperty) > 0,
+      `startContent transitions the property it is scaled with (${startProperty}; ${describe(startContent)})`
+    );
+    assert.ok(
+      durationFor(startContent, 'opacity') > 0,
+      `startContent transitions opacity (${describe(startContent)})`
+    );
+
+    // endContent slides out with `translate-x-3` and fades.
+    assert.ok(
+      durationFor(endContent, 'opacity') > 0,
+      `endContent transitions opacity (${describe(endContent)})`
+    );
+
+    // Reading the computed styles above also establishes the before-change
+    // style, so the browser has something to transition *from*.
+    isSelected.current = true;
+    await settled();
+
+    const endProperty = geometryProperty(endContent, 'translate');
+    assert.ok(
+      durationFor(endContent, endProperty) > 0,
+      `endContent transitions the property it is moved with (${endProperty}; ${describe(endContent)})`
+    );
+
+    // getAnimations() flushes pending style changes, so the transitions started
+    // by the selection change are observable here. Only a CSSTransition carries
+    // `transitionProperty`, which is enough to pick them out.
+    const runningOn = (el: HTMLElement): string[] =>
+      el
+        .getAnimations()
+        .map(
+          (animation) =>
+            (animation as Animation & { transitionProperty?: string })
+              .transitionProperty
+        )
+        .filter((property): property is string => typeof property === 'string');
+
+    const endRunning = runningOn(endContent);
+    assert.ok(
+      endRunning.includes(endProperty),
+      `toggling starts a transition on ${endProperty} for endContent (running: ${endRunning.join(', ') || 'none'})`
+    );
+
+    const wrapperRunning = runningOn(wrapper);
+    assert.ok(
+      wrapperRunning.includes('background-color'),
+      `toggling starts a background-color transition on the wrapper (running: ${wrapperRunning.join(', ') || 'none'})`
+    );
+  });
 });


### PR DESCRIPTION
`transition-background` and `transition-transform-opacity` are not Tailwind v4 utilities. Compiled through the repo's own vendored Tailwind (`test-app/node_modules/tailwindcss`, 4.1.11) they emit **no CSS at all**:

```
"transition-background"         => NO CSS
"transition-transform-opacity"  => NO CSS
"transition-200"                => NO CSS
"translate-x-3"                 => --tw-translate-x: …; translate: var(--tw-translate-x) var(--tw-translate-y);
"scale-50"                      => --tw-scale-x: 50%; …; scale: var(--tw-scale-x) var(--tw-scale-y);
```

So the Switch's wrapper, `startContent` and `endContent` had no transition whatsoever — every state change snapped in a single frame.

### Getting a real utility in place is only half the fix

Tailwind v4 compiles `translate-x-*` to the standalone **`translate`** CSS property and `scale-*` to **`scale`** — not to `transform`. A list naming `transform` still would not animate these elements. Same class of bug as 48b0079d in `segmented-control`.

| slot | changes via | was | now |
|---|---|---|---|
| wrapper | `group-data-[selected=true]:bg-*` | `transition-background` | `transition-colors` |
| startContent | `scale-50` → `scale-100`, opacity | `transition-transform-opacity` | `transition-[transform,scale,opacity]` |
| endContent | `translate-x-3`, opacity | `transition-transform-opacity` | `transition-[transform,translate,opacity]` |

`transform` stays listed for consumers overriding `@classes.*`. The thumb was already fine — it slides with `ms-*` under `transition-all`.

### The test asserts computed styles, not classes

Two weaker assertions would have passed while the component was broken:

1. **Class presence** — the class string was there and correctly spelled the whole time.
2. **Property in the computed `transition-property` list** — this genuinely passed against the broken theme on the first draft, because `transition-property` computes to `all` even with *no* transition utility at all. That is its CSS initial value. Only a non-zero **duration** for that property separates a real transition from none.

The test measures effective duration per property and also checks the transitions the browser actually starts via `getAnimations()`.

Discrimination proved by reverting each of the three theme changes independently and rebuilding:

- all three reverted → `wrapper transitions background-color (all / 0s)` ❌
- only `translate` removed → `endContent transitions the property it is moved with (translate; transform, opacity / 0.15s)` ❌
- only `scale` removed → `startContent transitions the property it is scaled with (scale; transform, opacity / 0.15s)` ❌

### Also in this change

Grepping the rest of `packages/theme/src/components/` turned up **`transition-200`** in `notification-card.ts` and `close-button.ts` — another non-utility emitting nothing. Replaced with `duration-200`. ⚠️ This is a **behavior change**: those elements were silently running at the 150ms default and now run at the intended 200ms.

The `transition-colors` / `transition-opacity` uses in `table.ts` and the input slot are real and match what those elements change. `overlays.ts` uses raw CSS objects (`transform: translateX(…)` with `transition: transform …`), self-consistent and unaffected.

### Verification

- Full suite: `1..1033 / # pass 1030 / # fail 0`
- `pnpm --filter @frontile/theme lint:types`: clean
- `pnpm lint:js`: 0 errors (87 pre-existing warnings, none in changed files)
- `pnpm lint:hbs` not run — pre-existing red, untouched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)