### PR TITLE
Refactor site icons to use Lucide via unplugin-icons

### DIFF
--- a/docs/theming/design-tokens/icons.md
+++ b/docs/theming/design-tokens/icons.md
@@ -20,40 +20,14 @@ The scale ranges from `pico` (smallest) to `mega` (largest), providing 14 distin
 Apply icon sizes using the `size-icon-*` utilities, which set both width and height:
 
 ```gts preview
+import { StarIcon } from 'site/components/icons';
+
 <template>
   <div class='flex items-center gap-6'>
-    <svg class='size-icon-sm text-primary' fill='currentColor' viewBox='0 0 20 20'>
-      <path d='M10 12a2 2 0 100-4 2 2 0 000 4z'></path>
-      <path
-        fill-rule='evenodd'
-        d='M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z'
-        clip-rule='evenodd'
-      ></path>
-    </svg>
-    <svg class='size-icon-md text-primary' fill='currentColor' viewBox='0 0 20 20'>
-      <path d='M10 12a2 2 0 100-4 2 2 0 000 4z'></path>
-      <path
-        fill-rule='evenodd'
-        d='M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z'
-        clip-rule='evenodd'
-      ></path>
-    </svg>
-    <svg class='size-icon-lg text-primary' fill='currentColor' viewBox='0 0 20 20'>
-      <path d='M10 12a2 2 0 100-4 2 2 0 000 4z'></path>
-      <path
-        fill-rule='evenodd'
-        d='M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z'
-        clip-rule='evenodd'
-      ></path>
-    </svg>
-    <svg class='size-icon-xl text-primary' fill='currentColor' viewBox='0 0 20 20'>
-      <path d='M10 12a2 2 0 100-4 2 2 0 000 4z'></path>
-      <path
-        fill-rule='evenodd'
-        d='M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z'
-        clip-rule='evenodd'
-      ></path>
-    </svg>
+    <StarIcon class='size-icon-sm text-primary' />
+    <StarIcon class='size-icon-md text-primary' />
+    <StarIcon class='size-icon-lg text-primary' />
+    <StarIcon class='size-icon-xl text-primary' />
   </div>
 </template>
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,7 +484,7 @@ importers:
         version: 4.0.0(@babel/core@7.26.7)(@ember/test-helpers@5.4.3(@babel/core@7.26.7))(@ember/test-waiters@4.1.2)(@glimmer/component@2.1.1)(@glint/template@1.8.0)(ember-source@6.6.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       ember-auto-import:
         specifier: ^2.13.1
-        version: 2.13.1(@glint/template@1.8.0)(webpack@5.109.2(postcss@8.5.6))
+        version: 2.13.1(@glint/template@1.8.0)(webpack@5.109.2)
       ember-click-outside:
         specifier: ^6.1.0
         version: 6.1.1(@babel/core@7.26.7)
@@ -1064,6 +1064,9 @@ importers:
       '@glint/template':
         specifier: ^1.8.0
         version: 1.8.0
+      '@iconify-json/lucide':
+        specifier: ^1.2.129
+        version: 1.2.129
       '@rollup/plugin-babel':
         specifier: ^7.1.0
         version: 7.1.0(@babel/core@7.28.0)(rollup@4.62.4)
@@ -1202,6 +1205,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unplugin-icons:
+        specifier: ^23.0.1
+        version: 23.0.1
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@5.8.3)
@@ -1405,6 +1411,12 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@antfu/install-pkg@2.0.1':
+    resolution: {integrity: sha512-iCKVQcIC0e3oDxEfs3SHQGW+ovhBMZmS1TE+bTk50rVyMCBmCfClv7Qi3HQKlumYwvjb/iIMeWCW2i67q6kFfQ==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -2690,6 +2702,15 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/lucide@1.2.129':
+    resolution: {integrity: sha512-pa0ufllJOXTDIH2BxE/BtWQEf/x46/lINDWcmncICV1/52veZ7KSBzQaVh9xDpmjDs8QN4j2Ex/LWlSSveL3yw==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.5':
+    resolution: {integrity: sha512-nT+AWyh5caHY6xa0PdLXpUooIz6l7qsT+adqsCTYBfbdn5Q18VrWs2fvuTa7KEoJnPBfEPqWkmAIht0EHtCi2A==}
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -5230,6 +5251,12 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.3.1:
+    resolution: {integrity: sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==}
+
   configstore@5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
     engines: {node: '>=8'}
@@ -6543,6 +6570,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -8106,6 +8136,10 @@ packages:
   loader.js@4.7.0:
     resolution: {integrity: sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==}
 
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
+
   locate-character@2.0.5:
     resolution: {integrity: sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==}
 
@@ -8674,6 +8708,9 @@ packages:
     resolution: {integrity: sha512-IXnMcJ6ZyTuhRmJSjzvHSRhlVPiN9Jwc6e59V0bEJ0ba6OBeX2L0E+mRN1QseeOF4mM+F1Rit6Nh7o+rl2Yn/A==}
     engines: {node: '>0.9'}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   morgan@1.10.1:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
@@ -8916,6 +8953,10 @@ packages:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
     engines: {node: '>=0.10.0'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -9064,6 +9105,9 @@ packages:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==}
     engines: {node: '>=8'}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   package-up@5.0.0:
     resolution: {integrity: sha512-MQEgDUvXCa3sGvqHg3pzHO8e9gqTCMPVrWUko3vPQGntwegmFo52mZb2abIVTjFnUcW0BcPz0D93jV5Cas1DWA==}
     engines: {node: '>=18'}
@@ -9188,6 +9232,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -9229,6 +9276,12 @@ packages:
   pkg-entry-points@1.1.2:
     resolution: {integrity: sha512-bmmM+SdLXNNetFr4o53QiiZRZicls2apmzj8HRpo4bU+3nJHiPO/omv8TXHIOzTcirua3YBAwTlKE+7zkICh4g==}
     engines: {node: '>=20.19.5'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.2:
+    resolution: {integrity: sha512-v0sVXzj7oPGysr543YYZLYbcJNJsKikSsp/fFzoxQ12ewY3ZZr7oCPC8y7OlmxfYB3QPvriXmuPD8KZggE1vqg==}
 
   pkg-up@2.0.0:
     resolution: {integrity: sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==}
@@ -9470,6 +9523,9 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -10524,6 +10580,10 @@ packages:
   tiny-lr@2.0.0:
     resolution: {integrity: sha512-f6nh0VMRvhGx4KCeK1lQ/jaL0Zdb5WdR+Jk8q9OSUQnaSDxAEGH1fgqLZ+cMl5EW3F2MGnCsalBO1IsnnogW1Q==}
 
+  tinyexec@1.3.1:
+    resolution: {integrity: sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
@@ -10743,6 +10803,9 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -10847,6 +10910,27 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin-icons@23.0.1:
+    resolution: {integrity: sha512-rv0XEJepajKzDLvRUWASM8K+8+/CCfZn2jtogXqg6RIp7kpatRc/aFrVJn8ANQA09e++lPEEv9yX8cC9enc+QQ==}
+    peerDependencies:
+      '@svgr/core': '>=7.0.0'
+      '@svgx/core': ^1.0.1
+      '@vue/compiler-sfc': ^3.0.2
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      '@svgr/core':
+        optional: true
+      '@svgx/core':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      svelte:
+        optional: true
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unset-value@1.0.0:
     resolution: {integrity: sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==}
@@ -11044,6 +11128,9 @@ packages:
   webpack-sources@3.5.1:
     resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   webpack@5.109.2:
     resolution: {integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==}
@@ -11290,6 +11377,16 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.1
+
+  '@antfu/install-pkg@2.0.1':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.1
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -14305,6 +14402,18 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify-json/lucide@1.2.129':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.5':
+    dependencies:
+      '@antfu/install-pkg': 2.0.1
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@inquirer/ansi@1.0.2': {}
 
   '@inquirer/ansi@2.0.7': {}
@@ -16178,15 +16287,6 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.109.2(postcss@8.5.26)
 
-  babel-loader@8.4.1(@babel/core@7.28.0)(webpack@5.109.2(postcss@8.5.6)):
-    dependencies:
-      '@babel/core': 7.28.0
-      find-cache-dir: 3.3.2
-      loader-utils: 2.0.4
-      make-dir: 3.1.0
-      schema-utils: 2.7.1
-      webpack: 5.109.2(postcss@8.5.6)
-
   babel-loader@8.4.1(@babel/core@7.28.0)(webpack@5.109.2):
     dependencies:
       '@babel/core': 7.28.0
@@ -16195,7 +16295,6 @@ snapshots:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.109.2
-    optional: true
 
   babel-loader@9.2.1(@babel/core@7.28.0)(webpack@5.109.2(postcss@8.5.26)):
     dependencies:
@@ -17237,6 +17336,10 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 18.0.0
 
+  confbox@0.1.8: {}
+
+  confbox@0.3.1: {}
+
   configstore@5.0.1:
     dependencies:
       dot-prop: 5.3.0
@@ -17412,20 +17515,6 @@ snapshots:
       semver: 7.7.4
       webpack: 5.109.2(postcss@8.5.26)
 
-  css-loader@5.2.7(webpack@5.109.2(postcss@8.5.6)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      loader-utils: 2.0.4
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      schema-utils: 3.3.0
-      semver: 7.7.4
-      webpack: 5.109.2(postcss@8.5.6)
-
   css-loader@5.2.7(webpack@5.109.2):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
@@ -17439,7 +17528,6 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.7.4
       webpack: 5.109.2
-    optional: true
 
   css-select@7.0.0:
     dependencies:
@@ -17790,7 +17878,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-auto-import@2.13.1(@glint/template@1.8.0)(webpack@5.109.2(postcss@8.5.6)):
+  ember-auto-import@2.13.1(@glint/template@1.8.0)(webpack@5.109.2):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.0)
@@ -17801,7 +17889,7 @@ snapshots:
       '@embroider/macros': 1.20.6(@babel/core@7.28.0)(@glint/template@1.8.0)
       '@embroider/reverse-exports': 0.2.0
       '@embroider/shared-internals': 2.9.1
-      babel-loader: 8.4.1(@babel/core@7.28.0)(webpack@5.109.2(postcss@8.5.6))
+      babel-loader: 8.4.1(@babel/core@7.28.0)(webpack@5.109.2)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.4.1
       babel-plugin-htmlbars-inline-precompile: 5.3.1
@@ -17811,7 +17899,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
-      css-loader: 5.2.7(webpack@5.109.2(postcss@8.5.6))
+      css-loader: 5.2.7(webpack@5.109.2)
       debug: 4.4.1(supports-color@8.1.1)
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
@@ -17819,14 +17907,14 @@ snapshots:
       is-subdir: 1.2.0
       js-string-escape: 1.0.1
       lodash: 4.17.21
-      mini-css-extract-plugin: 2.9.2(webpack@5.109.2(postcss@8.5.6))
+      mini-css-extract-plugin: 2.9.2(webpack@5.109.2)
       minimatch: 3.1.2
       parse5: 6.0.1
       pkg-entry-points: 1.1.1
       resolve: 1.22.10
       resolve-package-path: 4.0.3
       semver: 7.7.2
-      style-loader: 2.0.0(webpack@5.109.2(postcss@8.5.6))
+      style-loader: 2.0.0(webpack@5.109.2)
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
     transitivePeerDependencies:
@@ -19301,6 +19389,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  exsolve@1.1.1: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -21041,6 +21131,12 @@ snapshots:
 
   loader.js@4.7.0: {}
 
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.2
+      quansync: 0.2.11
+
   locate-character@2.0.5: {}
 
   locate-path@2.0.0:
@@ -21677,18 +21773,11 @@ snapshots:
       tapable: 2.2.2
       webpack: 5.109.2(postcss@8.5.26)
 
-  mini-css-extract-plugin@2.9.2(webpack@5.109.2(postcss@8.5.6)):
-    dependencies:
-      schema-utils: 4.3.2
-      tapable: 2.2.2
-      webpack: 5.109.2(postcss@8.5.6)
-
   mini-css-extract-plugin@2.9.2(webpack@5.109.2):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.2
       webpack: 5.109.2
-    optional: true
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -21744,16 +21833,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.26
 
-  minimizer-webpack-plugin@5.6.1(postcss@8.5.6)(webpack@5.109.2(postcss@8.5.6)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.49.2
-      webpack: 5.109.2(postcss@8.5.6)
-    optionalDependencies:
-      postcss: 8.5.6
-
   minimizer-webpack-plugin@5.6.1(webpack@5.109.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -21761,7 +21840,6 @@ snapshots:
       schema-utils: 4.3.3
       terser: 5.49.2
       webpack: 5.109.2
-    optional: true
 
   minipass-collect@2.0.1:
     dependencies:
@@ -21825,6 +21903,13 @@ snapshots:
   mkdirp@3.0.1: {}
 
   mktemp@0.4.0: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
 
   morgan@1.10.1:
     dependencies:
@@ -22194,6 +22279,8 @@ snapshots:
     dependencies:
       isobject: 3.0.1
 
+  obug@2.1.4: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -22374,6 +22461,8 @@ snapshots:
       registry-url: 5.1.0
       semver: 6.3.1
 
+  package-manager-detector@1.8.0: {}
+
   package-up@5.0.0:
     dependencies:
       find-up-simple: 1.0.1
@@ -22515,6 +22604,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -22540,6 +22631,18 @@ snapshots:
   pkg-entry-points@1.1.1: {}
 
   pkg-entry-points@1.1.2: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.2:
+    dependencies:
+      confbox: 0.3.1
+      exsolve: 1.1.1
+      pathe: 2.0.3
 
   pkg-up@2.0.0:
     dependencies:
@@ -22750,6 +22853,8 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+
+  quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
 
@@ -23854,18 +23959,11 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.109.2(postcss@8.5.26)
 
-  style-loader@2.0.0(webpack@5.109.2(postcss@8.5.6)):
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.109.2(postcss@8.5.6)
-
   style-loader@2.0.0(webpack@5.109.2):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.109.2
-    optional: true
 
   styled_string@0.0.1: {}
 
@@ -24227,6 +24325,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  tinyexec@1.3.1: {}
+
   tinyglobby@0.2.12:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -24486,6 +24586,8 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
+  ufo@1.6.4: {}
+
   uglify-js@3.19.3:
     optional: true
 
@@ -24596,6 +24698,21 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unplugin-icons@23.0.1:
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/utils': 3.1.5
+      local-pkg: 1.2.1
+      obug: 2.1.4
+      unplugin: 2.3.11
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.18.0
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
 
   unset-value@1.0.0:
     dependencies:
@@ -24768,6 +24885,8 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
+  webpack-virtual-modules@0.6.2: {}
+
   webpack@5.109.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -24803,7 +24922,6 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
-    optional: true
 
   webpack@5.109.2(postcss@8.5.26):
     dependencies:
@@ -24822,42 +24940,6 @@ snapshots:
       graceful-fs: 4.2.11
       mime-db: 1.54.0
       minimizer-webpack-plugin: 5.6.1(postcss@8.5.26)(webpack@5.109.2(postcss@8.5.26))
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.109.2(postcss@8.5.6):
-    dependencies:
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.18.0
-      browserslist: 4.28.8
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.5
-      es-module-lexer: 2.3.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(postcss@8.5.6)(webpack@5.109.2(postcss@8.5.6))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3

--- a/site/app/components/docfy/docfy-copy-page.gts
+++ b/site/app/components/docfy/docfy-copy-page.gts
@@ -3,8 +3,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { ButtonGroup, Dropdown } from 'frontile';
-import type { TOC } from '@ember/component/template-only';
 import { currentOrigin } from 'site/utils/origin';
+import { CheckIcon, DuplicateIcon, ChevronDownIcon } from '../icons';
 
 export interface DocfyCopyPageSignature {
   Args: {
@@ -195,7 +195,7 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
           {{#if this.isCopied}}
             <CheckIcon class="w-4 h-4" />
           {{else}}
-            <CopyIcon class="w-4 h-4" />
+            <DuplicateIcon class="w-4 h-4" />
           {{/if}}
           {{this.primaryLabel}}
         </g.Button>
@@ -208,20 +208,7 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
             aria-label="More page actions"
             data-test-id="copy-page-trigger"
           >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
+            <ChevronDownIcon class="w-4 h-4" aria-hidden="true" />
           </d.Trigger>
 
           <d.Menu
@@ -247,34 +234,3 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
     </div>
   </template>
 }
-
-const CopyIcon: TOC<{ Element: SVGElement }> = <template>
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    aria-hidden="true"
-    ...attributes
-  >
-    <rect x="8" y="8" width="14" height="14" rx="2" ry="2" />
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
-    />
-  </svg>
-</template>;
-
-const CheckIcon: TOC<{ Element: SVGElement }> = <template>
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    aria-hidden="true"
-    ...attributes
-  >
-    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-  </svg>
-</template>;

--- a/site/app/components/docfy/docfy-copy-page.gts
+++ b/site/app/components/docfy/docfy-copy-page.gts
@@ -193,9 +193,9 @@ export default class DocfyCopyPage extends Component<DocfyCopyPageSignature> {
       <ButtonGroup @appearance="soft" @size="xs" as |g|>
         <g.Button @onPress={{this.copyPage}} data-test-id="copy-page-primary">
           {{#if this.isCopied}}
-            <CheckIcon class="w-4 h-4" />
+            <CheckIcon class="w-4 h-4" aria-hidden="true" />
           {{else}}
-            <DuplicateIcon class="w-4 h-4" />
+            <DuplicateIcon class="w-4 h-4" aria-hidden="true" />
           {{/if}}
           {{this.primaryLabel}}
         </g.Button>

--- a/site/app/components/docfy/docfy-jump-to.gts
+++ b/site/app/components/docfy/docfy-jump-to.gts
@@ -12,6 +12,7 @@ import {
   AccessibilityIcon,
   PackageIcon,
   BookIcon,
+  SearchIcon,
 } from '../icons';
 import type RouterService from '@ember/routing/router-service';
 import type { PageMetadata, NestedPageMetadata } from '@docfy/core/lib/types';
@@ -211,19 +212,7 @@ export default class DocfyJumpTo extends Component {
       class="transition flex items-center rounded focus-visible:ring outline-none hover:text-neutral-strong"
       {{on "click" this.open}}
     >
-      <svg
-        class="w-4 h-4 mr-2"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-      ><path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-        ></path></svg>
+      <SearchIcon aria-hidden="true" class="w-4 h-4 mr-2" />
 
       Search
       <Kbd

--- a/site/app/components/docfy/docfy-page.gts
+++ b/site/app/components/docfy/docfy-page.gts
@@ -7,6 +7,9 @@ import DocfySectionNav from './docfy-section-nav';
 import docfyIntersectHeadings from '../../modifiers/docfy-intersect-headings';
 import DocfyCopyPage from './docfy-copy-page';
 import { DocfyLink, DocfyOutput, DocfyPreviousAndNextPage } from '@docfy/ember';
+import IconPencil from '~icons/lucide/pencil';
+import IconArrowLeft from '~icons/lucide/arrow-left';
+import IconArrowRight from '~icons/lucide/arrow-right';
 
 interface Signature {
   Args: {
@@ -67,11 +70,7 @@ export default class DocfyPage extends Component<Signature> {
                   rel="noopener noreferrer"
                   class="flex items-center text-xs text-neutral-firm hover:text-primary"
                 >
-                  <svg class="w-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                    <path
-                      d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
-                    ></path>
-                  </svg>
+                  <IconPencil class="size-4 mr-2" />
                   Edit this page on GitHub
                 </a>
               {{/if}}
@@ -84,13 +83,7 @@ export default class DocfyPage extends Component<Signature> {
             <DocfyPreviousAndNextPage as |previous next|>
               <div class="flex items-center pt-6 pr-2">
                 {{#if previous}}
-                  <svg class="h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                    <path
-                      d="M7.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l2.293 2.293a1 1 0 010 1.414z"
-                      clip-rule="evenodd"
-                      fill-rule="evenodd"
-                    ></path>
-                  </svg>
+                  <IconArrowLeft class="size-4 mr-2" />
 
                   <DocfyLink
                     @to={{previous.url}}
@@ -109,13 +102,7 @@ export default class DocfyPage extends Component<Signature> {
                     {{next.title}}
                   </DocfyLink>
 
-                  <svg class="h-4 ml-2" fill="currentColor" viewBox="0 0 20 20">
-                    <path
-                      d="M12.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-2.293-2.293a1 1 0 010-1.414z"
-                      clip-rule="evenodd"
-                      fill-rule="evenodd"
-                    ></path>
-                  </svg>
+                  <IconArrowRight class="size-4 ml-2" />
                 {{/if}}
               </div>
             </DocfyPreviousAndNextPage>

--- a/site/app/components/docfy/docfy-sidebar-nav/content.gts
+++ b/site/app/components/docfy/docfy-sidebar-nav/content.gts
@@ -6,6 +6,7 @@ import { fn } from '@ember/helper';
 import { concat } from '@ember/helper';
 import { service } from '@ember/service';
 import { Chip } from 'frontile';
+import IconChevronRight from '~icons/lucide/chevron-right';
 import type { NestedPageMetadata } from '@docfy/core/lib/types';
 import type RouterService from '@ember/routing/router-service';
 import type Owner from '@ember/owner';
@@ -200,7 +201,7 @@ export default class DocfySidebarNavContent extends Component<Signature> {
                     }}
                   >
                     <span>{{subChild.label}}</span>
-                    <svg
+                    <IconChevronRight
                       class="h-3 w-3 transition-transform
                         {{if
                           (this.isExpanded
@@ -209,17 +210,7 @@ export default class DocfySidebarNavContent extends Component<Signature> {
                           'rotate-90'
                           ''
                         }}"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M9 5l7 7-7 7"
-                      />
-                    </svg>
+                    />
                   </button>
 
                   {{#if

--- a/site/app/components/docfy/docfy-sidebar-nav/index.gts
+++ b/site/app/components/docfy/docfy-sidebar-nav/index.gts
@@ -53,7 +53,7 @@ export default class SidebarNav extends Component<Signature> {
       {{on "click" this.toggle}}
     >
       <VisuallyHidden>Contents</VisuallyHidden>
-      <IconMenu class="w-8" />
+      <IconMenu class="size-8" />
     </button>
 
     <Drawer

--- a/site/app/components/docfy/docfy-sidebar-nav/index.gts
+++ b/site/app/components/docfy/docfy-sidebar-nav/index.gts
@@ -4,6 +4,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { VisuallyHidden } from 'frontile';
 import { Drawer } from 'frontile';
+import IconMenu from '~icons/lucide/menu';
 import Content from './content';
 import type { NestedPageMetadata } from '@docfy/core/lib/types';
 
@@ -52,13 +53,7 @@ export default class SidebarNav extends Component<Signature> {
       {{on "click" this.toggle}}
     >
       <VisuallyHidden>Contents</VisuallyHidden>
-      <svg class="w-8" fill="currentColor" viewBox="0 0 20 20">
-        <path
-          d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-          clip-rule="evenodd"
-          fill-rule="evenodd"
-        ></path>
-      </svg>
+      <IconMenu class="w-8" />
     </button>
 
     <Drawer

--- a/site/app/components/docfy/docfy-theme-switcher.gts
+++ b/site/app/components/docfy/docfy-theme-switcher.gts
@@ -88,12 +88,12 @@ export default class DocfyThemeSwitcher extends Component<Signature> {
         <VisuallyHidden>
           Switch to Light Mode
         </VisuallyHidden>
-        <SunIcon aria-hidden="true" class="w-6 h-6" />
+        <MoonIcon aria-hidden="true" class="w-6 h-6" />
       {{else}}
         <VisuallyHidden>
           Switch to Dark Mode
         </VisuallyHidden>
-        <MoonIcon aria-hidden="true" class="w-6 h-6" />
+        <SunIcon aria-hidden="true" class="w-6 h-6" />
       {{/if}}
     </button>
   </template>

--- a/site/app/components/docfy/docfy-theme-switcher.gts
+++ b/site/app/components/docfy/docfy-theme-switcher.gts
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { later } from '@ember/runloop';
 import { VisuallyHidden } from 'frontile';
+import { SunIcon, MoonIcon } from '../icons';
 
 interface Signature {
   Element: HTMLButtonElement;
@@ -87,32 +88,12 @@ export default class DocfyThemeSwitcher extends Component<Signature> {
         <VisuallyHidden>
           Switch to Light Mode
         </VisuallyHidden>
-        <svg
-          aria-hidden="true"
-          class="w-6 h-6"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
-          ></path>
-        </svg>
+        <SunIcon aria-hidden="true" class="w-6 h-6" />
       {{else}}
         <VisuallyHidden>
           Switch to Dark Mode
         </VisuallyHidden>
-        <svg
-          aria-hidden="true"
-          class="w-6 h-6"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-            clip-rule="evenodd"
-            fill-rule="evenodd"
-          ></path>
-        </svg>
+        <MoonIcon aria-hidden="true" class="w-6 h-6" />
       {{/if}}
     </button>
   </template>

--- a/site/app/components/homepage/theme-seam.gts
+++ b/site/app/components/homepage/theme-seam.gts
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import { on } from '@ember/modifier';
 import { VisuallyHidden } from 'frontile';
+import IconChevronsLeftRight from '~icons/lucide/chevrons-left-right';
 
 type SafeString = ReturnType<typeof htmlSafe>;
 
@@ -203,21 +204,7 @@ export default class ThemeSeam extends Component<Signature> {
           contract clean. It never receives pointer events, so the handle
           underneath still gets the drag. }}
       <span class="theme-seam__grip-wrap" aria-hidden="true">
-        <svg
-          class="theme-seam__grip"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          focusable="false"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
-          />
-        </svg>
+        <IconChevronsLeftRight class="theme-seam__grip" focusable="false" />
       </span>
     </div>
   </template>

--- a/site/app/components/icons.gts
+++ b/site/app/components/icons.gts
@@ -1,503 +1,146 @@
 /**
  * Common icons used in documentation examples
  *
- * Each icon declares `Element: SVGSVGElement` so callers may pass `class` and
- * ARIA attributes through `...attributes`. Without the signature these were
- * inferred as taking no element, and every `<SomeIcon class="..." />` in the
- * app was a Glint error.
+ * Each icon wraps a Lucide icon (via unplugin-icons' `~icons/lucide/*` virtual
+ * modules, compiled to a Glimmer template-only component by `compiler: 'ember'`
+ * in site/vite.config.mjs) with this file's stable size class, so every `.md`
+ * demo that imports from `site/components/icons` keeps working unchanged.
  */
 import type { TOC } from '@ember/component/template-only';
+import IconEye from '~icons/lucide/eye';
+import IconPencil from '~icons/lucide/pencil';
+import IconCopy from '~icons/lucide/copy';
+import IconShare2 from '~icons/lucide/share-2';
+import IconDownload from '~icons/lucide/download';
+import IconArchive from '~icons/lucide/archive';
+import IconTrash2 from '~icons/lucide/trash-2';
+import IconPlus from '~icons/lucide/plus';
+import IconFilter from '~icons/lucide/filter';
+import IconChevronDown from '~icons/lucide/chevron-down';
+import IconStar from '~icons/lucide/star';
+import IconSearch from '~icons/lucide/search';
+import IconSun from '~icons/lucide/sun';
+import IconMoon from '~icons/lucide/moon';
+import IconUser from '~icons/lucide/user';
+import IconCheck from '~icons/lucide/check';
+import IconCode from '~icons/lucide/code';
+import IconPalette from '~icons/lucide/palette';
+import IconBookOpen from '~icons/lucide/book-open';
+import IconTarget from '~icons/lucide/target';
+import IconAccessibility from '~icons/lucide/accessibility';
+import IconSparkles from '~icons/lucide/sparkles';
+import IconComponent from '~icons/lucide/component';
+import IconPackage from '~icons/lucide/package';
+import IconRocket from '~icons/lucide/rocket';
+import IconSettings from '~icons/lucide/settings';
+import IconLogOut from '~icons/lucide/log-out';
 
 type IconSignature = TOC<{ Element: SVGSVGElement }>;
 
 export const ViewIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
-    />
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-    />
-  </svg>
+  <IconEye class="size-icon-lg" ...attributes />
 </template>;
 
 export const EditIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
-    />
-  </svg>
+  <IconPencil class="size-icon-lg" ...attributes />
 </template>;
 
 export const DuplicateIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
-    />
-  </svg>
+  <IconCopy class="size-icon-lg" ...attributes />
 </template>;
 
 export const ShareIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"
-    />
-  </svg>
+  <IconShare2 class="size-icon-lg" ...attributes />
 </template>;
 
 export const DownloadIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
-    />
-  </svg>
+  <IconDownload class="size-icon-lg" ...attributes />
 </template>;
 
 export const ArchiveIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z"
-    />
-  </svg>
+  <IconArchive class="size-icon-lg" ...attributes />
 </template>;
 
 export const DeleteIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
-    />
-  </svg>
+  <IconTrash2 class="size-icon-lg" ...attributes />
 </template>;
 
 export const PlusIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M12 4.5v15m7.5-7.5h-15"
-    />
-  </svg>
+  <IconPlus class="size-icon-lg" ...attributes />
 </template>;
 
 export const FilterIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"
-    />
-  </svg>
+  <IconFilter class="size-icon-lg" ...attributes />
 </template>;
 
 export const ChevronDownIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-md"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m19.5 8.25-7.5 7.5-7.5-7.5"
-    />
-  </svg>
+  <IconChevronDown class="size-icon-md" ...attributes />
 </template>;
 
 export const StarIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
-    />
-  </svg>
+  <IconStar class="size-icon-lg" ...attributes />
 </template>;
 
 export const SearchIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-md"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-    />
-  </svg>
+  <IconSearch class="size-icon-md" ...attributes />
 </template>;
 
 export const SunIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    class="size-icon-sm"
-    ...attributes
-  >
-    <path
-      d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5H21a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM7.758 17.303a.75.75 0 0 0-1.061-1.06l-1.591 1.59a.75.75 0 0 0 1.06 1.061l1.591-1.59ZM6 12a.75.75 0 0 1-.75.75H3a.75.75 0 0 1 0-1.5h2.25A.75.75 0 0 1 6 12ZM6.697 7.757a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 0 0-1.061 1.06l1.59 1.591Z"
-    />
-  </svg>
+  <IconSun class="size-icon-sm" ...attributes />
 </template>;
 
 export const MoonIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    class="size-icon-sm"
-    ...attributes
-  >
-    <path
-      fill-rule="evenodd"
-      d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z"
-      clip-rule="evenodd"
-    />
-  </svg>
+  <IconMoon class="size-icon-sm" ...attributes />
 </template>;
 
 export const UserIcon: IconSignature = <template>
-  <svg
-    fill="currentColor"
-    viewBox="0 0 20 20"
-    class="size-icon-sm"
-    ...attributes
-  >
-    <path
-      fill-rule="evenodd"
-      d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-      clip-rule="evenodd"
-    />
-  </svg>
+  <IconUser class="size-icon-sm" ...attributes />
 </template>;
 
 export const CheckIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="2"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m4.5 12.75 6 6 9-13.5"
-    />
-  </svg>
+  <IconCheck class="size-icon-lg" ...attributes />
 </template>;
 
 export const CodeIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
-    />
-  </svg>
+  <IconCode class="size-icon-lg" ...attributes />
 </template>;
 
 export const PaletteIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M4.098 19.902a3.75 3.75 0 0 0 5.304 0l6.401-6.402M6.75 21A3.75 3.75 0 0 1 3 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 0 0 3.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008Z"
-    />
-  </svg>
+  <IconPalette class="size-icon-lg" ...attributes />
 </template>;
 
 export const BookIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
-    />
-  </svg>
+  <IconBookOpen class="size-icon-lg" ...attributes />
 </template>;
 
 export const TargetIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-    />
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
-    />
-  </svg>
+  <IconTarget class="size-icon-lg" ...attributes />
 </template>;
 
 export const AccessibilityIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
-    />
-  </svg>
+  <IconAccessibility class="size-icon-lg" ...attributes />
 </template>;
 
 export const SparklesIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
-    />
-  </svg>
+  <IconSparkles class="size-icon-lg" ...attributes />
 </template>;
 
 export const ComponentIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M21 7.5l-2.25-1.313M21 7.5v2.25m0-2.25l-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3l2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75l2.25-1.313M12 21.75V19.5m0 2.25l-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25"
-    />
-  </svg>
+  <IconComponent class="size-icon-lg" ...attributes />
 </template>;
 
 export const PackageIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z"
-    />
-  </svg>
+  <IconPackage class="size-icon-lg" ...attributes />
 </template>;
 
 export const RocketIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"
-    />
-  </svg>
+  <IconRocket class="size-icon-lg" ...attributes />
 </template>;
 
 export const SettingsIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
-    />
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-    />
-  </svg>
+  <IconSettings class="size-icon-lg" ...attributes />
 </template>;
 
 export const LogoutIcon: IconSignature = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="size-icon-lg"
-    ...attributes
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75"
-    />
-  </svg>
+  <IconLogOut class="size-icon-lg" ...attributes />
 </template>;

--- a/site/app/components/signature.gts
+++ b/site/app/components/signature.gts
@@ -3,6 +3,7 @@ import { htmlSafe } from '@ember/template';
 import data, { type ComponentDoc } from './signature-data';
 import { Popover } from 'frontile';
 import type { TOC } from '@ember/component/template-only';
+import IconInfo from '~icons/lucide/info';
 
 interface SignatureSignature {
   Args: {
@@ -201,19 +202,6 @@ const PropertiesTable: TOC<{
   </div>
 </template>;
 
-const InfoIcon = <template>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 25 25"
-    stroke-width="1.5"
-    stroke="currentColor"
-    class="w-5 h-5"
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"
-    />
-  </svg>
+const InfoIcon: TOC<{ Element: SVGSVGElement }> = <template>
+  <IconInfo class="w-5 h-5" ...attributes />
 </template>;

--- a/site/app/components/theme-docs/color-palette-grid.gts
+++ b/site/app/components/theme-docs/color-palette-grid.gts
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { hash } from '@ember/helper';
 import ColorSwatch from './color-swatch';
+import { CheckIcon } from '../icons';
 
 import {
   colorLevels,
@@ -70,19 +71,7 @@ export default class ColorPaletteGrid extends Component<ColorPaletteGridSignatur
           class="mb-4 p-3 bg-success-subtle text-success-strong rounded border border-success-soft"
         >
           <div class="flex items-center gap-2">
-            <svg
-              class="size-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
+            <CheckIcon class="size-5" />
             <span class="font-mono text-sm">{{this.copiedClass}}</span>
             <span class="text-sm">copied to clipboard!</span>
           </div>

--- a/site/app/components/version-dropdown.gts
+++ b/site/app/components/version-dropdown.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { Dropdown } from 'frontile';
 import { currentDomain, stripScheme } from 'site/utils/origin';
+import { ChevronDownIcon } from './icons';
 
 interface VersionDropdownSignature {
   Element: HTMLDivElement;
@@ -94,19 +95,7 @@ export default class VersionDropdown extends Component<VersionDropdownSignature>
           @class="flex items-center gap-2 px-3 py-2 text-sm font-medium text-neutral-strong bg-neutral-subtle border border-neutral-subtle rounded-lg hover:bg-neutral-subtle focus:bg-neutral-subtle transition-all duration-200"
         >
           <span>{{this.getVersionLabel this.currentVersion}}</span>
-          <svg
-            class="w-4 h-4 text-neutral-firm"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
+          <ChevronDownIcon class="w-4 h-4 text-neutral-firm" />
         </d.Trigger>
 
         <d.Menu

--- a/site/package.json
+++ b/site/package.json
@@ -66,6 +66,7 @@
     "@glint/environment-ember-loose": "^1.5.2",
     "@glint/environment-ember-template-imports": "^1.5.2",
     "@glint/template": "^1.8.0",
+    "@iconify-json/lucide": "^1.2.129",
     "@rollup/plugin-babel": "^7.1.0",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
@@ -112,6 +113,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.67.0",
     "unified": "^11.0.5",
+    "unplugin-icons": "^23.0.1",
     "valibot": "^1.4.2",
     "vite": "^8.2.1"
   },

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -25,7 +25,8 @@
     "types": [
       "ember-source/types",
       "@embroider/core/virtual",
-      "vite/client"
+      "vite/client",
+      "unplugin-icons/types/ember"
     ]
   },
 }

--- a/site/vite.config.mjs
+++ b/site/vite.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 import { extensions, classicEmberSupport, ember } from '@embroider/vite';
 import { babel } from '@rollup/plugin-babel';
 import docfy from '@docfy/ember-vite';
+import Icons from 'unplugin-icons/vite';
 
 // Two builds from one config:
 //
@@ -35,6 +36,7 @@ export default defineConfig(({ isSsrBuild }) => ({
             }),
       },
     ),
+    Icons({ compiler: 'ember' }),
 
     // Nothing serves CSS out of the Node bundle.
     ...(isSsrBuild ? [] : [tailwindcss()]),


### PR DESCRIPTION
## Summary
- Wires up `unplugin-icons` (Vite plugin, `compiler: 'ember'`) with the Lucide icon set (`@iconify-json/lucide`) in the docs site (`site/`)
- Rewrites `site/app/components/icons.gts` so its 27 exports are thin wrappers around Lucide icons, keeping every export name unchanged so the 19 component `.md` demos that import from `site/components/icons` needed no edits
- Replaces the remaining one-off hand-rolled `<svg>` icons across site chrome (theme switcher, version dropdown, copy-page button, search jump-to, sidebar nav toggle/chevron, homepage theme-seam grip, color-palette copy notice, signature info icon, and the docfy-page edit/prev/next links) with Lucide equivalents
- Excludes brand marks on purpose: `logo.gts` (Frontile wordmark) and the GitHub logo in `docfy-header.gts` are untouched
- No changes to `packages/frontile/src/**`, `packages/theme/**`, or `test-app/**` — this is a docs-site-only refactor

## Notes for reviewers
- `pnpm --filter site build` (the full build, including SSR prerender) currently fails on every doc page with `uncaught: kbd is not a function` — this is a **pre-existing** bug in the Kbd/CommandDialog feature, confirmed present on `main` before this branch, and unrelated to this change. Every commit here was instead verified with `pnpm --filter site build:client` (client-only Vite build), which succeeds cleanly.
- The `test-app` suite currently has 207 pre-existing failures, all in `SegmentedControl` — confirmed present on `main` and untouched by this branch's diff.
- One design note: Lucide only ships an outline/stroke icon style, so a few icons that were previously Heroicons *solid* (`Sun`, `Moon`, `User`, `Check`) now render as outline — an intentional side effect of unifying on one icon library, not a bug.

## Test plan
- [x] `pnpm --filter site build:client` succeeds
- [x] Every icon-consuming `.md` doc demo type-checks/builds unchanged (no `.md` file edits needed beyond the "Icon Sizes" page's own example)
- [x] Visual spot-check on the Netlify deploy preview: confirmed via DOM inspection that the theme switcher shows the moon icon + "Switch to Light Mode" in dark mode (correct current-state mapping), the mobile sidebar "Contents" toggle renders `class="size-8"` (both axes, not shrunk), and the Button doc's "With Icons" section renders 17 Lucide SVGs with the expected `size-icon-lg` classes intact — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
