### PR TITLE
refactor(kbd): simplify and deduplicate after cleanup review

### DIFF
--- a/packages/frontile/src/components/collections/command/dialog.gts
+++ b/packages/frontile/src/components/collections/command/dialog.gts
@@ -4,6 +4,7 @@ import { modifier } from 'ember-modifier';
 import { useStyles } from '@frontile/theme';
 import { Overlay } from '../../overlays/overlay';
 import { Command, type CommandSignature } from './command';
+import { resolveKbdPlatform } from '../../../utils/keys';
 import type { OverlaySignature } from '../../overlays/overlay';
 
 /**
@@ -12,12 +13,13 @@ import type { OverlaySignature } from '../../overlays/overlay';
  *
  * `mod` is Cmd on Apple platforms and Ctrl elsewhere, which is what users of
  * either expect from a palette.
+ *
+ * The platform comes from `resolveKbdPlatform` so that what `Kbd` prints and
+ * what this matches can never disagree: an app that pins the platform to
+ * label a shortcut `⌘K` gets Cmd+K matched to go with it.
  */
 function isApplePlatform(): boolean {
-  const nav = globalThis.navigator;
-  // `platform` is deprecated but still the only synchronous signal in some
-  // browsers; userAgent covers the rest.
-  return /Mac|iPhone|iPad|iPod/i.test(nav?.platform || nav?.userAgent || '');
+  return resolveKbdPlatform() === 'apple';
 }
 
 function matchesShortcut(event: KeyboardEvent, shortcut: string): boolean {

--- a/packages/frontile/src/components/collections/command/footer.gts
+++ b/packages/frontile/src/components/collections/command/footer.gts
@@ -109,8 +109,6 @@ class CommandFooter extends Component<CommandFooterSignature> {
           )
         }}
       {{else}}
-        {{! Named keys rather than literal glyphs: Kbd supplies the spoken
-            labels, so these no longer need hand-written aria-labels. }}
         <CommandHint @classes={{@classes}}>
           <CommandKbd @keys="up" @classes={{@classes}} />
           <CommandKbd @keys="down" @classes={{@classes}} />

--- a/packages/frontile/src/components/collections/listbox/item.gts
+++ b/packages/frontile/src/components/collections/listbox/item.gts
@@ -148,10 +148,6 @@ class ListboxItem extends Component<ListboxItemSignature> {
     };
   }
 
-  /**
-   * `inherit` by default so the keycap picks up the option's own colour rather
-   * than the theme having to repaint it for every intent on an active row.
-   */
   get shortcutAppearance() {
     return this.args.shortcutAppearance ?? 'inherit';
   }

--- a/packages/frontile/src/components/utilities/kbd.gts
+++ b/packages/frontile/src/components/utilities/kbd.gts
@@ -1,14 +1,9 @@
 import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
 import { useStyles } from '@frontile/theme';
 import { parseKeys } from '../../utils/keys';
 import type { KbdKey, KbdPlatform } from '../../utils/keys';
 import type { KbdSlots, SlotsToClasses } from '@frontile/theme';
-
-interface RenderedKey {
-  key: KbdKey;
-  /** Set on every key but the first, so it renders *between* caps. */
-  separator?: string;
-}
 
 export interface KbdSignature {
   Args: {
@@ -98,20 +93,11 @@ class Kbd extends Component<KbdSignature> {
     return this.args.display === 'merged';
   }
 
+  @cached
   get keys(): KbdKey[] {
     return parseKeys(this.args.keys, this.args.platform);
   }
 
-  get renderedKeys(): RenderedKey[] {
-    const { separator } = this.args;
-
-    return this.keys.map((key, index) => ({
-      key,
-      separator: index > 0 ? separator : undefined
-    }));
-  }
-
-  /** In merged mode every glyph shares one cap, so they concatenate. */
   get mergedGlyph(): string {
     return this.keys.map((key) => key.glyph).join('');
   }
@@ -138,6 +124,9 @@ class Kbd extends Component<KbdSignature> {
     return named.length ? named.map((key) => key.name).join(' ') : undefined;
   }
 
+  // Cached because the template reads these once per key, and each read
+  // otherwise re-resolves every compound variant in the theme.
+  @cached
   get classNames() {
     const { kbd } = useStyles();
     const { classes } = this.args;
@@ -182,28 +171,28 @@ class Kbd extends Component<KbdSignature> {
           {{/if}}
         </kbd>
       {{else}}
-        {{#each this.renderedKeys as |rendered|}}
-          {{#if rendered.separator}}
-            <span
-              class={{this.classNames.separator}}
-              aria-hidden="true"
-              data-test-id="kbd-separator"
-            >{{rendered.separator}}</span>
+        {{#each this.keys as |key index|}}
+          {{! index is 0 for the first key, so a separator falls between. }}
+          {{#if index}}
+            {{#if @separator}}
+              <span
+                class={{this.classNames.separator}}
+                aria-hidden="true"
+                data-test-id="kbd-separator"
+              >{{@separator}}</span>
+            {{/if}}
           {{/if}}
 
           <kbd
             class={{this.classNames.key}}
             data-test-id="kbd-key"
-            title={{rendered.key.name}}
+            title={{key.name}}
           >
-            {{! A symbol is meaningless read aloud, so it is hidden and its
-                  name spoken instead. A glyph like Esc already reads
-                  correctly, and labelling it would say "Escape Escape". }}
-            {{#if rendered.key.needsSpokenLabel}}
-              <span aria-hidden="true">{{rendered.key.glyph}}</span>
-              <span class="sr-only">{{rendered.key.name}}</span>
+            {{#if key.needsSpokenLabel}}
+              <span aria-hidden="true">{{key.glyph}}</span>
+              <span class="sr-only">{{key.name}}</span>
             {{else}}
-              {{rendered.key.glyph}}
+              {{key.glyph}}
             {{/if}}
           </kbd>
         {{/each}}

--- a/packages/theme/src/components/command.ts
+++ b/packages/theme/src/components/command.ts
@@ -96,8 +96,8 @@ const command = tv({
       'select-none'
     ],
     footerHint: 'flex items-center gap-1.5',
-    // `Kbd` draws the keycap now. The slot stays as an override hook so
-    // `@classes={{hash kbd="..."}}` keeps working for consumers.
+    // Empty on purpose: an override hook so `@classes={{hash kbd="..."}}`
+    // reaches the keycap, which `Kbd` itself draws.
     kbd: ''
   },
   variants: {

--- a/packages/theme/src/components/kbd.ts
+++ b/packages/theme/src/components/kbd.ts
@@ -14,9 +14,13 @@ const kbd = tv({
     ],
     // Each cap. `min-w` is set per size to match its height, so a lone `K` stays
     // square instead of collapsing to the width of the letter.
+    // `font-label` is repeated here rather than inherited from `base`: the CSS
+    // reset styles the `kbd` element itself as monospace, and an element rule
+    // beats inheritance, so the cap must name its own font.
     key: [
       'inline-flex items-center justify-center',
       'shrink-0',
+      'font-label',
       'leading-none',
       '[&_svg]:size-3'
     ],

--- a/site/app/styles/app.css
+++ b/site/app/styles/app.css
@@ -517,10 +517,10 @@
 .prose h4 { @apply font-header text-header-lg; }
 .prose h5 { @apply font-header text-header-md; }
 .prose h6 { @apply font-header text-header-sm; }
-.prose :is(code, kbd, samp, pre) { @apply font-code; }
-/* Frontile's Kbd picks font-label on purpose: ⌘ ⇧ ⌥ ⌃ render poorly in most
-   monospace faces. The rule above is more specific than a utility class, so
-   without this the component's own choice loses inside docs prose. Plain
-   markdown <kbd> in prose tables stays monospace. */
-.prose [data-component='kbd'],
-.prose [data-component='kbd'] kbd { @apply font-label; }
+/* Prose typography is for markdown-authored content. Docfy renders live
+   component demos inside the same .prose subtree, where these rules would
+   override a component's own choices -- so the demo preview is excluded.
+   The source snippet beside it is a sibling, not a child, and stays code. */
+.prose :is(code, kbd, samp, pre):not(.docfy-demo__example__container *) {
+  @apply font-code;
+}

--- a/test-app/tests/integration/components/collections/command-test.gts
+++ b/test-app/tests/integration/components/collections/command-test.gts
@@ -463,8 +463,6 @@ module(
         4,
         'up, down, enter and escape keycaps'
       );
-      // Counting the caps says nothing about which keys they are, so assert
-      // the glyphs the named keys resolve to.
       assert.deepEqual(
         [...document.querySelectorAll('[data-test-id="command-kbd"]')].map(
           (el) =>

--- a/test-app/tests/unit/utilities/keys-test.ts
+++ b/test-app/tests/unit/utilities/keys-test.ts
@@ -5,11 +5,6 @@ import {
   resolveKbdPlatform
 } from 'frontile/utils/keys';
 
-/**
- * The parser is the whole reason `Kbd` is more than a styled `<kbd>`: it turns
- * one authored string into per-key glyphs, human names, and a platform-correct
- * reading of `mod`.
- */
 module('Unit | utils | keys', function (hooks) {
   hooks.afterEach(function () {
     setKbdPlatform('auto');


### PR DESCRIPTION
Quality pass over the Kbd work (reuse, simplification, efficiency, altitude). No behaviour change intended except the font fix below, which restores the intended behaviour.

> [!NOTE]
> This was meant to be part of #532, but that PR merged while the pass was running. Stacked on `claude/command-component` like #532 was; retarget to `main` when #527 merges.

## The keycap font was broken for every consumer

The `key` slot carried no font class and relied on inheriting `font-label` from the wrapper. But the CSS reset styles the `kbd` element itself as monospace, and **an element rule beats inheritance** — so every inner cap fell back to mono in any app, not just the docs site. The cap now names its own font.

That also replaces the site-side `.prose [data-component='kbd']` counter-rule from #532 with the more general fix: live demo previews are excluded from prose typography, because prose rules are for markdown-authored content. No future component needs its own entry there now.

Verified on the built site: demo keycaps sans, demo source snippets and prose code still mono.

## One platform predicate, not two

`dialog.gts` had a byte-for-byte copy of `isApplePlatform`. Worse, it sniffed the machine directly while `Kbd` honours `setKbdPlatform` — so an app that pinned the platform could label a shortcut `⌘K` while the matcher listened for `Ctrl+K`. It now resolves through `resolveKbdPlatform`, so what is printed and what is matched cannot disagree.

## `@cached` on the two hot getters

`classNames` re-ran `useStyles()` and resolved all 21 compound variants on **every** template access — six times for a three-key shortcut, and once per row in an adopted Dropdown or Command list. Follows the existing pattern in `command.gts`, `list.gts` and `table.gts`.

## Dropped the `RenderedKey` wrapper

It existed only to mark "not the first key". `{{#each}}` already yields the index and `0` is falsy. Removes a type, a getter and an allocation per key.

## Comments

Deleted ones that restate the code, narrate the change's history ("no longer needs…"), or repeat a rationale already stated at its source. Kept the ones explaining a non-obvious constraint — why `detected` is untracked, why the prose rule is scoped, why `font-label` over `font-code`.

## Considered and skipped

- **Factoring the 21 intent×appearance compound variants.** Tailwind scans source text, so interpolated class names generate no CSS. The literal block is required and matches `chip.ts`. The branch still nets negative — keycap styling went from three homes to one.
- **`@shortcutAppearance` prop-drilling.** `@appearance` and `@intent` already drill the same path; this repo has no context provider, so a new mechanism for one arg would be the *less* general change.
- **Unrelated churn in `signature-data.ts`.** It is generated, and regenerating it correctly picks up JSDoc the base branch changed without regenerating.

## Verification

1123 tests pass, 0 failures. `lint:js` 0 errors, `lint:types` clean, docs lint 0 errors, 71/71 site pages prerender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)