### PR TITLE
docs: cut process and meta commentary from component docs

### DIFF
--- a/packages/frontile/src/components/buttons/button.md
+++ b/packages/frontile/src/components/buttons/button.md
@@ -391,9 +391,8 @@ export default class KeyboardParityExample extends Component {
 }
 ```
 
-`@type='submit'` and `@type='reset'` are deliberately exempt: the default is
-preserved there so a button inside a form still submits or resets it from the
-keyboard.
+`@type='submit'` and `@type='reset'` are exempt — the default is preserved
+there, so a button inside a form still submits or resets it from the keyboard.
 
 ### Buttons with no text
 

--- a/packages/frontile/src/components/buttons/toggle-button.md
+++ b/packages/frontile/src/components/buttons/toggle-button.md
@@ -136,11 +136,10 @@ followed by its state, and announces the change when it flips.
 | `Enter` | Toggles it, firing `@onChange` with the new value.       |
 | `Space` | Toggles it, firing `@onChange` with the new value.       |
 
-`aria-pressed` tracks `@isSelected`, which the component does not own. Without an
-`@onChange` that writes the new value back, the toggle looks pressed to the eye
-for as long as the pointer is down but never reports a state change — the demos
-under [Sizes](#togglebutton-sizes) and [Disabled](#disabled) are deliberately
-inert for that reason, and are not the pattern to copy.
+`aria-pressed` tracks `@isSelected`, which the component does not own. Always
+pair it with an `@onChange` that writes the new value back: without one the
+toggle looks pressed to the eye for as long as the pointer is down, but never
+reports a state change.
 
 An icon with no text leaves the toggle unnamed, so the state is announced with
 nothing to attach it to. Pass `aria-label`, as the [Usage](#usage) demo does.

--- a/packages/frontile/src/components/collections/dropdown.md
+++ b/packages/frontile/src/components/collections/dropdown.md
@@ -634,15 +634,14 @@ carries `aria-haspopup="true"`, `aria-controls` pointing at the menu, and `aria-
 kept in sync. The menu itself is `role="menu"` and its items are `role="menuitem"` with
 `aria-labelledby`, plus `aria-disabled="true"` for keys in `@disabledKeys`.
 
-Menu items deliberately carry no `aria-selected`: it is invalid on a plain `menuitem`, which
-conveys state through `aria-checked` and only as `menuitemcheckbox` or `menuitemradio`. A
-menu is a list of commands rather than a set of choices.
+Menu items carry no `aria-selected` — it is invalid on a plain `menuitem`, which conveys
+state through `aria-checked` and only as `menuitemcheckbox` or `menuitemradio`.
 
 Menu items share the Listbox's roving `tabindex`: exactly one item carries `tabindex="0"` —
 the active one, falling back to the first selected item and then to the first item that is not
 disabled — and every other item is `-1`.
 
-Keys are handled in two places, which is worth knowing when debugging one that doesn't fire:
+Which keys are handled depends on where focus is:
 
 | Focus is on the trigger | Behavior                                          |
 | ----------------------- | ------------------------------------------------- |

--- a/packages/frontile/src/components/collections/listbox.md
+++ b/packages/frontile/src/components/collections/listbox.md
@@ -563,7 +563,7 @@ Keyboard, handled on the list itself:
 | `Enter`, `Space`        | Select the active item                                              |
 | any single character    | Type-ahead: jumps to the item whose text starts with what you typed |
 
-Two details worth knowing. Type-ahead means `Space` selects only when no search is in
+Two details. Type-ahead means `Space` selects only when no search is in
 progress, so a space typed mid-search is treated as part of the search string rather than as
 a selection. And `@elementToAddKeyboardEvents` moves the key handling onto another element —
 that is how Select and Autocomplete keep focus in their input while driving the list.

--- a/packages/frontile/src/components/collections/table.md
+++ b/packages/frontile/src/components/collections/table.md
@@ -438,17 +438,14 @@ export default class DemoComponent extends Component {
 }
 ```
 
-The hairline under the header shown above is deliberately subtle — it is meant
-for tables that already have content and are merely refreshing it. When a
-table is loading with nothing on screen yet, prefer the built-in skeleton rows
-below instead.
+The hairline under the header is a subtle indicator, for tables that already
+have content and are merely refreshing it. When a table is loading with nothing
+on screen yet, prefer the built-in skeleton rows below instead.
 
 ### Built-in skeleton rows
 
 `@skeletonRows` renders placeholder rows while the table is loading and has no
-items. It is opt-in, and the number is required rather than defaulted: the row
-count is the one thing the table cannot infer, and a wrong default promises ten
-rows and delivers three.
+items. It is opt-in, and the row count is required — there is no default.
 
 Load the data below to watch the placeholders hand off to real rows.
 
@@ -514,8 +511,7 @@ export default class DemoComponent extends Component {
 
 Placeholder rows fade in one after another, 60ms apart, so they arrive the way
 the real rows will rather than appearing as one block. The stagger stops
-growing after ten rows — past that the last row would sit blank longer than
-many requests take — and `prefers-reduced-motion` turns it off entirely.
+growing after ten rows, and `prefers-reduced-motion` turns it off entirely.
 
 Skeleton rows render only when `@isLoading` is true **and** there are no items,
 so a refresh, a filter requery, or loading page two never throws away rows the
@@ -556,9 +552,9 @@ Because `circle` and `square` reuse Avatar's size scale, a placeholder in an
 `@size="md"` table is the same 32px as the `<Avatar @size="md">` it stands in
 for.
 
-This is deliberately only a shape. For anything richer — cells that stack an
-icon, a name and a chip, or per-column widths — use `bodyTop` with the yielded
-columns and render `Skeleton` yourself for each piece of content.
+`skeleton` sets the shape and nothing else. For anything richer — cells that
+stack an icon, a name and a chip, or per-column widths — use `bodyTop` with the
+yielded columns and render `Skeleton` yourself for each piece of content.
 
 If neither the built-in skeleton rows nor a custom `bodyTop` layout fit —
 for example, an overlay that needs to sit over content that is already on
@@ -1348,9 +1344,8 @@ On top of that:
 | Row selection       | A checkbox per row labelled "Select row", and "Select all rows" in the header                |
 | Skeleton rows       | `aria-hidden="true"` while loading, so placeholder rows are not announced as data            |
 
-`aria-sort` comes from the underlying table library's header-cell modifier, which applies it
-to every header cell — including non-sortable ones, where it reads `none`. That is harmless
-but means the attribute's presence is not a reliable signal of whether a column can be
+`aria-sort` is present on every header cell, including non-sortable ones, where it reads
+`none`. So the attribute's presence is not a reliable signal of whether a column can be
 sorted; `data-sortable` is.
 
 Two things to supply yourself:

--- a/packages/frontile/src/components/forms/autocomplete.md
+++ b/packages/frontile/src/components/forms/autocomplete.md
@@ -298,9 +298,8 @@ export default class RoleInput extends Component {
 
 Pass `@isClearable={{true}}` to show a button that clears both the selection and the typed text.
 
-Like `Select`, this deliberately overrides `@allowEmpty` — that argument governs
-deselecting an option in the listbox, while the clear button is the affordance for
-emptying the field. No clear button renders on a disabled Autocomplete.
+Like `Select`, this overrides `@allowEmpty` — that argument governs deselecting an
+option in the listbox, while the clear button is the affordance for emptying the field. No clear button renders on a disabled Autocomplete.
 
 ```gts preview
 import Component from '@glimmer/component';

--- a/packages/frontile/src/components/forms/field.md
+++ b/packages/frontile/src/components/forms/field.md
@@ -615,10 +615,8 @@ When used with a Form component that provides `@data`, Field automatically binds
 
 - Extracts the current value for the field from `form.data`
 - Passes the appropriate value prop to each component type
-- Provides a no-op change handler to put components in controlled mode
-  - This ensures form-level `@onChange` handles all state updates
-  - Prevents components from managing their own internal state
-  - Enables the Form component to be the single source of truth
+- Provides a no-op change handler, which puts the component in controlled mode so that
+  form-level `@onChange` handles every update
 
 **Example:**
 
@@ -638,27 +636,14 @@ When the Form component's `@validateOn` argument includes `'change'` or `'input'
 
 **Change Validation (`'change'`)**
 
-Validates when a field loses focus (blur) after being modified:
-
-**How it works:**
-
-1. Form passes `@validateOn` to Field components (defaults to `['change']`)
-2. Field's `handleChange` action checks if `'change'` is included
-3. If change validation is enabled, Field calls `validateField` for that specific field when the field loses focus
-4. Validation errors appear after the user moves to the next field (on blur)
+Validates when a field loses focus (blur) after being modified, so errors appear once the
+user has moved on to the next field.
 
 **Note:** The `'change'` option validates on the HTML `change` event, which fires when a field loses focus (blur) after its value has been modified. It does NOT fire on every keystroke.
 
 **Input Validation (`'input'`)**
 
-Validates as the user types, on every keystroke:
-
-**How it works:**
-
-1. Form passes `@validateOn` to Field components
-2. Field's `handleInput` action checks if `'input'` is included
-3. If input validation is enabled, Field calls `validateField` for that specific field on every keystroke
-4. Validation errors appear in real-time as the user types
+Validates as the user types, so errors appear and clear on every keystroke.
 
 **Note:** The `'input'` option validates on the HTML `input` event, which fires on every keystroke as the user types. This provides immediate feedback but may be distracting for some use cases.
 
@@ -728,21 +713,6 @@ const schema = v.object({
   </Form>
 </template>
 ```
-
-**Benefits of change validation:**
-
-- **Early feedback**: Users see validation errors as they move between fields
-- **Better UX**: Errors are caught before form submission, reducing frustration
-- **Per-field validation**: Each field validates independently when blurred
-- **Clear guidance**: Users know exactly what's wrong before submitting
-- **Natural flow**: Validation happens when user is done with a field (on blur)
-
-**Benefits of input validation:**
-
-- **Immediate feedback**: Users see validation errors in real-time as they type
-- **Perfect for specific cases**: Great for password strength, character limits, username availability
-- **Continuous guidance**: Users can adjust their input immediately based on feedback
-- **Progressive disclosure**: Errors clear as soon as the input becomes valid
 
 **When to use input validation:**
 
@@ -911,7 +881,7 @@ below comes from the wrapped component, and holds for `field.Input`, `field.Sele
 | Errors announced as they appear                                        | `FormFeedback` renders `aria-live="assertive"` for errors, `"polite"` otherwise |
 | Label associated via `for`                                             | `FormControl` + `Label`                                                         |
 
-Two consequences worth knowing. Because error feedback is `aria-live="assertive"`, a form
+Two consequences. Because error feedback is `aria-live="assertive"`, a form
 using `@validateOn={{array "input"}}` interrupts a screen reader on **every keystroke** —
 prefer `change` or `blur` for validation a user hears. And because the announcement is tied
 to the feedback element rather than the control, a field whose errors you render yourself,

--- a/packages/frontile/src/components/forms/form-control.md
+++ b/packages/frontile/src/components/forms/form-control.md
@@ -207,7 +207,7 @@ apply them:
 | `c.isInvalid`   | `aria-invalid` on the control                                                                 |
 | `c.describedBy` | `aria-describedby` on the control, called with whether a description and feedback are present |
 
-Notes worth knowing before you rely on it:
+Notes before you rely on it:
 
 - **Required is visual.** `@isRequired` adds an asterisk to the label. Set `required` or
   `aria-required` on the control yourself.

--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -542,7 +542,7 @@ regardless of validity and `@onError` never fires. That's the path for multi-ste
 saves, or validating by hand inside `@onSubmit`. Everything else — dirty tracking, reset, data
 snapshots — keeps working.
 
-Two limits worth knowing: the field-level values (`change`, `blur`, `input`) need
+Two limits: the field-level values (`change`, `blur`, `input`) need
 `form.Field`, and [CheckboxGroup](checkbox-group) validates only on submit.
 
 ## Dirty Field Tracking
@@ -1479,8 +1479,7 @@ Form renders a native `<form>`, so submission on <kbd>Enter</kbd>, field labelli
 - **Error messages** render in a `FormFeedback` associated with the control through
   `aria-describedby`, and are announced from a persistent, visually hidden
   `aria-live='assertive'` region that `FormControl` renders whether or not the field is
-  currently invalid. A live region inserted at the same moment as its content is not
-  announced reliably, which is why the region is always present and merely filled.
+  currently invalid.
 - **Disabled fields** carry the real `disabled` attribute rather than a styling-only state.
 - **Focus** is not managed or trapped by Form; it stays where the browser puts it. If you
   redirect focus to the first invalid field in `@onError`, see

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -558,11 +558,9 @@ export default class DeclarativeItemsSelect extends Component {
 
 The built-in clear button can be enabled using the `@isClearable` flag. This allows users to reset the selection easily.
 
-It deliberately overrides `@allowEmpty`: that argument governs deselecting an *option*,
-while `@isClearable` is a separate affordance you add for exactly the purpose of emptying
-the field, and it would be dead in every default configuration otherwise (`@allowEmpty`
-defaults to `false`). No clear button renders on a disabled Select, or with nothing
-selected.
+It overrides `@allowEmpty`: that argument governs deselecting an *option*, while
+`@isClearable` is the affordance for emptying the field. No clear button renders on a
+disabled Select, or with nothing selected.
 
 > **Note:** This example demonstrates the clearable feature with direct state management. The `@isClearable` option also works with Form/Field integration.
 
@@ -759,9 +757,9 @@ last remaining selection cannot be removed — its chip renders with **no close 
 rather than a dead one. Set `@allowEmpty={{true}}` to allow emptying the selection one chip
 at a time.
 
-`@isClearable` adds a clear button to the field that removes everything at once. It
-deliberately ignores `@allowEmpty`, so a clearable Select can always be emptied even though
-its last chip has no close button.
+`@isClearable` adds a clear button to the field that removes everything at once. It ignores
+`@allowEmpty`, so a clearable Select can always be emptied even though its last chip has no
+close button.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1019,9 +1017,8 @@ Keyboard handling comes from the listbox:
 ### The chips keyboard model
 
 Chip close buttons are **pointer affordances**: they are set to `tabindex="-1"` and are not
-tab stops. This is deliberate. A field holding five selections would otherwise put five Tab
-stops in front of the combobox, so a keyboard user Tabbing into the control would land on
-"Remove ..." rather than on the field itself.
+tab stops, so Tabbing into the control lands on the field itself rather than on a run of
+"Remove ..." buttons in front of it.
 
 Keyboard removal is on the field instead, in **both** modes:
 

--- a/packages/frontile/src/components/overlays/overlay.md
+++ b/packages/frontile/src/components/overlays/overlay.md
@@ -560,9 +560,9 @@ export default class OverlayElementClick extends Component {
 }
 ```
 
-> **Why is `@closeOnOverlayElementClick` `true` by default?**
->
-> This option is set to `true` by default to make "outside click" functionality work intuitively. Most overlay content is wrapped with an inner element (like a card or dialog), which prevents accidental closure when clicking on the actual content. The overlay element itself acts as part of the "outside" area, allowing users to click anywhere around the content to dismiss the overlay.
+> **Note:** Content wrapped in an inner element — a card, a dialog — is not the overlay
+> element itself, so clicking your content never closes the overlay. What
+> `@closeOnOverlayElementClick` covers is the area around it.
 
 ## Using Power Select inside an Overlay
 

--- a/packages/frontile/src/components/overlays/portal.md
+++ b/packages/frontile/src/components/overlays/portal.md
@@ -221,9 +221,9 @@ server-rendered HTML.
 
 ## Accessibility
 
-Neither component adds a role or any ARIA attribute — `PortalTarget` is a plain `div`, and
-that is deliberate: the semantics belong to whatever you render inside it. What they do
-change is DOM position, and that has consequences:
+Neither component adds a role or any ARIA attribute — `PortalTarget` is a plain `div`, so
+the semantics belong to whatever you render inside it. What they do change is DOM position,
+and that has consequences:
 
 - **Reading and tab order follow the destination, not the source.** Content written next to a
   button but portalled to the end of the page is announced and reached there. Place your
@@ -236,10 +236,6 @@ change is DOM position, and that has consequences:
   `aria-describedby`, or `aria-labelledby`, since proximity in the DOM no longer implies it.
 - **Give a named target only one owner.** Two portals targeting the same name append in render
   order; for a slot that should hold one thing at a time, render one `Portal` at a time.
-
-These notes come from reading `portal.gts` and `portal-target.gts` and the integration tests
-in `test-app/tests/integration/components/overlays/`; the tests cover destination resolution,
-not assistive-technology behavior.
 
 ## API
 

--- a/packages/frontile/src/components/utilities/avatar.md
+++ b/packages/frontile/src/components/utilities/avatar.md
@@ -149,7 +149,7 @@ The `@alt` should name the person, not the picture. "Jon Snow" is useful;
 "User profile picture" and "Avatar" describe the widget, which the reader already
 knows and cannot act on.
 
-Two limits worth knowing:
+Two limits:
 
 - **An avatar is never focusable or interactive.** It renders a `<span>` and
   takes no key handling. If the avatar should open a menu or a profile, wrap it

--- a/packages/frontile/src/components/utilities/spinner.md
+++ b/packages/frontile/src/components/utilities/spinner.md
@@ -85,8 +85,8 @@ import { Spinner } from 'frontile';
 
 ## Accessibility
 
-The spinner is `aria-hidden` by default, and deliberately so: it is a picture of
-a state, not the state itself. An unhidden, unnamed `<svg>` is announced as an
+The spinner is `aria-hidden` by default: it is a picture of a state, not the
+state itself. An unhidden, unnamed `<svg>` is announced as an
 image with no name, which tells a screen reader user nothing — and naming the
 graphic ("Loading spinner") describes the decoration rather than saying that the
 content they asked for is on its way.
@@ -174,7 +174,7 @@ export default class Example extends Component {
 }
 ```
 
-If you genuinely need the graphic itself announced — a full-page loader with
+If you need the graphic itself announced — a full-page loader with
 nothing else on screen — pass your own attributes, which are applied after the
 default and so win:
 
@@ -186,11 +186,10 @@ import { Spinner } from 'frontile';
 </template>
 ```
 
-Motion is the other consideration, and worth knowing precisely: the theme applies
-`animate-spin` with **no** `motion-reduce` variant, so the spinner keeps turning
-for users who have asked for reduced motion. That is a deliberate trade — a
-stopped spinner conveys nothing at all — but if your product treats the
-preference as absolute, suppress it yourself:
+Motion is the other consideration: the theme applies `animate-spin` with **no**
+`motion-reduce` variant, so the spinner keeps turning for users who have asked
+for reduced motion. If your product treats that preference as absolute, suppress
+it yourself:
 
 ```gts preview
 import { Spinner } from 'frontile';

--- a/packages/frontile/src/utils/ref.md
+++ b/packages/frontile/src/utils/ref.md
@@ -90,9 +90,6 @@ export default class ElementMeasureComponent extends Component {
 }
 ```
 
-This example is to just ilustrate the use of the `onChange`, but getting the element width
-could be achieved using a getter property on the component as well.
-
 ### Using as a Template Helper
 
 You can also use `ref` directly within your templates:


### PR DESCRIPTION
Applies the rule added in #538 to the docs that already exist. 15 files, prose only.

## Cut outright

| Where | What |
|---|---|
| `portal.md` | "These notes come from reading `portal.gts` … the tests cover destination resolution, not assistive-technology behavior." |
| `overlay.md` | A blockquote headed **"Why is `@closeOnOverlayElementClick` `true` by default?"** — replaced with what a click actually does |
| `field.md` | Two `**How it works:**` lists naming the internal `handleChange` / `handleInput` / `validateField` methods; the `**Note:**` under each already stated the behaviour |
| `field.md` | `**Benefits of change validation:**` and `**Benefits of input validation:**` — ten bullets of "Better UX", "reducing frustration". The `**When to use**` lists that follow are kept |
| `field.md` | Three nested bullets justifying the no-op change handler ("single source of truth") |
| `form.md` | "A live region inserted at the same moment as its content is not announced reliably, which is why…" |
| `dropdown.md` | "A menu is a list of commands rather than a set of choices" + "worth knowing when debugging one that doesn't fire" |
| `select.md` | "it would be dead in every default configuration otherwise"; "This is deliberate. A field holding five selections would otherwise…" |
| `table.md` | "a wrong default promises ten rows and delivers three"; "past that the last row would sit blank longer than many requests take"; the provenance of `aria-sort` ("comes from the underlying table library's header-cell modifier") |
| `toggle-button.md` | "the demos under Sizes and Disabled are deliberately inert for that reason" — the docs defending their own demos. Reworded as the instruction it was implying: always pair `@isSelected` with `@onChange` |
| `ref.md` | "This example is to just ilustrate the use of the `onChange`, but…" (also fixes the typo by deletion) |

## Reworded, fact kept

`deliberately` / `genuinely` / `worth knowing` doing rhetorical work — `button.md`, `autocomplete.md`, `portal.md`, `spinner.md` (x3), `listbox.md`, `form-control.md`, `form.md`, `avatar.md`, `table.md` (x2). Each keeps the behaviour and drops the defence.

## Deliberately not touched

Rationale that survives the rule's test because it changes what the reader expects: clamped `aria-valuenow` in `progress-bar.md`, dropped `__proto__` fields in `form.md`, Label in Name in `select.md`, the test-waiter note in `collapsible.md`.

Also left alone: the seven Accessibility sections opening with "The X component follows accessibility best practices:" (checkbox, radio, input, textarea, switch, checkbox-group, radio-group). Those claim compliance instead of documenting attributes — a real gap, but a different fix and its own PR.

## Verification

- `lint-docs.mjs`: **0 errors, 10 warnings** — all pre-existing (`gts` fence languages, one palette class, one missing `.md`), none in prose.
- `lint-docs.mjs --since main`: no demo loss.
- Fence counts are byte-identical to `main` in all 15 files, so no demo changed.
- **`cd site && pnpm build` was not run** — this worktree has no `node_modules` and a full monorepo install is disproportionate for a prose-only diff. The demos are therefore unverified by build, though nothing inside a fence was edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)