### PR TITLE
docs(skill): catch prose tells in the linter, and name the structural ones

### DIFF
--- a/.claude/skills/frontile-docs/SKILL.md
+++ b/.claude/skills/frontile-docs/SKILL.md
@@ -129,8 +129,13 @@ This drifts in during review. A reviewer challenges a claim, the claim gets corr
 the correction's *reasoning* is left in the prose — so the page ends up arguing with an
 earlier version of itself. Cut the argument and keep the corrected fact.
 
-Tells, all of which came out of one page:
+Tells, starting with the one to learn first — it is the highest-yield, and the only one
+that survives review by looking like documentation:
 
+- **A section that announces itself as mechanism or justification** — `**How it works:**`
+  followed by numbered internal steps, `**Benefits of X:**`, a callout headed `**Why is
+  @isFoo true by default?**`. The word-level tells below would not catch any of these,
+  and an audit of the 36 component pages found five.
 - **Defensive contrasts** — "genuinely", "rather than", "not fatal", "it is X only", "the
   exception is". They rebut a claim the reader never made.
 - **Internal vocabulary** — "fake caret", "the mirror", a class or method name used as if
@@ -159,8 +164,22 @@ rule is rejected whole rather than stripped.
 **The test: does this change what the reader writes or expects to see? Keep it. Does it
 explain why the implementation is the way it is, or how someone checked it? Cut it.**
 
-When auditing an existing page, read for these tells the way you'd read for a wrong class
-name — they accumulate silently and no linter catches them.
+### Cutting rationale can delete the only statement of a fact
+
+Rationale is often fused to the fact it defends, and the fact appears nowhere else on the
+page — a "Why is this the default?" callout is also the only place the default's *effect*
+is described. Delete it cleanly and the page silently loses information while the diff
+looks like pure subtraction.
+
+So restate before you cut: write the behaviour as a plain sentence, check it stands without
+the surrounding argument, and only then remove the original. Four of the fifteen passages
+cut in the first pass needed this — the rest were deletions.
+
+When auditing, start with `lint-docs.mjs`, which flags the greppable subset of these as
+warnings — never errors, since every one needs a human call. It caught 31 of these across
+the pages before the first cleanup, including all five structural tells. Then read the
+prose anyway: implementation rationale written in ordinary words matches no pattern, and
+that is most of the category.
 
 ## Shortening a doc
 
@@ -216,7 +235,8 @@ Zero dependencies, so it runs without `node_modules`, and it exits non-zero on e
 CI. It covers required sections, fence languages, `<Signature>` wiring including tags naming
 a component that doesn't exist, arguments used in demos that aren't in the signature,
 arguments missing the JSDoc that fills the API table, numbered color utilities, raw palette
-classes, inline `<svg>`, and — with `--since` — runnable demos removed since a git ref.
+classes, inline `<svg>`, prose tells from *Write for the reader, not the reviewer*, and —
+with `--since` — runnable demos removed since a git ref.
 
 Demo loss warns, and errors only when more than a third of the page's demos are gone. A
 warning isn't a verdict: removing one demo of seven is often real cleanup. It's a prompt to
@@ -231,9 +251,15 @@ cd site && pnpm build
 
 If that didn't run, say the demos are unverified rather than implying they were checked.
 
-Neither check reads prose. When reviewing or auditing a page, do that pass yourself: scan
-for the tells in *Write for the reader, not the reviewer* and report each one with the
+Prose tells warn and never error, because each one is a judgement call — "move focus
+somewhere deliberate" is a legitimate instruction that matches the *defensive contrast*
+pattern. Triage each, and read for the ones no pattern can catch. Report each with the
 sentence it's in.
+
+When the site build isn't available — a worktree with no `node_modules`, say — a prose-only
+change has a cheap proxy: compare fence counts against the base ref. Identical counts in
+every file mean no demo was touched, so nothing the build would have checked has changed.
+Say which check you ran; don't let the proxy pass for the build.
 
 ## Repo facts
 

--- a/.claude/skills/frontile-docs/scripts/lint-docs.mjs
+++ b/.claude/skills/frontile-docs/scripts/lint-docs.mjs
@@ -39,6 +39,44 @@ const DISCOURAGED_HEADINGS = {
   'Important Notes': 'move each note next to the thing it describes',
   'Best Practices': 'move guidance into the section it applies to'
 };
+// Prose that argues with the reader instead of informing them — see the
+// "Write for the reader, not the reviewer" section of SKILL.md. Every one of
+// these is a `warn`, never an error: each is a prompt to reread the sentence,
+// not a verdict. "Move focus somewhere deliberate" is a legitimate instruction
+// and will match `deliberate`; the reviewer is expected to wave it through.
+const PROSE_TELLS = [
+  {
+    // Structural tells. A paragraph or heading that announces itself as
+    // mechanism or justification, e.g. `**How it works:**`, `**Benefits of
+    // input validation:**`, `> **Why is @isFoo true by default?**`. These
+    // survive review because they look like documentation, and they were the
+    // highest-yield findings of the first audit — none of the word-level
+    // patterns below would have caught one.
+    re: /^\s*>?\s*\**\s*(?:How it works|Benefits of\b|Why (?:is|are|does|do)\b[^\n]*\?)/i,
+    message: 'Section explains mechanism or justifies a decision',
+    hint: 'document what it does; why it was built this way belongs in the code or the PR'
+  },
+  {
+    re: /\b(?:deliberate|deliberately|genuinely|not fatal)\b/,
+    message: 'Defensive contrast',
+    hint: 'rebuts a claim the reader never made — state the behaviour on its own'
+  },
+  {
+    re: /\bworth knowing\b/,
+    message: 'Throat-clearing before content that stands on its own',
+    hint: 'drop the preamble and lead with the fact'
+  },
+  {
+    re: /\b(?:covered by tests|the tests cover|comes? from reading|a headless browser|needs a real device)\b/i,
+    message: 'Verification narration',
+    hint: 'how a claim was checked belongs in the PR, not on the page'
+  },
+  {
+    re: /\bcompiled out of production\b|\b(?:development|dev) and production\b/i,
+    message: 'Environment reasoning',
+    hint: 'cut unless the consumer actually observes the difference'
+  }
+];
 const SEMANTIC_CATEGORIES =
   'neutral|primary|secondary|tertiary|success|warning|danger|inverse|surface';
 const UTILITY_PREFIXES =
@@ -300,6 +338,24 @@ function lintDoc(mdPath) {
     if (advice && h.depth <= 3)
       add('warn', h.line, `Heading \`${h.text}\``, advice);
   }
+
+  // --- Prose that argues instead of informing -----------------------------
+  // Only prose: a tell inside a demo is a code comment, which is exactly where
+  // this reasoning is supposed to live.
+  const fenceLines = new Set();
+  for (const fence of collectFences(source)) {
+    for (let n = fence.line; n <= fence.endLine; n++) fenceLines.add(n);
+  }
+  source.split('\n').forEach((line, i) => {
+    const lineNo = i + 1;
+    if (fenceLines.has(lineNo)) return;
+    for (const tell of PROSE_TELLS) {
+      const m = tell.re.exec(line);
+      if (!m) continue;
+      add('warn', lineNo, `${tell.message} — \`${m[0].trim()}\``, tell.hint);
+      break;
+    }
+  });
 
   // --- <Signature> wiring -------------------------------------------------
   const signatureTags = [


### PR DESCRIPTION
Three learnings from applying #538's rule across all 36 component pages in #539.

## 1. The tell list missed its own biggest catches

Every tell in the rule was a *phrase* ("deliberately", "not fatal") because they all came from one page. The highest-yield findings in the audit were **structural** — a section that announces itself as mechanism or justification:

- two `**How it works:**` lists walking through internal methods (`field.md`)
- two `**Benefits of X:**` lists (`field.md`)
- a callout headed `**Why is @closeOnOverlayElementClick true by default?**` (`overlay.md`)

None of the word-level tells would have flagged one. These survive review precisely because they look like documentation. Promoted to the top of the list, where it's marked as the one to learn first.

## 2. Most of this is greppable — the skill claimed it wasn't

The skill said "no linter catches them", and then I ran the audit largely off a grep. Adds `PROSE_TELLS` to `lint-docs.mjs`: the structural shapes above, plus defensive contrasts, throat-clearing, verification narration, and environment reasoning. Prose only — a tell inside a demo is a code comment, which is where this reasoning is supposed to live.

**Warnings, never errors.** `close-button.md`'s "move focus somewhere deliberate" is a legitimate instruction that matches the defensive-contrast pattern, so every hit needs a human call. That's the same posture as the existing demo-loss check.

Measured both directions:

| Tree | Result |
|---|---|
| Pages before the #539 cleanup | **31 hits** — 15 defensive contrasts, 7 throat-clearing, 5 structural, 2 verification narration, 2 environment reasoning. All five structural tells caught, at the right lines. |
| Pages as they stand now | **4 hits** — exactly the borderline cases #539 deliberately kept (`close-button.md` "deliberate", `select.md` "genuinely", modal/drawer "compiled out of production"). |

So it surfaces the judgement calls and stays quiet otherwise. `--json`, `--since` and single-file modes all still work; still zero dependencies.

## 3. Cutting rationale can delete the only statement of a fact

Four of the fifteen passages cut in #539 weren't deletions — the offending passage had a reader-facing fact fused into the justification, stated nowhere else on the page. The "Why is this the default?" callout was also the only description of what the default *does*. Delete it cleanly and the page loses information while the diff looks like pure subtraction.

New short subsection: restate the behaviour as a plain sentence, check it stands without the argument, then remove the original.

## Also

`## Verify` now records the fence-count proxy — when the site build isn't available (a worktree with no `node_modules`), identical fence counts against the base ref prove no demo changed. With the caveat not to let the proxy pass for the build.

No component `.md` files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)