### PR TITLE
fix(site): let an anchored URL keep its anchor

### DIFF
--- a/site/app/routes/application.ts
+++ b/site/app/routes/application.ts
@@ -2,9 +2,36 @@ import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import config from 'site/config/environment';
 
+/**
+ * Where a page change should leave the reader: the heading the URL names, or
+ * `'top'` when it names none.
+ *
+ * A URL carrying an anchor is a request for a position, and it arrives through
+ * the same hook as an ordinary page change — both on a fresh load of
+ * `/docs/…/button-group#accessibility` and on an in-app link to another page's
+ * heading (`skeleton.md` links to `table#built-in-skeleton-rows`). Scrolling to
+ * the top in either case throws away the position the reader asked for.
+ *
+ * Resolving the element covers both: on a fresh load the browser has already
+ * put the heading there, so scrolling to it again changes nothing, and on an
+ * in-app transition nothing else would have moved the page at all. An anchor
+ * naming something this page doesn't have falls back to the top, which is what
+ * the browser does with it too.
+ */
+export function scrollTargetFor(hash: string): Element | 'top' {
+  const id = hash.replace(/^#/, '');
+
+  if (!id) {
+    return 'top';
+  }
+
+  return document.getElementById(id) ?? 'top';
+}
+
 export default class Application extends Route {
   /**
-   * Send the reader back to the top of the new page.
+   * Send the reader to the top of the new page — or to the heading its URL
+   * names, per `scrollTargetFor`.
    *
    * Smoothly, so the change of page reads as a movement rather than a jump —
    * the docs are long enough that an instant snap left no clue that anything
@@ -13,8 +40,8 @@ export default class Application extends Route {
    * height gets clamped to the wrong position. Readers who ask for less
    * motion get the jump instead.
    *
-   * Heading links do not come through here — they are plain anchors handled by
-   * DocfyPageHeadings' own scrolling — so this only fires on page changes.
+   * In-page heading clicks do not come through here — they are plain anchors
+   * handled by DocfyPageHeadings' own scrolling.
    *
    * **This hook also runs while prerendering**, on every page: `ssr/prerender.mjs`
    * visits each route in Node, so `didTransition` fires there too, and
@@ -39,14 +66,22 @@ export default class Application extends Route {
       ? 'auto'
       : 'smooth';
 
-    const scrollToTop = (): void => {
-      window.scrollTo({ top: 0, behavior });
+    const scroll = (): void => {
+      // Resolved here rather than above, because the incoming page's headings
+      // are only in the DOM once this frame runs.
+      const target = scrollTargetFor(window.location.hash);
+
+      if (target === 'top') {
+        window.scrollTo({ top: 0, behavior });
+      } else {
+        target.scrollIntoView({ behavior, block: 'start' });
+      }
     };
 
     if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(scrollToTop);
+      window.requestAnimationFrame(scroll);
     } else {
-      scrollToTop();
+      scroll();
     }
   }
 }

--- a/site/tests/unit/routes/application-test.ts
+++ b/site/tests/unit/routes/application-test.ts
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { scrollTargetFor } from 'site/routes/application';
+
+module('Unit | Route | application', function (hooks) {
+  setupTest(hooks);
+
+  module('scrollTargetFor', function (innerHooks) {
+    let heading: HTMLElement;
+
+    innerHooks.beforeEach(function () {
+      heading = document.createElement('h2');
+      heading.id = 'accessibility';
+      document.body.append(heading);
+    });
+
+    innerHooks.afterEach(function () {
+      heading.remove();
+    });
+
+    test('a page change with no anchor goes to the top', function (assert) {
+      assert.strictEqual(scrollTargetFor(''), 'top');
+    });
+
+    test('a bare hash goes to the top', function (assert) {
+      assert.strictEqual(scrollTargetFor('#'), 'top');
+    });
+
+    test('an anchor that names a heading goes to that heading', function (assert) {
+      assert.strictEqual(
+        scrollTargetFor('#accessibility'),
+        heading,
+        'landing on /page#accessibility must not be dragged to the top'
+      );
+    });
+
+    test('an anchor naming nothing on the page goes to the top', function (assert) {
+      assert.strictEqual(scrollTargetFor('#no-such-heading'), 'top');
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #528, which introduced this.

## The bug

Scroll-to-top ran on every page change — and a URL carrying an anchor *is* a page change. Loading `/docs/components/buttons/segmented-control#ghost` landed on the heading, then the app booted and dragged the reader to the top.

Measured on the built site before the fix, using an anchor that exists on this branch:

```
GET /docs/components/buttons/button-group#accessibility
  immediately after load:  scrollY = 3716   (browser honored the anchor)
  after hydration:         scrollY = 0      (didTransition overrode it)
```

## The fix

`scrollTargetFor(hash)` decides where a page change should land: the heading the URL names, or the top when it names none — or names something this page doesn't have, which is what the browser does with it too.

One rule covers both arrivals. On a fresh load the browser has already positioned the heading, so scrolling to it again changes nothing; on an in-app transition nothing else would have moved the page at all.

That second half fixes a case nobody had noticed: **in-app links to another page's heading**, like [`skeleton.md`](https://github.com/josemarluedke/frontile/blob/main/packages/frontile/src/components/utilities/skeleton.md)'s link to `table#built-in-skeleton-rows`. Those were sent to the top as well; they now land on the heading.

The element lookup happens *inside* the `requestAnimationFrame` callback, because the incoming page's headings are only in the DOM once that frame runs — resolving it earlier finds nothing and falls back to the top, which is the bug again for in-app links.

## Verification

Four unit tests on `scrollTargetFor` (no anchor, bare `#`, anchor naming a heading, anchor naming nothing). Site suite 23/23; types and eslint clean on the touched files.

Behavior on the built site (`pnpm build`, served from `dist/`):

| case | result |
| --- | --- |
| fresh load of `button-group#accessibility` | `scrollY = 3716`, heading at the viewport top — stays put |
| in-app link to `table#built-in-skeleton-rows` | navigates and lands on the heading (`scrollY = 13332`) |
| plain page change from `scrollY = 1200` | still glides to `0` |

No console or page errors. `pnpm build` including SSR prerender: 68 rendered, 0 failed.

## Known, pre-existing

The heading lands flush with the viewport top, so the sticky 64px header overlaps it. That is what the browser's native anchor jump already did on this site (and what `DocfyPageHeadings`' own click scrolling does), so this PR is at parity — but a `scroll-margin-top` on prose headings would fix all three paths at once, if you want that as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)