### PR TITLE
Fix Kbd API docs table not rendering

### DIFF
--- a/packages/frontile/src/components/utilities/kbd.md
+++ b/packages/frontile/src/components/utilities/kbd.md
@@ -180,4 +180,4 @@ users who do not recognise a glyph.
 
 ## API
 
-<Signature @package="frontile" @component="Kbd" />
+<Signature @component="Kbd" />


### PR DESCRIPTION
## Summary
- `kbd.md`'s API section was blank because it passed `@package="frontile"` to `<Signature>`, but the docgen tool stamps `package: 'unknown'` for every component in the consolidated `frontile` package (their `.d.ts` files live one folder deeper than the tool's package-name regex expects), so the lookup never matched.
- Removed the `@package` argument, matching how every other component doc invokes `<Signature @component="..." />`.

## Test plan
- [x] Traced `Signature`'s filter logic (`site/app/components/signature.gts`) and confirmed `signature-data.ts` has `package: 'unknown'` for `Kbd` (and other frontile components), so dropping `@package` restores the match.
- [ ] Visual confirmation in the docs site is still pending — local `pnpm install` for `site/` needs a full reinstall to pick up `@docfy/plugin-shiki`.