### PR TITLE
Refactor Table keyboard navigation onto rovingFocus

### DIFF
--- a/packages/frontile/src/components/collections/table.md
+++ b/packages/frontile/src/components/collections/table.md
@@ -1205,16 +1205,26 @@ export default class DemoComponent extends Component {
 When selection is enabled, rows follow the WAI-ARIA grid pattern:
 
 - **Tab**: Moves into the rows. The table is a single tab stop — it uses a
-  roving `tabindex`, so exactly one row is tabbable at a time. That is the first
-  selected row, or the first row when nothing is selected.
+  roving `tabindex`, so exactly one row is tabbable at a time. That is the row
+  focus was last on, else the first selected row, else the first row.
 - **Arrow Down** / **Arrow Up**: Move focus between rows, carrying the
-  `tabindex="0"` along with focus.
+  `tabindex="0"` along with focus. Focus wraps: down past the last row lands on
+  the first, up past the first lands on the last.
+- **Home** / **End**: Move focus to the first / last row.
 - **Space** or **Enter**: Toggle selection (multiple mode) or select row (single mode)
-- Disabled rows cannot be selected via keyboard, but can still be focused
+- Disabled rows (`@disabledKeys`) are marked `aria-disabled="true"`. Arrow keys,
+  `Home` and `End` skip them entirely, and they never hold the tab stop — a
+  table whose first row is disabled hands it to the first enabled row instead.
+  They can still be focused with the pointer, but not selected.
+- Rows added, removed or reordered are picked up on their own; the tab stop and
+  the navigation order always follow what is rendered.
 - Interactive content inside cells keeps its own keys: a button, link or input in
   a cell handles Enter, Space and the arrow keys itself, and the row does not
   toggle its selection. Row keyboard handling only applies to keys pressed on the
   row itself.
+
+This is the shared [`rovingFocus`](/docs/components/utilities/roving-focus) utility in vertical,
+manual-activation mode — arrows move focus only, and selection waits for Space or Enter.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -1342,6 +1352,7 @@ On top of that:
 | Sort control        | A real `<button>` inside the header, so it is focusable and activates on `Enter` and `Space` |
 | Sort direction icon | `aria-hidden="true"` — the chevron is decoration, `aria-sort` carries the meaning            |
 | Row selection       | A checkbox per row labelled "Select row", and "Select all rows" in the header                |
+| Disabled row        | `aria-disabled="true"`, which is also what keyboard navigation reads to skip it              |
 | Skeleton rows       | `aria-hidden="true"` while loading, so placeholder rows are not announced as data            |
 
 `aria-sort` is present on every header cell, including non-sortable ones, where it reads

--- a/packages/frontile/src/components/collections/table/table.gts
+++ b/packages/frontile/src/components/collections/table/table.gts
@@ -8,6 +8,7 @@ import { cached } from '@glimmer/tracking';
 import { SimpleTable } from '../simple-table';
 import { extractFrontileOptions } from './utils';
 import { keyAndLabelForItem } from '../../../utils/listManager';
+import { rovingFocus, type RovingFocus } from '../../../utils/roving-focus';
 import ColumnVisibilityComponent from './column-visibility';
 import CellForComponent from './cell-for';
 import CellDefaultComponent from './cell-default';
@@ -298,10 +299,30 @@ class Table<
     return keys ? new Set(keys) : new Set();
   }
 
-  // Roving tabindex (WAI-ARIA grid pattern): the key of the row the user last
-  // moved to with the keyboard. `undefined` until they move — see
-  // `rovingRowKey` for the default tab stop.
-  @tracked activeRowKey?: string;
+  // Roving tabindex (WAI-ARIA grid pattern). The rows declare their own
+  // selected and disabled state as attributes, so `rovingFocus` reads both off
+  // the elements and owns arrow keys, Home/End, wrapping, the single tab stop,
+  // and keeping all of it right as rows come and go.
+  //
+  // `manual` activation: arrows move focus only, and selection waits for
+  // Space or Enter, which is what a grid does — a multi-select table that
+  // selected every row you arrowed past would be unusable.
+  roving = rovingFocus(() => ({
+    orientation: 'vertical' as const,
+    activationMode: 'manual' as const,
+    onActivate: this.toggleRowSelection
+  }));
+
+  // Rows are only in the tab order when there is something to select, so the
+  // modifier itself is swapped out rather than gated inside. A no-op modifier
+  // rather than a falsy value keeps this a plain dynamic-modifier value.
+  noopRowSetup: RovingFocus['setupItem'] = modifier(
+    (_element: HTMLElement) => {}
+  );
+
+  get setupRow(): RovingFocus['setupItem'] {
+    return this.hasSelection ? this.roving.setupItem : this.noopRowSetup;
+  }
 
   // Extract actual data from row (handles both row.data and direct row)
   getRowData = (row: Row<T>): T => {
@@ -332,31 +353,6 @@ class Table<
       // Final fallback
       return String(item);
     }
-  };
-
-  // The single row that owns the table's tab stop. Defaults to the first
-  // selected row - so tabbing back into the table lands on the user's own
-  // selection - and to the first row when nothing is selected.
-  @cached
-  get rovingRowKey(): string | undefined {
-    // Key off the same `Row` objects the template iterates, so this and
-    // `rowTabIndex` always agree. Mapping `sortedItems` instead would diverge
-    // for an item carrying both `data` and `table`, which `getRowData` unwraps
-    // — leaving the table with no tab stop at all.
-    const keys = [...this.headlessRows].map((row) => this.getKey(row));
-
-    if (this.activeRowKey !== undefined && keys.includes(this.activeRowKey)) {
-      return this.activeRowKey;
-    }
-
-    return keys.find((key) => this.selectedKeysSet.has(key)) ?? keys[0];
-  }
-
-  // Only one row is tabbable at a time; arrow keys move the tab stop along
-  // with focus. Without selection, rows are not part of the tab order at all.
-  rowTabIndex = (row: Row<T>): string => {
-    if (!this.hasSelection) return '-1';
-    return this.getKey(row) === this.rovingRowKey ? '0' : '-1';
   };
 
   // Check if a key is disabled
@@ -425,84 +421,23 @@ class Table<
     }
   };
 
-  // Handler for keyboard row selection and navigation
-  handleRowKeydown = (row: Row<T>, event: KeyboardEvent): void => {
-    if (!this.hasSelection) return;
-
-    // Only react to keys pressed on the row itself. Anything bubbling up from
-    // interactive cell content (buttons, links, inputs) belongs to that
-    // control, not to the row.
-    if (event.target !== event.currentTarget) return;
-
-    // Handle arrow key navigation
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-
-      const currentElement = event.target as HTMLElement;
-      const allRows = Array.from(
-        currentElement
-          .closest('tbody')
-          ?.querySelectorAll('[data-selectable="true"]') || []
-      ) as HTMLElement[];
-
-      const currentIndex = allRows.indexOf(currentElement);
-      let nextRow: HTMLElement | undefined;
-
-      if (event.key === 'ArrowDown' && currentIndex < allRows.length - 1) {
-        nextRow = allRows[currentIndex + 1];
-      } else if (event.key === 'ArrowUp' && currentIndex > 0) {
-        nextRow = allRows[currentIndex - 1];
-      }
-
-      if (nextRow) {
-        nextRow.focus();
-        // Keep the roving tab stop on the focused row.
-        this.activeRowKey = nextRow.dataset['key'];
-      }
-
-      return;
-    }
-
-    // Handle selection (Space/Enter)
-    if (this.isRowDisabled(row)) return;
-
-    // Only handle Space and Enter keys
-    if (event.key !== ' ' && event.key !== 'Enter') return;
-
-    // Prevent default behavior (scroll for Space, form submission for Enter)
-    event.preventDefault();
-
-    const key = this.getKey(row.data);
-    const isSelected = this.isRowSelected(row);
-
-    // This row is focused, so it keeps the tab stop even as selection changes.
-    this.activeRowKey = key;
+  // What Space and Enter do on a focused row, via `rovingFocus`'s manual
+  // activation. The row is identified by its own `data-key` rather than by a
+  // captured `Row`, because that is the only thing the roving-focus primitive
+  // hands back — and it is the same key the rest of selection speaks in.
+  toggleRowSelection = (element: HTMLElement): void => {
+    const key = element.dataset['key'];
+    if (key === undefined || this.isKeyDisabled(key)) return;
 
     if (this.selectionMode === 'single') {
       // Single selection: always select the row
       this.handleSelect(key);
+    } else if (this.selectedKeysSet.has(key)) {
+      this.handleDeselect(key);
     } else {
-      // Multiple selection: toggle
-      if (isSelected) {
-        this.handleDeselect(key);
-      } else {
-        this.handleSelect(key);
-      }
+      this.handleSelect(key);
     }
   };
-
-  // Modifier for row keyboard navigation
-  rowKeyboardHandler = modifier((element: HTMLElement, [row]: [Row<T>]) => {
-    const handler = (event: KeyboardEvent) => {
-      this.handleRowKeydown(row, event);
-    };
-
-    element.addEventListener('keydown', handler);
-
-    return () => {
-      element.removeEventListener('keydown', handler);
-    };
-  });
 
   // Get all selectable (non-disabled) item keys
   get selectableKeys(): string[] {
@@ -824,14 +759,14 @@ class Table<
           {{#each this.headlessRows as |row|}}
             <t.Row
               {{this.tableInstance.modifiers.row row}}
-              {{this.rowKeyboardHandler row}}
+              {{this.setupRow}}
               @isSticky={{this.isRowSticky row}}
               @hasStickyHeader={{@isStickyHeader}}
               data-key={{this.getKey row}}
               data-selected={{if (this.isRowSelected row) "true" "false"}}
               data-disabled={{if (this.isRowDisabled row) "true"}}
+              aria-disabled={{if (this.isRowDisabled row) "true"}}
               data-selectable={{if this.hasSelection "true"}}
-              tabindex={{this.rowTabIndex row}}
             >
               {{#each this.headlessColumns as |column|}}
                 <t.Cell

--- a/packages/frontile/src/components/collections/table/table.gts
+++ b/packages/frontile/src/components/collections/table/table.gts
@@ -401,19 +401,25 @@ class Table<
     this.args.onSelectionChange?.(newSelection);
   };
 
+  // Every row-level path below keys off the `Row`, never off `row.data`.
+  // `getRowData`'s unwrap check is structural, so handing it `row.data` for an
+  // item that itself carries `data` and `table` unwraps a second time and
+  // yields a different key from the one rendered into `data-key` — which is
+  // what keyboard selection reads back.
+
   // Check if a row is selected
   isRowSelected = (row: Row<T>): boolean => {
-    return this.selectedKeysSet.has(this.getKey(row.data));
+    return this.selectedKeysSet.has(this.getKey(row));
   };
 
   // Check if a row is disabled
   isRowDisabled = (row: Row<T>): boolean => {
-    return this.isKeyDisabled(this.getKey(row.data));
+    return this.isKeyDisabled(this.getKey(row));
   };
 
   // Handler for row checkbox change
   handleRowSelectionChange = (row: Row<T>, checked: boolean): void => {
-    const key = this.getKey(row.data);
+    const key = this.getKey(row);
     if (checked) {
       this.handleSelect(key);
     } else {
@@ -441,9 +447,11 @@ class Table<
 
   // Get all selectable (non-disabled) item keys
   get selectableKeys(): string[] {
-    const items = this.args.items || [];
-    return items
-      .map((item) => this.getKey(item))
+    // Derived from the rendered rows rather than `@items` for the same reason
+    // as the row helpers above: only a `Row` keys the same way `data-key`
+    // does, so select-all and per-row selection speak one vocabulary.
+    return [...this.headlessRows]
+      .map((row) => this.getKey(row))
       .filter((key) => !this.isKeyDisabled(key));
   }
 

--- a/packages/frontile/src/utils/roving-focus.md
+++ b/packages/frontile/src/utils/roving-focus.md
@@ -9,7 +9,8 @@ ARIA authoring practices ask for: the group is a **single tab stop**, and once
 focus is inside it the arrow keys move between the items. It owns the keyboard
 and the `tabindex` bookkeeping only — it renders nothing, decides nothing about
 selection, and applies no styling — which is what lets one primitive serve
-`SegmentedControl`'s radiogroup today and a future `Tabs` unchanged.
+`SegmentedControl`'s radiogroup and `Table`'s selectable rows today, and a
+future `Tabs` unchanged.
 
 ## Import
 
@@ -101,6 +102,12 @@ navigation order is computed from the enabled items alone, so wrapping and
 `Home`/`End` land on real targets. Any handled key calls `preventDefault()`;
 anything else is left to the browser.
 
+Keys are only handled when they are pressed on the item **itself**. An item is
+not always a leaf — a grid row holds real controls — and a key pressed on a
+button, link or input inside one belongs to that control. Without this, typing
+in a cell would move the row focus and `Enter` on a nested button would activate
+the row instead.
+
 ## Activation modes
 
 `automatic` — the default, and what the radiogroup pattern requires — moves
@@ -125,11 +132,18 @@ or changes state. Because both facts are read from the element rather than
 passed in, nothing re-runs the modifier when they change — so each item is
 watched for changes to those attributes, and the tab stop hands off on its own.
 
-The tab stop is the selected item — unless nothing is selected, or the selected
-item is disabled, in which case it is the **first enabled item**. That fallback
-is not incidental: a radiogroup with no selection still has to be reachable by
-`Tab`, and without it a fresh group with nothing chosen would have no tab stop
-at all and would be skipped over entirely by keyboard users.
+The tab stop is where focus last was, else the selected item, else the **first
+enabled item**. That last fallback is not incidental: a radiogroup with no
+selection still has to be reachable by `Tab`, and without it a fresh group with
+nothing chosen would have no tab stop at all and would be skipped over entirely
+by keyboard users.
+
+Focus comes ahead of selection because the two only disagree when activation
+does not follow focus — a `manual` group, or one where several items are
+selected at once. There the selected item is not where the user is, and sending
+`Tab` back to it would undo their navigation. Focus is tracked with `focusin`
+rather than `focus`, so focus landing on a control *inside* an item still puts
+that item in play.
 
 A group in which every item is disabled has no tab stop, which is the correct
 outcome — there is nothing there to operate.

--- a/packages/frontile/src/utils/roving-focus.ts
+++ b/packages/frontile/src/utils/roving-focus.ts
@@ -50,6 +50,7 @@ const DISABLED_SELECTOR = ':disabled, [aria-disabled="true"]';
  */
 class RovingFocus {
   #items: HTMLElement[] = [];
+  #focused: HTMLElement | undefined;
   #observers = new Map<HTMLElement, MutationObserver>();
   #readOptions: () => RovingFocusOptions;
 
@@ -65,6 +66,7 @@ class RovingFocus {
   setupItem = modifier((element: HTMLElement) => {
     this.#register(element);
     element.addEventListener('keydown', this.handleKeydown);
+    element.addEventListener('focusin', this.handleFocusIn);
 
     // Navigation reads the DOM live, so it never goes stale. The tab stop is a
     // written attribute though, and nothing re-runs this modifier when the
@@ -86,16 +88,42 @@ class RovingFocus {
 
     return (): void => {
       element.removeEventListener('keydown', this.handleKeydown);
+      element.removeEventListener('focusin', this.handleFocusIn);
       this.#observers.get(element)?.disconnect();
       this.#observers.delete(element);
       this.#items = this.#items.filter((item) => item !== element);
+      if (this.#focused === element) {
+        this.#focused = undefined;
+      }
       this.#syncTabStops();
     };
   });
 
+  /**
+   * The tab stop belongs wherever focus last was, so that leaving the group
+   * and coming back returns the user to where they left off. `focusin` rather
+   * than `focus` because an item is not always a leaf -- a grid row holds real
+   * controls, and focus landing on one of them still puts the row in play.
+   */
+  handleFocusIn = (event: FocusEvent): void => {
+    const item = event.currentTarget as HTMLElement | null;
+    if (!item || this.#focused === item) {
+      return;
+    }
+    this.#focused = item;
+    this.#syncTabStops();
+  };
+
   handleKeydown = (event: KeyboardEvent): void => {
     const current = event.currentTarget as HTMLElement | null;
     if (!current) {
+      return;
+    }
+
+    // An item is not necessarily a leaf. A key pressed on a button, link or
+    // input *inside* one belongs to that control -- taking it would break
+    // typing in a cell and swallow Enter on a nested button.
+    if (event.target !== current) {
       return;
     }
 
@@ -182,18 +210,39 @@ class RovingFocus {
   }
 
   /**
-   * Exactly one item is tabbable. It is the selected one, or -- per the
-   * radiogroup pattern, where a group with nothing selected still has to be
-   * reachable by Tab -- the first enabled item.
+   * Exactly one item is tabbable. It is wherever focus last was, else the
+   * selected one, else -- per the radiogroup pattern, where a group with
+   * nothing selected still has to be reachable by Tab -- the first enabled
+   * item.
+   *
+   * Focus comes first because the two only disagree when activation does not
+   * follow focus: a `manual` group, or one whose selection is several items
+   * at once. There the selected item is not where the user is, and sending
+   * Tab back to it would undo their navigation.
    */
   #syncTabStops(): void {
+    const focused =
+      this.#focused &&
+      this.#items.includes(this.#focused) &&
+      !this.#isDisabled(this.#focused)
+        ? this.#focused
+        : undefined;
+
     const selected = this.#items.find(
       (item) => item.matches(SELECTED_SELECTOR) && !this.#isDisabled(item)
     );
-    const stop = selected ?? this.#enabled[0];
+    const stop = focused ?? selected ?? this.#enabled[0];
 
     for (const item of this.#items) {
-      item.tabIndex = item === stop ? 0 : -1;
+      const tabIndex = item === stop ? 0 : -1;
+      // Compared against the *attribute*, not the property: an element that is
+      // not natively focusable already reports `tabIndex === -1` with no
+      // attribute set, so a property comparison would skip the very write that
+      // makes it focusable. Guarded at all because this runs once per item as
+      // a group registers -- O(n²) writes for a table's worth of rows.
+      if (item.getAttribute('tabindex') !== String(tabIndex)) {
+        item.tabIndex = tabIndex;
+      }
     }
   }
 }

--- a/test-app/tests/integration/components/collections/table-keyboard-test.gts
+++ b/test-app/tests/integration/components/collections/table-keyboard-test.gts
@@ -1,0 +1,257 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import {
+  render,
+  settled,
+  focus,
+  triggerKeyEvent,
+  findAll
+} from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
+import { Table, type ColumnConfig } from 'frontile';
+
+const array = <T,>(...args: T[]): T[] => args;
+
+interface TestItem {
+  id: string;
+  name: string;
+}
+
+const columns = [
+  { key: 'id', name: 'ID' },
+  { key: 'name', name: 'Name' }
+] as const satisfies ColumnConfig<TestItem>[];
+
+const rowFor = (key: string): HTMLElement =>
+  document.querySelector<HTMLElement>(
+    `[data-test-id="table-row"][data-key="${key}"]`
+  ) as HTMLElement;
+
+const rowKeys = (): (string | undefined)[] =>
+  findAll('[data-test-id="table-row"]').map(
+    (row) => (row as HTMLElement).dataset['key']
+  );
+
+const tabbableKeys = (): (string | undefined)[] =>
+  findAll('[data-test-id="table-row"][tabindex="0"]').map(
+    (row) => (row as HTMLElement).dataset['key']
+  );
+
+class State {
+  @tracked items: TestItem[];
+
+  constructor(items: TestItem[]) {
+    this.items = items;
+  }
+}
+
+const threeItems = (): TestItem[] => [
+  { id: '1', name: 'John Doe' },
+  { id: '2', name: 'Jane Smith' },
+  { id: '3', name: 'Bob Wilson' }
+];
+
+module(
+  'Integration | Component | Table | Keyboard | @frontile/collections',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('Home and End jump to the first and last row', async function (assert) {
+      const items = threeItems();
+
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{items}}
+            @selectionMode="multiple"
+          />
+        </template>
+      );
+
+      await focus(rowFor('2'));
+
+      await triggerKeyEvent(rowFor('2'), 'keydown', 'End');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('3'),
+        'End moves to the last row'
+      );
+
+      await triggerKeyEvent(rowFor('3'), 'keydown', 'Home');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('1'),
+        'Home moves to the first row'
+      );
+    });
+
+    test('arrow navigation wraps at both ends', async function (assert) {
+      const items = threeItems();
+
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{items}}
+            @selectionMode="multiple"
+          />
+        </template>
+      );
+
+      await focus(rowFor('3'));
+      await triggerKeyEvent(rowFor('3'), 'keydown', 'ArrowDown');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('1'),
+        'ArrowDown past the last row wraps to the first'
+      );
+
+      await triggerKeyEvent(rowFor('1'), 'keydown', 'ArrowUp');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('3'),
+        'ArrowUp past the first row wraps to the last'
+      );
+    });
+
+    test('arrow navigation skips disabled rows', async function (assert) {
+      const items = threeItems();
+
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{items}}
+            @selectionMode="multiple"
+            @disabledKeys={{array "2"}}
+          />
+        </template>
+      );
+
+      await focus(rowFor('1'));
+      await triggerKeyEvent(rowFor('1'), 'keydown', 'ArrowDown');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('3'),
+        'the disabled middle row is stepped over'
+      );
+
+      await triggerKeyEvent(rowFor('3'), 'keydown', 'ArrowUp');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('1'),
+        'and stepped over on the way back'
+      );
+    });
+
+    test('a disabled first row does not own the tab stop', async function (assert) {
+      const items = threeItems();
+
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{items}}
+            @selectionMode="multiple"
+            @disabledKeys={{array "1"}}
+          />
+        </template>
+      );
+
+      assert.deepEqual(
+        tabbableKeys(),
+        ['2'],
+        'the tab stop falls through to the first enabled row'
+      );
+    });
+
+    test('the tab stop survives the row holding it being removed', async function (assert) {
+      const state = new State(threeItems());
+
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{state.items}}
+            @selectionMode="multiple"
+          />
+        </template>
+      );
+
+      assert.deepEqual(tabbableKeys(), ['1'], 'the first row starts tabbable');
+
+      await focus(rowFor('2'));
+      await triggerKeyEvent(rowFor('2'), 'keydown', 'ArrowDown');
+      assert.deepEqual(tabbableKeys(), ['3'], 'the tab stop follows focus');
+
+      state.items = state.items.filter((item) => item.id !== '3');
+      await settled();
+
+      assert.deepEqual(
+        tabbableKeys(),
+        ['1'],
+        'removing the row that held the tab stop leaves exactly one behind'
+      );
+    });
+
+    test('a newly added row joins the navigation order', async function (assert) {
+      const state = new State(threeItems());
+
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{state.items}}
+            @selectionMode="multiple"
+          />
+        </template>
+      );
+
+      state.items = [...state.items, { id: '4', name: 'Ada Lovelace' }];
+      await settled();
+
+      await focus(rowFor('3'));
+      await triggerKeyEvent(rowFor('3'), 'keydown', 'ArrowDown');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('4'),
+        'ArrowDown reaches the row added after render'
+      );
+
+      await triggerKeyEvent(rowFor('4'), 'keydown', 'ArrowDown');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('1'),
+        'and wrapping accounts for it'
+      );
+    });
+
+    test('reordered rows are navigated in the order they are rendered', async function (assert) {
+      const state = new State(threeItems());
+
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{state.items}}
+            @selectionMode="multiple"
+          />
+        </template>
+      );
+
+      state.items = [state.items[2]!, state.items[0]!, state.items[1]!];
+      await settled();
+
+      assert.deepEqual(rowKeys(), ['3', '1', '2'], 'the rows moved');
+
+      await focus(rowFor('3'));
+      await triggerKeyEvent(rowFor('3'), 'keydown', 'ArrowDown');
+      assert.strictEqual(
+        document.activeElement,
+        rowFor('1'),
+        'ArrowDown follows document order, not registration order'
+      );
+    });
+  }
+);

--- a/test-app/tests/integration/components/collections/table-selection-test.gts
+++ b/test-app/tests/integration/components/collections/table-selection-test.gts
@@ -1285,5 +1285,113 @@ module(
           'the table keeps exactly one tab stop for items shaped like rows'
         );
     });
+    test('keyboard selection uses the same key as the rendered row, for items shaped like rows', async function (assert) {
+      // `getRowData`'s unwrap check is structural, so a plain item carrying
+      // both `data` and `table` is unwrapped as though it were a row. Every
+      // path that names a row has to agree on which key that produces, or
+      // selecting by keyboard writes a key nothing else recognises.
+      interface PayloadItem {
+        id: string;
+        name: string;
+        data: string;
+        table: string;
+      }
+
+      const columns = [
+        { key: 'id', name: 'ID' },
+        { key: 'name', name: 'Name' }
+      ] as const satisfies ColumnConfig<PayloadItem>[];
+
+      const items: PayloadItem[] = [
+        { id: '1', name: 'John Doe', data: 'payload-1', table: 'users' },
+        { id: '2', name: 'Jane Smith', data: 'payload-2', table: 'users' }
+      ];
+
+      let capturedKeys: Set<string> | undefined;
+      const onSelectionChange = (keys: Set<string>): void => {
+        capturedKeys = keys;
+      };
+
+      // Uncontrolled, so the table keeps its own selection and the callback is
+      // free to record exactly which key it was handed.
+      await render(
+        <template>
+          <Table
+            @columns={{columns}}
+            @items={{items}}
+            @selectionMode="multiple"
+            @onSelectionChange={{onSelectionChange}}
+          />
+        </template>
+      );
+
+      const row1 = this.element.querySelector<HTMLElement>(
+        '[data-test-id="table-row"][data-key="1"]'
+      );
+      await focus(row1!);
+      await triggerKeyEvent(
+        '[data-test-id="table-row"][data-key="1"]',
+        'keydown',
+        ' '
+      );
+
+      assert
+        .dom('[data-test-id="table-row"][data-key="1"]')
+        .hasAttribute(
+          'data-selected',
+          'true',
+          'the row the user pressed Space on reads as selected'
+        );
+      assert.deepEqual(
+        [...(capturedKeys ?? [])],
+        ['1'],
+        'and the reported key is the row key, not the unwrapped payload'
+      );
+    });
+
+    test('select all selects every row for items shaped like rows', async function (assert) {
+      interface PayloadItem {
+        id: string;
+        name: string;
+        data: string;
+        table: string;
+      }
+
+      const columns = [
+        { key: 'id', name: 'ID' },
+        { key: 'name', name: 'Name' }
+      ] as const satisfies ColumnConfig<PayloadItem>[];
+
+      const items: PayloadItem[] = [
+        { id: '1', name: 'John Doe', data: 'payload-1', table: 'users' },
+        { id: '2', name: 'Jane Smith', data: 'payload-2', table: 'users' }
+      ];
+
+      await render(
+        <template>
+          <TestHelper as |selectedKeys onSelectionChange|>
+            <Table
+              @columns={{columns}}
+              @items={{items}}
+              @selectionMode="multiple"
+              @selectedKeys={{selectedKeys}}
+              @onSelectionChange={{onSelectionChange}}
+            />
+          </TestHelper>
+        </template>
+      );
+
+      const selectAllCheckbox = this.element.querySelector<HTMLInputElement>(
+        '[data-test-id="table-column"][data-key="__selection__"] input[type="checkbox"]'
+      );
+      await click(selectAllCheckbox!);
+
+      assert
+        .dom('[data-test-id="table-row"][data-key="1"]')
+        .hasAttribute('data-selected', 'true', 'first row selected');
+      assert
+        .dom('[data-test-id="table-row"][data-key="2"]')
+        .hasAttribute('data-selected', 'true', 'second row selected');
+    });
   }
 );

--- a/test-app/tests/integration/components/utilities/roving-focus-test.gts
+++ b/test-app/tests/integration/components/utilities/roving-focus-test.gts
@@ -396,5 +396,79 @@ module(
         'and navigation now skips the newly disabled item'
       );
     });
+    test('the tab stop follows focus, not just selection', async function (assert) {
+      // Manual activation, so selection stays put and the tab stop has to
+      // move on its own. A group whose tab stop lags behind focus sends the
+      // user back to where they started the next time they Tab in.
+      const roving = rovingFocus(() => ({
+        activationMode: 'manual' as const
+      }));
+
+      await render(
+        <template>
+          <div>
+            <button
+              type="button"
+              aria-checked="true"
+              {{roving.setupItem}}
+            >A</button>
+            <button type="button" {{roving.setupItem}}>B</button>
+            <button type="button" {{roving.setupItem}}>C</button>
+          </div>
+        </template>
+      );
+
+      const items = findAll('button') as HTMLButtonElement[];
+      await focus(items[0]!);
+
+      await triggerKeyEvent(items[0]!, 'keydown', 'ArrowRight');
+      assert.deepEqual(
+        items.map((i) => i.tabIndex),
+        [-1, 0, -1],
+        'the tab stop moved to the focused item'
+      );
+
+      await triggerKeyEvent(items[1]!, 'keydown', 'End');
+      assert.deepEqual(
+        items.map((i) => i.tabIndex),
+        [-1, -1, 0],
+        'and follows End too'
+      );
+    });
+
+    test('keys pressed on nested content inside an item are left alone', async function (assert) {
+      // An item is not always a leaf: a grid row holds real controls, and a
+      // key pressed on one of them belongs to that control.
+      const activated: string[] = [];
+      const roving = rovingFocus(() => ({
+        orientation: 'vertical' as const,
+        activationMode: 'manual' as const,
+        onActivate: (el: HTMLElement) => activated.push(el.id)
+      }));
+
+      await render(
+        <template>
+          <div>
+            <div id="a" {{roving.setupItem}}>
+              <button type="button" id="inner">edit</button>
+            </div>
+            <div id="b" {{roving.setupItem}}></div>
+          </div>
+        </template>
+      );
+
+      const inner = document.getElementById('inner') as HTMLButtonElement;
+      await focus(inner);
+
+      await triggerKeyEvent(inner, 'keydown', 'ArrowDown');
+      assert.strictEqual(
+        document.activeElement,
+        inner,
+        'the arrow key did not move focus out of the nested control'
+      );
+
+      await triggerKeyEvent(inner, 'keydown', 'Enter');
+      assert.deepEqual(activated, [], 'and Enter did not activate the item');
+    });
   }
 );


### PR DESCRIPTION
## Summary

`Table` hand-rolled the roving-tabindex behaviour that the `rovingFocus` utility already provides — it queried `[data-selectable="true"]` rows, stepped an index by one, called `.focus()`, and tracked the tab stop in an `activeRowKey`. Its own comment said as much ("Keep the roving tab stop on the focused row"). That covered arrows and nothing else.

This replaces it with one vertical, manual-activation `rovingFocus` instance. `manual` because a multi-select table that selected every row you arrowed past would be unusable.

- Rows lose their `tabindex={{...}}` binding — the utility owns it.
- Rows gain `aria-disabled`, which is how `rovingFocus` sees a disabled row.
- Selection on Space/Enter becomes `onActivate`, keyed off the row's own `data-key`.
- Because rows only belong in the tab order when selection is on, the modifier *value* is swapped (`roving.setupItem` or a no-op) rather than gated inside.

Net: ~110 lines of `handleRowKeydown` / `rowKeyboardHandler` / `activeRowKey` / `rovingRowKey` / `rowTabIndex` deleted.

## Behaviour gained

Each of these was a real keyboard-accessibility gap, and each got a failing test written before the implementation ([`table-keyboard-test.gts`](https://github.com/josemarluedke/frontile/blob/claude/keen-grothendieck-e234b4/test-app/tests/integration/components/collections/table-keyboard-test.gts)):

- `Home` / `End`
- Wrapping at both ends
- Disabled rows skipped by arrow navigation, and never holding the tab stop
- Rows added, removed or reordered picked up on their own

## Two changes to `rovingFocus`

The adoption was not quite free. Table's existing contract exercised parts of the utility `SegmentedControl` never had. Both changes are correct per the ARIA authoring practices rather than Table-specific, and both got their own failing test first:

- **The tab stop now follows focus, ahead of selection.** Tracking only selection works in `automatic` mode, where selection follows focus anyway. In `manual` mode the tab stop would lag behind arrow navigation, breaking Table's existing single-tab-stop test. Tracked via `focusin`, so focus landing on a control *inside* an item still counts.
- **Keys are only handled when pressed on the item itself.** Without a `event.target === currentTarget` guard, a button or input inside a cell would have its Enter and arrow keys swallowed. `SegmentedControl` puts `setupItem` only on a leaf `<button>`, so it never hit this.

One subtlety worth knowing about, in a comment in the code: the redundant-write guard in `#syncTabStops` compares the `tabindex` **attribute**, not the property. A `<tr>` with no attribute already reports `tabIndex === -1`, so a property comparison silently skips the very write that makes the row focusable.

## Out of scope

`ListManager` is deliberately untouched. Autocomplete, Select and Command are comboboxes using **virtual** focus (`aria-activedescendant`, zero `.focus()` calls) because DOM focus must stay in the text input; moving them to real focus would break typing. Extracting the traversal logic the two share is a possible follow-up, not part of this.

## Verification

- Full suite: **1284 pass, 3 pre-existing skips, 0 fail** (`cd test-app && CI=true pnpm ember test`)
- `pnpm lint:js` — 0 errors (88 pre-existing warnings, none in changed files)
- `pnpm --filter frontile lint:types` — clean
- `pnpm lint:hbs` reports 90 errors repo-wide, all pre-existing; the one in `table.gts` (`this.args.classes`, line 694) is unchanged from `main`
- Docs updated: `table.md` keyboard + accessibility tables, `roving-focus.md` for the two contract changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)