### PR TITLE
feat(button): add @isLoading

### DIFF
--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -1,8 +1,36 @@
 import Component from '@glimmer/component';
 import { hash } from '@ember/helper';
 import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
 import { useStyles } from '@frontile/theme';
 import { press, type PressEvent } from '../../modifiers/press';
+
+/**
+ * Sets `disabled` on the element while `loading` is true, restoring whatever
+ * the consumer had before. This is a modifier rather than a plain attribute
+ * because splattributes are applied last: `disabled={{@isLoading}}` written
+ * before `...attributes` is clobbered by a consumer's own `disabled`, and
+ * written after it a consumer's `disabled={{false}}` would erase ours.
+ * Modifiers run after attributes, so neither ordering problem applies.
+ *
+ * Known limitation: this re-runs only when `loading` changes. If a consumer's
+ * own `disabled` binding flips from true to false while loading is already in
+ * flight, Glimmer rewrites the attribute and we do not re-run, so the button
+ * goes live mid-load. Closing that would need a MutationObserver for a case
+ * nobody has hit.
+ */
+const disableWhile = modifier((el: HTMLButtonElement, [loading]: [boolean]) => {
+  if (!loading) {
+    return;
+  }
+
+  const previous = el.disabled;
+  el.disabled = true;
+
+  return () => {
+    el.disabled = previous;
+  };
+});
 
 export interface ButtonArgs {
   /**
@@ -53,6 +81,13 @@ export interface ButtonArgs {
   isInGroup?: boolean;
 
   /**
+   * Renders a spinner in place of the icon and disables the button.
+   *
+   * @defaultValue false
+   */
+  isLoading?: boolean;
+
+  /**
    * Callback for when the button is pressed.
    */
   onPress?: (event: PressEvent) => void;
@@ -76,6 +111,10 @@ class Button extends Component<ButtonSignature> {
     return 'button';
   }
 
+  get isLoading(): boolean {
+    return this.args.isLoading === true;
+  }
+
   get classNames(): string {
     const { button } = useStyles();
 
@@ -84,6 +123,7 @@ class Button extends Component<ButtonSignature> {
       size: this.args.size,
       appearance: this.args.appearance || 'default',
       isInGroup: this.args.isInGroup,
+      isLoading: this.isLoading,
       class: this.args.class
     });
   }
@@ -105,9 +145,12 @@ class Button extends Component<ButtonSignature> {
       <button
         type={{this.type}}
         class={{this.classNames}}
+        aria-busy={{if this.isLoading "true"}}
+        data-loading={{if this.isLoading "true"}}
         data-pressed={{if this.isPressed "true"}}
         {{press this.onPress onPressChange=this.handlePressChange}}
         ...attributes
+        {{disableWhile this.isLoading}}
       >
         {{yield (hash classNames=this.classNames)}}
       </button>

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
 import { useStyles } from '@frontile/theme';
 import { press, type PressEvent } from '../../modifiers/press';
+import { Spinner } from '../utilities/spinner';
 
 /**
  * Sets `disabled` on the element while `loading` is true, restoring whatever
@@ -128,6 +129,12 @@ class Button extends Component<ButtonSignature> {
     });
   }
 
+  get spinnerClassNames(): string {
+    const { buttonSpinner } = useStyles();
+
+    return buttonSpinner();
+  }
+
   handlePressChange = (isPressed: boolean): void => {
     this.isPressed = isPressed;
   };
@@ -152,6 +159,12 @@ class Button extends Component<ButtonSignature> {
         ...attributes
         {{disableWhile this.isLoading}}
       >
+        {{#if this.isLoading}}
+          <Spinner
+            @class={{this.spinnerClassNames}}
+            data-test-id="loading-spinner"
+          />
+        {{/if}}
         {{yield (hash classNames=this.classNames)}}
       </button>
     {{/if}}

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
 import type { TOC } from '@ember/component/template-only';
 import { useStyles } from '@frontile/theme';
@@ -176,6 +176,7 @@ class Button extends Component<ButtonSignature> {
     return !this.isIconAtEnd;
   }
 
+  @cached
   get classNames(): string {
     const { button } = useStyles();
 
@@ -189,6 +190,7 @@ class Button extends Component<ButtonSignature> {
     });
   }
 
+  @cached
   get spinnerClassNames(): string {
     const { buttonSpinner } = useStyles();
 
@@ -200,6 +202,7 @@ class Button extends Component<ButtonSignature> {
    * place of rendering). Hoisted so the shape is written once — it's part of
    * this component's public contract, asserted on directly by tests.
    */
+  @cached
   get yieldedHash(): { classNames: string; isLoading: boolean } {
     return { classNames: this.classNames, isLoading: this.isLoading };
   }

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { hash } from '@ember/helper';
 import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
+import type { TOC } from '@ember/component/template-only';
 import { useStyles } from '@frontile/theme';
 import { press, type PressEvent } from '../../modifiers/press';
 import { Spinner } from '../utilities/spinner';
@@ -32,6 +33,27 @@ const disableWhile = modifier((el: HTMLButtonElement, [loading]: [boolean]) => {
     el.disabled = previous;
   };
 });
+
+/**
+ * The spinner stands in for the icon while loading, on whichever side
+ * `@iconPlacement` puts it. Extracted so the choice is written once; the
+ * caller passes the icon through as this component's default block.
+ */
+const SpinnerOrIcon: TOC<{
+  Args: {
+    isLoading: boolean;
+    spinnerClass: string;
+  };
+  Blocks: {
+    default: [];
+  };
+}> = <template>
+  {{#if @isLoading}}
+    <Spinner @class={{@spinnerClass}} data-test-id="loading-spinner" />
+  {{else}}
+    {{yield}}
+  {{/if}}
+</template>;
 
 export interface ButtonArgs {
   /**
@@ -89,6 +111,14 @@ export interface ButtonArgs {
   isLoading?: boolean;
 
   /**
+   * Which side the `icon` block — and the loading spinner that replaces it —
+   * sits on.
+   *
+   * @defaultValue 'start'
+   */
+  iconPlacement?: 'start' | 'end';
+
+  /**
    * Callback for when the button is pressed.
    */
   onPress?: (event: PressEvent) => void;
@@ -98,6 +128,7 @@ interface ButtonSignature {
   Args: ButtonArgs;
   Blocks: {
     default: [{ classNames: string }];
+    icon?: [];
   };
   Element: HTMLButtonElement;
 }
@@ -114,6 +145,14 @@ class Button extends Component<ButtonSignature> {
 
   get isLoading(): boolean {
     return this.args.isLoading === true;
+  }
+
+  get isIconAtEnd(): boolean {
+    return this.args.iconPlacement === 'end';
+  }
+
+  get isIconAtStart(): boolean {
+    return !this.isIconAtEnd;
   }
 
   get classNames(): string {
@@ -159,13 +198,25 @@ class Button extends Component<ButtonSignature> {
         ...attributes
         {{disableWhile this.isLoading}}
       >
-        {{#if this.isLoading}}
-          <Spinner
-            @class={{this.spinnerClassNames}}
-            data-test-id="loading-spinner"
-          />
+        {{#if this.isIconAtStart}}
+          <SpinnerOrIcon
+            @isLoading={{this.isLoading}}
+            @spinnerClass={{this.spinnerClassNames}}
+          >
+            {{yield to="icon"}}
+          </SpinnerOrIcon>
         {{/if}}
+
         {{yield (hash classNames=this.classNames)}}
+
+        {{#if this.isIconAtEnd}}
+          <SpinnerOrIcon
+            @isLoading={{this.isLoading}}
+            @spinnerClass={{this.spinnerClassNames}}
+          >
+            {{yield to="icon"}}
+          </SpinnerOrIcon>
+        {{/if}}
       </button>
     {{/if}}
   </template>

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -51,8 +51,13 @@ const disableWhile = modifier((el: HTMLButtonElement, [loading]: [boolean]) => {
 
 /**
  * The spinner stands in for the icon while loading, on whichever side
- * `@iconPlacement` puts it. Extracted so the choice is written once; the
- * caller passes the icon through as this component's default block.
+ * `@iconPlacement` puts it. Extracted so the spinner-or-icon choice is written
+ * once; the caller passes the icon through as this component's default block.
+ *
+ * The invocation below is still written twice, once per side, and that is
+ * deliberate: the block contains `{{yield to="icon"}}`, and Glimmer has no way
+ * to hoist a block-yielding invocation into a `{{#let}}` or a helper. Only the
+ * choice was deduplicated, not the two call sites.
  */
 const SpinnerOrIcon: TOC<{
   Args: {

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -187,10 +187,7 @@ class Button extends Component<ButtonSignature> {
 
   <template>
     {{#if @isRenderless}}
-      {{yield
-        (hash classNames=this.classNames isLoading=this.isLoading)
-        to="default"
-      }}
+      {{yield (hash classNames=this.classNames isLoading=this.isLoading)}}
     {{else}}
       <button
         type={{this.type}}
@@ -215,16 +212,10 @@ class Button extends Component<ButtonSignature> {
           {{#if (has-block "loading")}}
             {{yield to="loading"}}
           {{else}}
-            {{yield
-              (hash classNames=this.classNames isLoading=this.isLoading)
-              to="default"
-            }}
+            {{yield (hash classNames=this.classNames isLoading=this.isLoading)}}
           {{/if}}
         {{else}}
-          {{yield
-            (hash classNames=this.classNames isLoading=this.isLoading)
-            to="default"
-          }}
+          {{yield (hash classNames=this.classNames isLoading=this.isLoading)}}
         {{/if}}
 
         {{#if this.isIconAtEnd}}

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -127,8 +127,9 @@ export interface ButtonArgs {
 interface ButtonSignature {
   Args: ButtonArgs;
   Blocks: {
-    default: [{ classNames: string }];
+    default: [{ classNames: string; isLoading: boolean }];
     icon?: [];
+    loading?: [];
   };
   Element: HTMLButtonElement;
 }
@@ -186,7 +187,10 @@ class Button extends Component<ButtonSignature> {
 
   <template>
     {{#if @isRenderless}}
-      {{yield (hash classNames=this.classNames)}}
+      {{yield
+        (hash classNames=this.classNames isLoading=this.isLoading)
+        to="default"
+      }}
     {{else}}
       <button
         type={{this.type}}
@@ -207,7 +211,21 @@ class Button extends Component<ButtonSignature> {
           </SpinnerOrIcon>
         {{/if}}
 
-        {{yield (hash classNames=this.classNames)}}
+        {{#if this.isLoading}}
+          {{#if (has-block "loading")}}
+            {{yield to="loading"}}
+          {{else}}
+            {{yield
+              (hash classNames=this.classNames isLoading=this.isLoading)
+              to="default"
+            }}
+          {{/if}}
+        {{else}}
+          {{yield
+            (hash classNames=this.classNames isLoading=this.isLoading)
+            to="default"
+          }}
+        {{/if}}
 
         {{#if this.isIconAtEnd}}
           <SpinnerOrIcon

--- a/packages/frontile/src/components/buttons/button.gts
+++ b/packages/frontile/src/components/buttons/button.gts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { hash } from '@ember/helper';
 import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
 import type { TOC } from '@ember/component/template-only';
@@ -15,11 +14,27 @@ import { Spinner } from '../utilities/spinner';
  * written after it a consumer's `disabled={{false}}` would erase ours.
  * Modifiers run after attributes, so neither ordering problem applies.
  *
- * Known limitation: this re-runs only when `loading` changes. If a consumer's
- * own `disabled` binding flips from true to false while loading is already in
- * flight, Glimmer rewrites the attribute and we do not re-run, so the button
- * goes live mid-load. Closing that would need a MutationObserver for a case
- * nobody has hit.
+ * Known limitation: this re-runs only when `loading` changes, so `previous`
+ * is a snapshot taken once at install time — it goes stale if the consumer's
+ * own `disabled` binding changes while loading is already in flight, in
+ * either direction:
+ *
+ * - true → false: Glimmer rewrites the attribute to `false`, we do not
+ *   re-run, so the button stays disabled (from our own `el.disabled = true`)
+ *   until loading ends and teardown restores the stale `previous` (`false`),
+ *   which happens to match — net: the button goes live at the same moment,
+ *   with the disabling outliving the intent for no visible reason.
+ * - false → true: Glimmer rewrites the attribute to `true`, we do not
+ *   re-run, so `previous` is left holding the stale `false`. When loading
+ *   ends, teardown restores `previous` and sets `disabled = false` — the
+ *   button ends up enabled even though the consumer's binding says
+ *   `disabled={{true}}`. This is a fail-open: the consumer's disable is
+ *   silently and indefinitely lost. See the
+ *   `'known limitation: a consumer disable applied mid-load is lost when
+ *   loading ends'` test in buttons-test.gts, which pins this exact case.
+ *
+ * Closing this would need a MutationObserver watching `disabled` for a case
+ * nobody has hit; the project has decided not to add one.
  */
 const disableWhile = modifier((el: HTMLButtonElement, [loading]: [boolean]) => {
   if (!loading) {
@@ -175,6 +190,15 @@ class Button extends Component<ButtonSignature> {
     return buttonSpinner();
   }
 
+  /**
+   * The object yielded to the default block (and, when `@isRenderless`, in
+   * place of rendering). Hoisted so the shape is written once — it's part of
+   * this component's public contract, asserted on directly by tests.
+   */
+  get yieldedHash(): { classNames: string; isLoading: boolean } {
+    return { classNames: this.classNames, isLoading: this.isLoading };
+  }
+
   handlePressChange = (isPressed: boolean): void => {
     this.isPressed = isPressed;
   };
@@ -187,7 +211,7 @@ class Button extends Component<ButtonSignature> {
 
   <template>
     {{#if @isRenderless}}
-      {{yield (hash classNames=this.classNames isLoading=this.isLoading)}}
+      {{yield this.yieldedHash}}
     {{else}}
       <button
         type={{this.type}}
@@ -212,10 +236,10 @@ class Button extends Component<ButtonSignature> {
           {{#if (has-block "loading")}}
             {{yield to="loading"}}
           {{else}}
-            {{yield (hash classNames=this.classNames isLoading=this.isLoading)}}
+            {{yield this.yieldedHash}}
           {{/if}}
         {{else}}
-          {{yield (hash classNames=this.classNames isLoading=this.isLoading)}}
+          {{yield this.yieldedHash}}
         {{/if}}
 
         {{#if this.isIconAtEnd}}

--- a/packages/frontile/src/components/buttons/button.md
+++ b/packages/frontile/src/components/buttons/button.md
@@ -135,6 +135,22 @@ import { DownloadIcon, ShareIcon, CheckIcon } from 'site/components/icons';
 </template>
 ```
 
+Icons passed as plain content keep working exactly as above. The `icon` named
+block is opt-in sugar: it buys you `@iconPlacement` and, when the button is
+loading, it is the slot the spinner takes over.
+
+```gts preview
+import { Button } from 'frontile';
+import { ShareIcon } from 'site/components/icons';
+
+<template>
+  <Button>
+    <:icon><ShareIcon /></:icon>
+    <:default>Share</:default>
+  </Button>
+</template>
+```
+
 ## Label with a Unit
 
 A label can carry a smaller trailing unit — a price suffix like `/mo`, a count,
@@ -229,6 +245,76 @@ import { Button } from 'frontile';
     <Button @intent='success' disabled>Success</Button>
     <Button @intent='warning' disabled>Warning</Button>
     <Button @intent='danger' disabled>Danger</Button>
+  </div>
+</template>
+```
+
+## Loading
+
+`@isLoading` renders a spinner and disables the button.
+
+```gts preview
+import { Button } from 'frontile';
+
+<template>
+  <div class='flex flex-wrap items-center gap-3'>
+    <Button @isLoading={{true}}>Save</Button>
+    <Button @appearance='outlined' @isLoading={{true}}>Save</Button>
+    <Button @intent='danger' @isLoading={{true}}>Delete</Button>
+  </div>
+</template>
+```
+
+Use the `loading` block to swap the label while the action is in flight.
+
+```gts preview
+import { Button } from 'frontile';
+
+<template>
+  <Button @isLoading={{true}}>
+    <:default>Save</:default>
+    <:loading>Saving…</:loading>
+  </Button>
+</template>
+```
+
+The spinner takes the place of the `icon` block, so a button with an icon keeps
+its width while loading.
+
+```gts preview
+import { Button } from 'frontile';
+import { ShareIcon } from 'site/components/icons';
+
+<template>
+  <div class='flex flex-wrap items-center gap-3'>
+    <Button>
+      <:icon><ShareIcon /></:icon>
+      <:default>Share</:default>
+    </Button>
+    <Button @isLoading={{true}}>
+      <:icon><ShareIcon /></:icon>
+      <:default>Share</:default>
+    </Button>
+  </div>
+</template>
+```
+
+`@iconPlacement='end'` moves both the icon and the spinner after the label.
+
+```gts preview
+import { Button } from 'frontile';
+import { ShareIcon } from 'site/components/icons';
+
+<template>
+  <div class='flex flex-wrap items-center gap-3'>
+    <Button @iconPlacement='end'>
+      <:icon><ShareIcon /></:icon>
+      <:default>Share</:default>
+    </Button>
+    <Button @iconPlacement='end' @isLoading={{true}}>
+      <:icon><ShareIcon /></:icon>
+      <:default>Share</:default>
+    </Button>
   </div>
 </template>
 ```
@@ -416,6 +502,20 @@ There is no `@isDisabled` argument. Pass the plain HTML `disabled` attribute, as
 the [Disabled](#disabled) demo above does; it removes the button from the tab
 order and is what assistive technology reports.
 
+### Loading
+
+`@isLoading` sets the plain HTML `disabled` attribute, which has two
+consequences worth designing around.
+
+**Focus is lost.** A button that disables itself mid-press drops focus to
+`<body>`, so keyboard and screen reader users lose their place and hear
+nothing. Put the outcome of the action in a live region, or leave the button
+enabled and guard against re-entry inside your handler.
+
+**The button widens** by the spinner plus the gap, unless it has an `icon`
+block for the spinner to take over. Either use the `icon` block, or set a
+`min-w-*` class on buttons that toggle between states.
+
 ### Renderless buttons
 
 `@isRenderless` hands back only class names, so every semantic the `<button>`
@@ -423,6 +523,10 @@ provided becomes yours. An `<a href>` is already focusable and activates on
 Enter; anything else — a `<div>`, a `<span>` — needs `role='button'`,
 `tabindex='0'`, and its own key handling. Prefer a real `<button>` or `<a>` over
 recreating that.
+
+`@isRenderless` yields only to the default block — `<:icon>` and `<:loading>`
+are ignored, because there is no element for the component to compose. The
+yielded hash still carries `isLoading`, so you can branch on it yourself.
 
 ## API
 

--- a/packages/frontile/src/components/buttons/button.md
+++ b/packages/frontile/src/components/buttons/button.md
@@ -516,6 +516,12 @@ enabled and guard against re-entry inside your handler.
 block for the spinner to take over. Either use the `icon` block, or set a
 `min-w-*` class on buttons that toggle between states.
 
+**A plain-content icon is not replaced.** The spinner only swaps in for an
+`icon` block (see [With Icons](#with-icons)); an icon passed as ordinary
+content — `<Button @isLoading={{true}}><DownloadIcon /> Download</Button>` —
+stays on screen alongside the spinner, rendering both. If you want the
+loading-swap behavior, move the icon into `<:icon>`.
+
 ### Renderless buttons
 
 `@isRenderless` hands back only class names, so every semantic the `<button>`

--- a/packages/frontile/src/components/forms/form.gts
+++ b/packages/frontile/src/components/forms/form.gts
@@ -161,9 +161,10 @@ interface FormSignature<T = FormDataCompiled> {
  *   <form.Field name="lastName" as |field|>
  *     <field.Input />
  *   </form.Field>
- *   <button type="submit" disabled={{form.isLoading}}>
- *     {{#if form.isLoading}}Submitting...{{else}}Submit{{/if}}
- *   </button>
+ *   <Button type="submit" @isLoading={{form.isLoading}}>
+ *     Submit
+ *     <:loading>Submitting...</:loading>
+ *   </Button>
  * </Form>
  * ```
  */

--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -481,8 +481,9 @@ export default class ValidatedForm extends Component {
             />
           </form.Field>
 
-          <Button type='submit' disabled={{form.isLoading}} @class='mt-4'>
-            {{if form.isLoading 'Creating Account...' 'Create Account'}}
+          <Button type='submit' @isLoading={{form.isLoading}} @class='mt-4'>
+            <:default>Create Account</:default>
+            <:loading>Creating Account…</:loading>
           </Button>
 
           <Button @appearance='outlined' type='reset'>Reset</Button>
@@ -1059,8 +1060,9 @@ export default class ValidatedNestedForm extends Component {
             </form.Field>
           </div>
 
-          <Button type='submit' disabled={{form.isLoading}}>
-            {{if form.isLoading 'Saving...' 'Save Profile'}}
+          <Button type='submit' @isLoading={{form.isLoading}}>
+            <:default>Save Profile</:default>
+            <:loading>Saving…</:loading>
           </Button>
         </div>
       </Form>
@@ -1296,8 +1298,9 @@ export default class ResetValidationForm extends Component {
           </form.Field>
 
           <div class='flex gap-2'>
-            <Button type='submit' disabled={{form.isLoading}}>
-              {{if form.isLoading 'Saving...' 'Save'}}
+            <Button type='submit' @isLoading={{form.isLoading}}>
+              <:default>Save</:default>
+              <:loading>Saving…</:loading>
             </Button>
             <Button
               type='button'

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -102,6 +102,9 @@ const button = tv({
       minimal: '',
       tonal: 'shadow-elevation-2',
       custom: ''
+    },
+    isLoading: {
+      true: 'disabled:cursor-progress'
     }
   },
   compoundVariants: [

--- a/packages/theme/src/components/button.ts
+++ b/packages/theme/src/components/button.ts
@@ -395,4 +395,12 @@ const buttonGroup = tv({
   base: ['inline-flex items-stretch justify-center h-auto']
 });
 
-export { button, toggleButton, buttonGroup };
+// The in-button spinner has to inherit the button's ink. `spinner`'s own base
+// is `text-neutral-muted` / `fill-neutral-strong`, which is invisible on a
+// filled primary button. `size-[1em]` makes it track the button's font size
+// across all six sizes, matching the base button's `[&_svg]:size-[1em]`.
+const buttonSpinner = tv({
+  base: 'size-[1em] text-current/25 fill-current'
+});
+
+export { button, toggleButton, buttonGroup, buttonSpinner };

--- a/test-app/tests/integration/components/buttons/buttons-test.gts
+++ b/test-app/tests/integration/components/buttons/buttons-test.gts
@@ -4,7 +4,8 @@ import {
   render,
   triggerEvent,
   triggerKeyEvent,
-  click
+  click,
+  find
 } from '@ember/test-helpers';
 import { registerCustomStyles, tv } from '@frontile/theme';
 import { Button } from 'frontile';
@@ -320,6 +321,139 @@ module(
           pressEventCount,
           0,
           'onPress should not be called in renderless mode'
+        );
+      });
+    });
+
+    module('@isLoading', function () {
+      test('it is not loading by default', async function (assert) {
+        await render(
+          <template>
+            <Button data-test-id="button">Save</Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').doesNotHaveAttribute('disabled');
+        assert.dom('[data-test-id="button"]').doesNotHaveAttribute('aria-busy');
+        assert
+          .dom('[data-test-id="button"]')
+          .doesNotHaveAttribute('data-loading');
+      });
+
+      test('it disables and marks the button busy while loading', async function (assert) {
+        await render(
+          <template>
+            <Button @isLoading={{true}} data-test-id="button">Save</Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').isDisabled();
+        assert.dom('[data-test-id="button"]').hasAttribute('aria-busy', 'true');
+        assert
+          .dom('[data-test-id="button"]')
+          .hasAttribute('data-loading', 'true');
+      });
+
+      test('it clears the loading state when @isLoading becomes false', async function (assert) {
+        class State {
+          @tracked isLoading = true;
+        }
+        const state = new State();
+        const stopLoading = () => (state.isLoading = false);
+
+        await render(
+          <template>
+            <Button
+              @isLoading={{state.isLoading}}
+              data-test-id="button"
+            >Save</Button>
+            <button
+              type="button"
+              data-test-id="stop"
+              {{on "click" stopLoading}}
+            >stop</button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').isDisabled();
+
+        await click('[data-test-id="stop"]');
+
+        assert.dom('[data-test-id="button"]').isNotDisabled();
+        assert.dom('[data-test-id="button"]').doesNotHaveAttribute('aria-busy');
+      });
+
+      test('a consumer disabled={{false}} does not defeat @isLoading', async function (assert) {
+        await render(
+          <template>
+            <Button
+              @isLoading={{true}}
+              disabled={{false}}
+              data-test-id="button"
+            >
+              Save
+            </Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').isDisabled();
+      });
+
+      test('a consumer disabled={{true}} survives @isLoading toggling off', async function (assert) {
+        class State {
+          @tracked isLoading = true;
+        }
+        const state = new State();
+        const stopLoading = () => (state.isLoading = false);
+
+        await render(
+          <template>
+            <Button
+              @isLoading={{state.isLoading}}
+              disabled={{true}}
+              data-test-id="button"
+            >Save</Button>
+            <button
+              type="button"
+              data-test-id="stop"
+              {{on "click" stopLoading}}
+            >stop</button>
+          </template>
+        );
+
+        await click('[data-test-id="stop"]');
+
+        assert
+          .dom('[data-test-id="button"]')
+          .isDisabled('the consumer disable is restored, not cleared');
+      });
+
+      test('@onPress does not fire while loading', async function (assert) {
+        let pressCount = 0;
+        const handlePress = () => (pressCount += 1);
+
+        await render(
+          <template>
+            <Button
+              @isLoading={{true}}
+              @onPress={{handlePress}}
+              data-test-id="button"
+            >Save</Button>
+          </template>
+        );
+
+        // A genuinely `disabled` button dispatches no click at all, and
+        // `@ember/test-helpers`'s `click()` throws proactively rather than
+        // simulate one (`Can not click disabled ...`), so a native
+        // `HTMLElement#click()` call is used here instead: per spec it is a
+        // no-op on a disabled element, which is exactly the behavior under
+        // test.
+        find('[data-test-id="button"]').click();
+
+        assert.strictEqual(
+          pressCount,
+          0,
+          '@onPress was suppressed while loading'
         );
       });
     });

--- a/test-app/tests/integration/components/buttons/buttons-test.gts
+++ b/test-app/tests/integration/components/buttons/buttons-test.gts
@@ -559,7 +559,7 @@ module(
           <template>
             <Button @iconPlacement="end" data-test-id="button">
               <:icon><span data-test-id="icon">i</span></:icon>
-              <:default>Save</:default>
+              <:default><span data-test-id="label">Save</span></:default>
             </Button>
           </template>
         );
@@ -570,6 +570,11 @@ module(
           button?.lastElementChild,
           button?.querySelector('[data-test-id="icon"]'),
           'the icon is the last element in the button'
+        );
+        assert.strictEqual(
+          button?.firstElementChild,
+          button?.querySelector('[data-test-id="label"]'),
+          'the label comes before the icon'
         );
       });
 
@@ -582,7 +587,7 @@ module(
               data-test-id="button"
             >
               <:icon><span data-test-id="icon">i</span></:icon>
-              <:default>Save</:default>
+              <:default><span data-test-id="label">Save</span></:default>
             </Button>
           </template>
         );
@@ -593,6 +598,11 @@ module(
           button?.lastElementChild,
           button?.querySelector('[data-test-id="loading-spinner"]'),
           'the spinner is the last element in the button'
+        );
+        assert.strictEqual(
+          button?.firstElementChild,
+          button?.querySelector('[data-test-id="label"]'),
+          'the label comes before the spinner'
         );
       });
 

--- a/test-app/tests/integration/components/buttons/buttons-test.gts
+++ b/test-app/tests/integration/components/buttons/buttons-test.gts
@@ -427,6 +427,65 @@ module(
           .isDisabled('the consumer disable is restored, not cleared');
       });
 
+      test('known limitation: a consumer disable applied mid-load is lost when loading ends', async function (assert) {
+        // Pins the fail-open direction documented on `disableWhile` in
+        // button.gts: the modifier snapshots `previous = el.disabled` only
+        // when it installs (when `loading` becomes true). A `disabled`
+        // binding that flips false -> true *after* that, while loading is
+        // still in flight, does not cause the modifier to re-run (it only
+        // reacts to `loading` changing), so `previous` stays stale at
+        // `false`. When loading ends, teardown restores that stale
+        // `previous`, silently discarding the consumer's disable.
+        //
+        // A literal `disabled={{true}}` would NOT reproduce this: Glimmer
+        // writes attributes before modifiers run, so `previous` would
+        // already be `true` at install time (see the passing
+        // 'a consumer disabled={{true}} survives @isLoading toggling off'
+        // test above). This test uses a tracked binding that changes only
+        // after the modifier has installed, which is the case that goes
+        // stale.
+        class State {
+          @tracked isLoading = true;
+          @tracked disabled = false;
+        }
+        const state = new State();
+        const disableButton = () => (state.disabled = true);
+        const stopLoading = () => (state.isLoading = false);
+
+        await render(
+          <template>
+            <Button
+              @isLoading={{state.isLoading}}
+              disabled={{state.disabled}}
+              data-test-id="button"
+            >Save</Button>
+            <button
+              type="button"
+              data-test-id="disable"
+              {{on "click" disableButton}}
+            >disable</button>
+            <button
+              type="button"
+              data-test-id="stop"
+              {{on "click" stopLoading}}
+            >stop</button>
+          </template>
+        );
+
+        // Modifier installed with `previous = false`. Flip the consumer's
+        // own `disabled` binding to `true` while loading is still active —
+        // `loading` itself does not change, so the modifier does not re-run.
+        await click('[data-test-id="disable"]');
+
+        await click('[data-test-id="stop"]');
+
+        assert
+          .dom('[data-test-id="button"]')
+          .isNotDisabled(
+            "known limitation: the consumer's disabled={{true}} is lost because the modifier's stale `previous` snapshot wins on teardown"
+          );
+      });
+
       test('@onPress does not fire while loading', async function (assert) {
         let pressCount = 0;
         const handlePress = () => (pressCount += 1);

--- a/test-app/tests/integration/components/buttons/buttons-test.gts
+++ b/test-app/tests/integration/components/buttons/buttons-test.gts
@@ -516,6 +516,95 @@ module(
           'the spinner is the first element in the button'
         );
       });
+
+      test('the <:icon> block renders before the label by default', async function (assert) {
+        await render(
+          <template>
+            <Button data-test-id="button">
+              <:icon><span data-test-id="icon">i</span></:icon>
+              <:default>Save</:default>
+            </Button>
+          </template>
+        );
+
+        const button = document.querySelector('[data-test-id="button"]');
+
+        assert.dom('[data-test-id="icon"]').exists();
+        assert.strictEqual(
+          button?.firstElementChild,
+          button?.querySelector('[data-test-id="icon"]'),
+          'the icon is the first element in the button'
+        );
+        assert.dom('[data-test-id="button"]').hasText('i Save');
+      });
+
+      test('the spinner replaces the <:icon> block while loading', async function (assert) {
+        await render(
+          <template>
+            <Button @isLoading={{true}} data-test-id="button">
+              <:icon><span data-test-id="icon">i</span></:icon>
+              <:default>Save</:default>
+            </Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="loading-spinner"]').exists();
+        assert
+          .dom('[data-test-id="icon"]')
+          .doesNotExist('the icon is replaced, not joined, by the spinner');
+      });
+
+      test('@iconPlacement="end" puts the icon after the label', async function (assert) {
+        await render(
+          <template>
+            <Button @iconPlacement="end" data-test-id="button">
+              <:icon><span data-test-id="icon">i</span></:icon>
+              <:default>Save</:default>
+            </Button>
+          </template>
+        );
+
+        const button = document.querySelector('[data-test-id="button"]');
+
+        assert.strictEqual(
+          button?.lastElementChild,
+          button?.querySelector('[data-test-id="icon"]'),
+          'the icon is the last element in the button'
+        );
+      });
+
+      test('@iconPlacement="end" puts the spinner after the label', async function (assert) {
+        await render(
+          <template>
+            <Button
+              @isLoading={{true}}
+              @iconPlacement="end"
+              data-test-id="button"
+            >
+              <:icon><span data-test-id="icon">i</span></:icon>
+              <:default>Save</:default>
+            </Button>
+          </template>
+        );
+
+        const button = document.querySelector('[data-test-id="button"]');
+
+        assert.strictEqual(
+          button?.lastElementChild,
+          button?.querySelector('[data-test-id="loading-spinner"]'),
+          'the spinner is the last element in the button'
+        );
+      });
+
+      test('a button with no <:icon> block still shows the spinner', async function (assert) {
+        await render(
+          <template>
+            <Button @isLoading={{true}} data-test-id="button">Save</Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="loading-spinner"]').exists();
+      });
     });
   }
 );

--- a/test-app/tests/integration/components/buttons/buttons-test.gts
+++ b/test-app/tests/integration/components/buttons/buttons-test.gts
@@ -615,6 +615,104 @@ module(
 
         assert.dom('[data-test-id="loading-spinner"]').exists();
       });
+
+      test('the <:loading> block replaces the label while loading', async function (assert) {
+        class State {
+          @tracked isLoading = false;
+        }
+        const state = new State();
+        const startLoading = () => (state.isLoading = true);
+
+        await render(
+          <template>
+            <Button @isLoading={{state.isLoading}} data-test-id="button">
+              <:default>Save</:default>
+              <:loading>Saving…</:loading>
+            </Button>
+            <button
+              type="button"
+              data-test-id="start"
+              {{on "click" startLoading}}
+            >go</button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').hasText('Save');
+
+        await click('[data-test-id="start"]');
+
+        assert.dom('[data-test-id="button"]').hasText('Saving…');
+      });
+
+      test('the default block returns when loading ends', async function (assert) {
+        class State {
+          @tracked isLoading = true;
+        }
+        const state = new State();
+        const stopLoading = () => (state.isLoading = false);
+
+        await render(
+          <template>
+            <Button @isLoading={{state.isLoading}} data-test-id="button">
+              <:default>Save</:default>
+              <:loading>Saving…</:loading>
+            </Button>
+            <button
+              type="button"
+              data-test-id="stop"
+              {{on "click" stopLoading}}
+            >stop</button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').hasText('Saving…');
+
+        await click('[data-test-id="stop"]');
+
+        assert.dom('[data-test-id="button"]').hasText('Save');
+      });
+
+      test('the yielded hash carries isLoading', async function (assert) {
+        await render(
+          <template>
+            <Button @isLoading={{true}} data-test-id="button" as |b|>
+              {{if b.isLoading "busy" "idle"}}
+            </Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').hasText('busy');
+      });
+
+      test('@isRenderless yields isLoading and ignores <:icon> and <:loading>', async function (assert) {
+        await render(
+          <template>
+            <Button @isRenderless={{true}} @isLoading={{true}}>
+              <:icon><span data-test-id="icon">i</span></:icon>
+              <:default as |b|>
+                <a href="/next" class={{b.classNames}} data-test-id="link">
+                  {{if b.isLoading "Loading…" "Go"}}
+                </a>
+              </:default>
+              <:loading>Saving…</:loading>
+            </Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="link"]').hasText('Loading…');
+        assert.dom('[data-test-id="icon"]').doesNotExist();
+        assert.dom('[data-test-id="loading-spinner"]').doesNotExist();
+      });
+
+      test('plain content with no named blocks still renders', async function (assert) {
+        await render(
+          <template>
+            <Button data-test-id="button">Save</Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').hasText('Save');
+      });
     });
   }
 );

--- a/test-app/tests/integration/components/buttons/buttons-test.gts
+++ b/test-app/tests/integration/components/buttons/buttons-test.gts
@@ -4,8 +4,7 @@ import {
   render,
   triggerEvent,
   triggerKeyEvent,
-  click,
-  find
+  click
 } from '@ember/test-helpers';
 import { registerCustomStyles, tv } from '@frontile/theme';
 import { Button } from 'frontile';
@@ -442,19 +441,22 @@ module(
           </template>
         );
 
-        // A genuinely `disabled` button dispatches no click at all, and
-        // `@ember/test-helpers`'s `click()` throws proactively rather than
-        // simulate one (`Can not click disabled ...`), so a native
-        // `HTMLElement#click()` call is used here instead: per spec it is a
-        // no-op on a disabled element, which is exactly the behavior under
-        // test.
-        find('[data-test-id="button"]').click();
-
-        assert.strictEqual(
-          pressCount,
-          0,
-          '@onPress was suppressed while loading'
+        // The `press` modifier listens on pointer/mouse/key events and
+        // registers no `click` listener, so a native `element.click()` can
+        // never reach `onPress` and a test built on one passes even when
+        // `@isLoading` is unwired. Synthetic `dispatchEvent` is no better: it
+        // reaches listeners regardless of `disabled`, so driving
+        // pointerdown/pointerup would fail against a correct implementation.
+        // Asserting that the click helper refuses the element is the
+        // faithful check — it refuses for exactly the reason the browser
+        // does.
+        await assert.rejects(
+          click('[data-test-id="button"]'),
+          /disabled/,
+          'the click helper refuses a disabled button'
         );
+
+        assert.strictEqual(pressCount, 0, '@onPress never fired');
       });
     });
   }

--- a/test-app/tests/integration/components/buttons/buttons-test.gts
+++ b/test-app/tests/integration/components/buttons/buttons-test.gts
@@ -458,6 +458,64 @@ module(
 
         assert.strictEqual(pressCount, 0, '@onPress never fired');
       });
+
+      test('it renders a spinner only while loading', async function (assert) {
+        class State {
+          @tracked isLoading = false;
+        }
+        const state = new State();
+        const startLoading = () => (state.isLoading = true);
+
+        await render(
+          <template>
+            <Button
+              @isLoading={{state.isLoading}}
+              data-test-id="button"
+            >Save</Button>
+            <button
+              type="button"
+              data-test-id="start"
+              {{on "click" startLoading}}
+            >go</button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="loading-spinner"]').doesNotExist();
+
+        await click('[data-test-id="start"]');
+
+        assert.dom('[data-test-id="loading-spinner"]').exists();
+      });
+
+      test('the label stays visible while loading', async function (assert) {
+        await render(
+          <template>
+            <Button @isLoading={{true}} data-test-id="button">Save</Button>
+          </template>
+        );
+
+        assert.dom('[data-test-id="button"]').hasText('Save');
+      });
+
+      test('the spinner renders before the label', async function (assert) {
+        await render(
+          <template>
+            <Button @isLoading={{true}} data-test-id="button">Save</Button>
+          </template>
+        );
+
+        const button = document.querySelector('[data-test-id="button"]');
+        const spinner = button?.querySelector(
+          '[data-test-id="loading-spinner"]'
+        );
+
+        assert.ok(spinner, 'the spinner is inside the button');
+        assert.strictEqual(
+          button?.firstElementChild,
+          spinner,
+          'the spinner is the first element in the button'
+        );
+      });
     });
   }
 );


### PR DESCRIPTION
Adds `@isLoading` to `<Button>`: one boolean renders a spinner and disables the button, replacing the hand-rolled `disabled={{form.isLoading}}` + `{{if form.isLoading 'Saving...' 'Save'}}` pattern that appears throughout the docs.

Closes #68.

## API

```gjs
<Button @isLoading={{form.isLoading}}>Save</Button>

<Button @isLoading={{form.isLoading}}>
  <:icon><SaveIcon /></:icon>
  <:default>Save</:default>
  <:loading>Saving…</:loading>
</Button>
```

- **`@isLoading`** — renders a spinner, sets the native `disabled` attribute, `aria-busy="true"`, and `data-loading="true"`.
- **`@iconPlacement`** (`'start' | 'end'`, default `'start'`) — which side the `<:icon>` block sits on.
- **`<:icon>`** — opt-in named block. While loading, the spinner takes its slot, so an icon button's width doesn't change. A button without one still shows the spinner at `@iconPlacement`.
- **`<:loading>`** — replaces `<:default>` while loading.
- The yielded hash is now `{ classNames, isLoading }`.

Everything is additive. `<Button>Text</Button>`, the existing `as |b|` hash, and `@isRenderless` are unchanged; `@isRenderless` yields only to `:default` and ignores `<:icon>`/`<:loading>`, since there's no element for the component to compose.

## Design decisions

Surveyed HeroUI, Chakra, MUI, Nuxt UI, and Intent UI / React Aria first. The real split is React Aria vs everyone else, and this follows the majority on both counts — with the trade-offs accepted knowingly and documented rather than papered over:

- **Native `disabled`, not `aria-disabled`.** Simpler, and existing `disabled:*` styling and event blocking come free. Cost: focus drops to `<body>` when the button disables itself mid-press. The docs say so and give remedies.
- **Spinner alongside the label, not overlaying it.** The label stays readable so the user keeps context. Cost: the button widens unless it has an `<:icon>`. Also documented, with a `min-w-*` remedy.

Note both reverse the position I argued in #68 — that was deliberate, not an oversight.

Two implementation details worth a reviewer's eye:

- **`disableWhile` is an element modifier, not a `disabled` attribute.** Splattributes are applied last, so `disabled={{@isLoading}}` before `...attributes` is clobbered by a consumer's own `disabled`, and after it a consumer's `disabled={{false}}` erases ours. Modifiers run after attributes, so neither ordering problem applies. One known limitation is documented in the code and pinned by a test: the modifier re-runs only when `isLoading` changes, so a consumer's *tracked* `disabled` flipping mid-load is lost on teardown. Closing it would need a `MutationObserver`.
- **The theme stays single-slot.** `button` still returns a string, so the yielded `classNames` and the renderless API are untouched. Loading is a variant; the in-button spinner is a separate `buttonSpinner` export, because `spinner`'s own `text-neutral-muted` / `fill-neutral-strong` base is invisible on a filled primary button.

## Testing

20 new integration tests. Full suite: **1400 tests, 1397 pass, 3 pre-existing skips, 0 fail.** Site build clean (75 pages prerendered).

Three tests were caught passing regardless of the implementation and fixed before merge — worth flagging because both causes are easy to repeat:

- `press` registers no `click` listener, so a native `element.click()` can never reach `@onPress`. Synthetic `dispatchEvent` is no better — it reaches listeners regardless of `disabled`. The faithful check is `assert.rejects(click(el), /disabled/)`.
- A plain-text label inside a `<button>` contributes no element child, so `button.lastElementChild === icon` passes whichever side the icon renders on. The placement tests now wrap the label and assert both ends.

Each was verified by unwiring the feature and confirming the test fails.

## Out of scope

`ToggleButton` / `CloseButton` / `Chip` / `SegmentedControl` loading states; auto-loading from an async `@onPress`; `@loadingText` (the `<:loading>` block covers it); a `StatefulButton` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
