### PR TITLE
Set 0.19.0 removal for forms-legacy and changeset-form

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -75,10 +75,10 @@ export default class Example extends Component {
 
 ### Legacy Packages
 
-> **Note:** The following packages are deprecated and will be removed before v1 release:
+> **Note:** The following packages are deprecated and will be removed in 0.19.0. See the [migration guides](/docs/migrations/v0-18/) for details:
 >
-> - `@frontile/changeset-form` - Use `frontile` forms instead
-> - `@frontile/forms-legacy` - Migrate to the new `frontile` forms
+> - [`@frontile/changeset-form`](/docs/migrations/v0-18/changeset-form) - Use `frontile` forms instead
+> - [`@frontile/forms-legacy`](/docs/migrations/v0-18/forms-legacy) - Migrate to the new `frontile` forms
 
 ## Architecture Philosophy
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -24,10 +24,10 @@ import { Button, Input, Modal, Table } from 'frontile';
 
 With modern build tools and explicit imports (`.gts`/`.gjs`), only the components you import will be included in your application bundle through tree-shaking.
 
-> **Note:** The following packages are deprecated and will be removed before v1 release:
+> **Note:** The following packages are deprecated and will be removed in 0.19.0. See the [migration guides](/docs/migrations/v0-18/) for details:
 >
-> - `@frontile/changeset-form` - Use `frontile` forms instead
-> - `@frontile/forms-legacy` - Migrate to the new `frontile` forms
+> - [`@frontile/changeset-form`](/docs/migrations/v0-18/changeset-form) - Use `frontile` forms instead
+> - [`@frontile/forms-legacy`](/docs/migrations/v0-18/forms-legacy) - Migrate to the new `frontile` forms
 >
 > If you're currently using the separate scoped packages (`@frontile/buttons`, `@frontile/forms`, etc.), you can migrate to the consolidated `frontile` package. Simply update your imports:
 >

--- a/docs/migrations/v0.18/changeset-form.md
+++ b/docs/migrations/v0.18/changeset-form.md
@@ -1,10 +1,17 @@
+---
+title: Migrating from Changeset Form
+order: 7
+category: migrations
+subcategory: v0.18
+---
+
 # Migrating from Changeset Form
 
 This guide will help you migrate from the deprecated `@frontile/changeset-form` package to the modern `frontile` forms. We recommend migrating to the modern Form + Field pattern with Valibot validation for the best experience, but also provide paths for teams that need to keep ember-changeset validation.
 
 ## Overview
 
-The `@frontile/changeset-form` package is deprecated and will be removed in future versions. This guide presents three migration paths based on your project's constraints and goals.
+The `@frontile/changeset-form` package is deprecated and will be removed in 0.19.0. This guide presents three migration paths based on your project's constraints and goals.
 
 ## Key Architectural Patterns
 
@@ -12,7 +19,7 @@ The `@frontile/changeset-form` package is deprecated and will be removed in futu
 
 **Standalone components** (Approaches 2 & 3): Use form components directly with manual binding and validation integration.
 
-See the [Form documentation](../forms/) for detailed architecture information.
+See the [Form documentation](https://frontile.dev/docs/components/forms/form) for detailed architecture information.
 
 ## Migration Approach Overview
 
@@ -28,7 +35,7 @@ You have three main migration paths, **ordered by recommendation**:
 
 ## Before You Start
 
-Build the package you'll use: `pnpm --filter forms build` or `pnpm --filter forms-legacy build`
+Build the package you'll use: `pnpm --filter frontile build` (Approaches 1 & 2) or `pnpm --filter forms-legacy build` (Approach 3)
 
 ---
 
@@ -168,7 +175,7 @@ export default class UserFormComponent extends Component {
 }
 ```
 
-For advanced features like dirty tracking, loading states, and validation timing control, see the [Form documentation](../forms/).
+For advanced features like dirty tracking, loading states, and validation timing control, see the [Form documentation](https://frontile.dev/docs/components/forms/form).
 
 ---
 
@@ -423,6 +430,6 @@ Don't mix these patterns in the same form.
 
 ## Additional Resources
 
-- [Form documentation](../forms/) - Complete Form + Field pattern guide
+- [Form documentation](https://frontile.dev/docs/components/forms/form) - Complete Form + Field pattern guide
 - [Forms Legacy Migration Guide](forms-legacy.md) - Component-specific migration details
 - [Valibot documentation](https://valibot.dev/) - Validation schema reference

--- a/docs/migrations/v0.18/forms-legacy.md
+++ b/docs/migrations/v0.18/forms-legacy.md
@@ -1,6 +1,15 @@
+---
+title: Migrating from Forms Legacy
+order: 6
+category: migrations
+subcategory: v0.18
+---
+
 # Migrating from Forms Legacy
 
 This guide will help you migrate from the legacy `@frontile/forms-legacy` package to the modern `frontile` forms. The new forms package provides improved developer experience, better accessibility, enhanced customization options, and reduced external dependencies.
+
+`@frontile/forms-legacy` is deprecated and will be removed in 0.19.0.
 
 ## Overview
 
@@ -110,7 +119,7 @@ export default class LoginForm extends Component {
 - No need to manually manage `@tracked` properties for form data
 - `result.data` contains all form values on submit
 
-For complete documentation on the Form component, validation patterns, nested data, and advanced features, see the [Form Component Documentation](https://frontile.dev/docs/forms/form).
+For complete documentation on the Form component, validation patterns, nested data, and advanced features, see the [Form Component Documentation](https://frontile.dev/docs/components/forms/form).
 
 ## Migrating Validation
 
@@ -236,7 +245,7 @@ export default class UserProfileForm extends Component {
 - Validation runs automatically on blur and submit (configurable with `@validateOn`)
 - Less code overall
 
-For complex validation scenarios or custom validation functions, see the [Form Component Documentation](https://frontile.dev/docs/forms/form).
+For complex validation scenarios or custom validation functions, see the [Form Component Documentation](https://frontile.dev/docs/components/forms/form).
 
 ## Nested Data Support
 
@@ -293,7 +302,7 @@ export default class UserSettingsForm extends Component {
 }
 ```
 
-The Form component automatically handles data flattening and unflattening. On submit, `result.data` will contain the properly nested structure. See the [Form Component Documentation](https://frontile.dev/docs/forms/form) for more details.
+The Form component automatically handles data flattening and unflattening. On submit, `result.data` will contain the properly nested structure. See the [Form Component Documentation](https://frontile.dev/docs/components/forms/form) for more details.
 
 ## Breaking Changes
 
@@ -874,4 +883,4 @@ For form validation patterns, see the [Migrating Validation](#migrating-validati
 
 ---
 
-This migration guide covers the essential changes needed to move from `@frontile/forms-legacy` to `frontile`. The new package provides improved developer experience with better accessibility, flexibility, and maintainability. For detailed Form component documentation, see [frontile.dev/docs/forms/form](https://frontile.dev/docs/forms/form).
+This migration guide covers the essential changes needed to move from `@frontile/forms-legacy` to `frontile`. The new package provides improved developer experience with better accessibility, flexibility, and maintainability. For detailed Form component documentation, see [frontile.dev/docs/forms/form](https://frontile.dev/docs/components/forms/form).

--- a/docs/migrations/v0.18/index.md
+++ b/docs/migrations/v0.18/index.md
@@ -22,6 +22,7 @@ them is optional for the whole 0.18 line.
 | `--frontile-*` variable references | The declaration is dropped | **Silently** |
 | Nested `LayoutTheme` config | Build or type error | Loudly, and only if you customize the theme |
 | `@frontile/*` package imports | Nothing — they still work in 0.18.x | Deprecation warning only |
+| `@frontile/forms-legacy` / `@frontile/changeset-form` | Nothing — they still work in 0.18.x, but are removed in 0.19.0 | Deprecation warning only |
 | Derived border-radius scale | Slightly rounder corners on menus and small marks | Visual only — nothing to fix |
 | Multi-select renders chips | Multi-selects look different — selections become removable chips | Visual only — nothing to fix |
 | Filtered lists are ranked | `Autocomplete`/`Select` list the closest match first instead of source order | Visual only — nothing to fix |
@@ -86,6 +87,19 @@ you can't read — which matters precisely because those changes fail silently.
 **Impact:** none until 0.19. **Time:** 10–30 minutes, mostly automated.
 
 **See:** [Package Consolidation](./package-consolidation.md)
+
+### Forms Legacy & Changeset Form — optional, any time before 0.19
+
+`@frontile/forms-legacy` and `@frontile/changeset-form` are deprecated and,
+unlike the wrapper packages above, are being removed entirely in 0.19.0, not
+just re-exported. If you depend on either, migrate to the modern `frontile`
+forms (Form + Field pattern with Valibot, Zod, or a custom validator).
+
+**Impact:** none until 0.19, unless you already depend on one of these
+packages. **Time:** varies with form count and validation complexity — see
+each guide's migration checklist.
+
+**See:** [Forms Legacy Migration Guide](./forms-legacy.md), [Changeset Form Migration Guide](./changeset-form.md)
 
 ### Filtered lists are ranked by relevance — visual only
 
@@ -168,6 +182,7 @@ for `text-body-pico`, `text-body-nano`, and `text-body-micro`.
 - [ ] `{color}-foreground` / `contrast-*` replaced with `on-{color}-{level}`
 - [ ] **Looked at the running app**, not just the diff
 - [ ] Imports moved to `frontile` (optional until 0.19)
+- [ ] Migrated off `@frontile/forms-legacy` / `@frontile/changeset-form`, if used (required before 0.19)
 - [ ] Looked at any multi-selects — they now render chips and are taller
 - [ ] Replaced `text-body-pico`/`-nano`/`-micro` with `text-body-4xs`/`-3xs`/`-2xs`
 

--- a/docs/migrations/v0.18/package-consolidation.md
+++ b/docs/migrations/v0.18/package-consolidation.md
@@ -181,15 +181,15 @@ echo "Done! Review the changes with: git diff"
 The following packages are **not** part of this consolidation. Their imports remain unchanged:
 
 - **`@frontile/theme`** -- The styling system. Stays as a separate package because it provides Tailwind CSS configuration and has a distinct role in the build pipeline.
-- **`@frontile/forms-legacy`** -- Legacy form components. Will be dropped before v1.0.
-- **`@frontile/changeset-form`** -- Changeset integration. Will be dropped before v1.0.
+- **`@frontile/forms-legacy`** -- Legacy form components. Deprecated, and removed in 0.19.0 alongside the wrapper packages above. See the [Forms Legacy migration guide](./forms-legacy.md).
+- **`@frontile/changeset-form`** -- Changeset integration. Deprecated, and removed in 0.19.0 alongside the wrapper packages above. See the [Changeset Form migration guide](./changeset-form.md).
 
 ## Deprecation Timeline
 
 | Version | Status |
 |---------|--------|
-| **0.18.0** | Old `@frontile/*` packages become thin wrappers that re-export from `frontile`. They emit deprecation warnings at build time. All existing import paths continue to work. |
-| **0.19.0** | Old `@frontile/*` wrapper packages are removed. You must update imports to use `frontile` directly. |
+| **0.18.0** | Old `@frontile/*` packages become thin wrappers that re-export from `frontile`. `@frontile/forms-legacy` and `@frontile/changeset-form` are also marked deprecated. All of them emit deprecation warnings at build time. All existing import paths continue to work. |
+| **0.19.0** | All of the above are removed: the `@frontile/*` wrapper packages, `@frontile/forms-legacy`, and `@frontile/changeset-form`. You must update imports to use `frontile` directly, and migrate off legacy forms and changeset integration. |
 
 During the **0.18.x** cycle, you can migrate at your own pace. Both old and new import paths work simultaneously. However, we recommend migrating sooner rather than later to avoid a last-minute rush before 0.19.0.
 

--- a/packages/changeset-form/src/index.ts
+++ b/packages/changeset-form/src/index.ts
@@ -1,1 +1,17 @@
+import { deprecate } from '@ember/debug';
+
+deprecate(
+  'The "@frontile/changeset-form" package is deprecated and will be removed in 0.19.0. ' +
+    'Migrate to the modern "frontile" forms instead. ' +
+    'See https://frontile.dev/docs/migrations/changeset-form',
+  false,
+  {
+    id: 'frontile.changeset-form',
+    until: '0.19.0',
+    for: 'frontile',
+    since: { available: '0.18.0', enabled: '0.18.0' },
+    url: 'https://frontile.dev/docs/migrations/changeset-form'
+  }
+);
+
 export * from './components/changeset-form';

--- a/packages/forms-legacy/src/index.ts
+++ b/packages/forms-legacy/src/index.ts
@@ -1,3 +1,19 @@
+import { deprecate } from '@ember/debug';
+
+deprecate(
+  'The "@frontile/forms-legacy" package is deprecated and will be removed in 0.19.0. ' +
+    'Migrate to the modern "frontile" forms instead. ' +
+    'See https://frontile.dev/docs/migrations/forms-legacy',
+  false,
+  {
+    id: 'frontile.forms-legacy',
+    until: '0.19.0',
+    for: 'frontile',
+    since: { available: '0.18.0', enabled: '0.18.0' },
+    url: 'https://frontile.dev/docs/migrations/forms-legacy'
+  }
+);
+
 export { default as FormInput } from './components/form-input';
 export { default as FormCheckbox } from './components/form-checkbox';
 export { default as FormCheckboxGroup } from './components/form-checkbox-group';


### PR DESCRIPTION
## Summary
- Adds `deprecate()` warnings to `@frontile/forms-legacy` and `@frontile/changeset-form`, matching the pattern already used by the 0.18 package-consolidation wrappers, with removal pinned to `0.19.0` (both packages emit a build-time warning pointing at their migration guide).
- Moves both packages' migration guides under `docs/migrations/v0.18/` alongside the rest of that release's guides, and updates the v0.18 upgrade overview, package-consolidation guide, and get-started pages to state the `0.19.0` removal instead of the previous vague "before v1.0" language, with links to the guides.
- Content review pass on both migration guides (per the frontile-docs skill): fixed dead links (a relative `../forms/` and a 404'd `frontile.dev/docs/forms/form` — corrected to `/docs/components/forms/form`) and a stale `pnpm --filter forms build` command left over from before the package consolidation.

## Test plan
- [x] `pnpm build` (full monorepo, after a clean reinstall)
- [x] `pnpm --filter @frontile/forms-legacy lint:types` / `lint:js`
- [x] `pnpm --filter @frontile/changeset-form lint:types` / `lint:js`
- [x] `cd test-app && CI=true pnpm ember test --filter="forms-legacy"` — 123 passed
- [x] `cd test-app && CI=true pnpm ember test --filter="changeset-form"` — 31 passed, 3 pre-existing skips
- [x] `cd site && pnpm build` — moved migration guides render at `/docs/migrations/v0-18/forms-legacy` and `/docs/migrations/v0-18/changeset-form`, 75/75 pages rendered