### PR TITLE
fix(overlays): forward preventAutoFocus from Drawer and Modal to Overlay

### DIFF
--- a/packages/frontile/src/components/overlays/drawer.gts
+++ b/packages/frontile/src/components/overlays/drawer.gts
@@ -36,6 +36,7 @@ export interface DrawerArgs extends Pick<
   | 'closeOnOutsideClick'
   | 'closeOnEscapeKey'
   | 'backdropTransition'
+  | 'preventAutoFocus'
 > {
   /**
    * The transition to be used in the Drawer.
@@ -234,6 +235,7 @@ export default class Drawer extends Component<DrawerSignature> {
       @backdropTransition={{@backdropTransition}}
       @transition={{this.transition}}
       @closeOnOverlayElementClick={{true}}
+      @preventAutoFocus={{@preventAutoFocus}}
     >
       <div
         class={{this.classes.base class=@classes.base}}

--- a/packages/frontile/src/components/overlays/drawer.md
+++ b/packages/frontile/src/components/overlays/drawer.md
@@ -736,7 +736,9 @@ In development, a drawer that ends up with no accessible name at all — no `Hea
 `frontile.drawer.missing-accessible-name`. It is compiled out of production builds.
 
 `aria-modal="true"` is dropped when `@disableFocusTrap={{true}}`: with the trap off the page
-behind really is reachable, and claiming otherwise would mislead screen reader users.
+behind really is reachable, and claiming otherwise would mislead screen reader users. Note
+that the drawer still auto-focuses itself in this case, unless `@preventAutoFocus={{true}}`
+is also passed — see [Overlay](./overlay.md#accessibility).
 
 Behavior inherited from [Overlay](./overlay.md):
 

--- a/packages/frontile/src/components/overlays/modal.gts
+++ b/packages/frontile/src/components/overlays/modal.gts
@@ -36,6 +36,7 @@ export interface ModalArgs extends Pick<
   | 'closeOnOutsideClick'
   | 'closeOnEscapeKey'
   | 'backdropTransition'
+  | 'preventAutoFocus'
 > {
   /**
    * The transition to be used in the Modal.
@@ -234,6 +235,7 @@ export default class Modal extends Component<ModalSignature> {
       @backdropTransition={{@backdropTransition}}
       @transition={{this.transition}}
       @closeOnOverlayElementClick={{true}}
+      @preventAutoFocus={{@preventAutoFocus}}
     >
       <div
         class={{this.classes.base class=@classes.base}}

--- a/packages/frontile/src/components/overlays/modal.md
+++ b/packages/frontile/src/components/overlays/modal.md
@@ -839,7 +839,9 @@ In development, a modal that ends up with no accessible name at all — no `Head
 `frontile.modal.missing-accessible-name`. It is compiled out of production builds.
 
 `aria-modal="true"` is dropped when `@disableFocusTrap={{true}}`: with the trap off the page
-behind really is reachable, and claiming otherwise would mislead screen reader users.
+behind really is reachable, and claiming otherwise would mislead screen reader users. Note
+that the modal still auto-focuses itself in this case, unless `@preventAutoFocus={{true}}`
+is also passed — see [Overlay](./overlay.md#accessibility).
 
 Behavior inherited from [Overlay](./overlay.md):
 

--- a/packages/frontile/src/components/overlays/overlay.md
+++ b/packages/frontile/src/components/overlays/overlay.md
@@ -591,6 +591,7 @@ accessible name.
 | -------------- | -------------------------------------------------------------------------- |
 | Focus on open  | Moves into the overlay; `ember-focus-trap` keeps it there                  |
 | Focus trap     | Disable with `@disableFocusTrap={{true}}`, or tune via `@focusTrapOptions` |
+| Focus without trap | Still auto-focuses the overlay when `@disableFocusTrap={{true}}`, unless `@preventAutoFocus={{true}}` |
 | Focus on close | Returns to the previously focused element, unless `@preventFocusRestore`   |
 | `Escape`       | Closes, unless `@closeOnEscapeKey={{false}}`                               |
 | Backdrop click | Closes, unless `@closeOnOutsideClick={{false}}`                            |

--- a/test-app/tests/integration/components/overlays/drawer-test.gts
+++ b/test-app/tests/integration/components/overlays/drawer-test.gts
@@ -584,6 +584,53 @@ module('Integration | Component | @frontile/overlays/Drawer', function (hooks) {
     assert.dom('[data-test-id="drawer"]').doesNotHaveAttribute('aria-modal');
   });
 
+  test('it auto focuses when @disableFocusTrap={{true}}, unless @preventAutoFocus={{true}}', async function (assert) {
+    const isOpen = cell(false);
+    const preventAutoFocus = cell<boolean | undefined>(undefined);
+
+    await render(
+      <template>
+        <button type="button" data-test-id="some-button">Button</button>
+        <Drawer
+          @isOpen={{isOpen.current}}
+          @disableFocusTrap={{true}}
+          @preventAutoFocus={{preventAutoFocus.current}}
+          @disableTransitions={{true}}
+          data-test-id="drawer"
+          as |m|
+        >
+          <m.Body>My Content</m.Body>
+        </Drawer>
+      </template>
+    );
+
+    (find('[data-test-id="some-button"]') as HTMLButtonElement).focus();
+    isOpen.current = true;
+    await settled();
+    assert
+      .dom(document.activeElement)
+      .hasAttribute(
+        'data-component',
+        'overlay',
+        'auto focuses the drawer by default'
+      );
+
+    isOpen.current = false;
+    await settled();
+
+    preventAutoFocus.current = true;
+    (find('[data-test-id="some-button"]') as HTMLButtonElement).focus();
+    isOpen.current = true;
+    await settled();
+    assert
+      .dom(document.activeElement)
+      .hasAttribute(
+        'data-test-id',
+        'some-button',
+        'does not steal focus when @preventAutoFocus={{true}}'
+      );
+  });
+
   test('it does not render aria-labelledby when no header is rendered, and warns', async function (assert) {
     const isOpen = cell(true);
 

--- a/test-app/tests/integration/components/overlays/modal-test.gts
+++ b/test-app/tests/integration/components/overlays/modal-test.gts
@@ -480,6 +480,53 @@ module('Integration | Component | @frontile/overlays/modal', function (hooks) {
     assert.dom('[data-test-id="modal"]').doesNotHaveAttribute('aria-modal');
   });
 
+  test('it auto focuses when @disableFocusTrap={{true}}, unless @preventAutoFocus={{true}}', async function (assert) {
+    const isOpen = cell(false);
+    const preventAutoFocus = cell<boolean | undefined>(undefined);
+
+    await render(
+      <template>
+        <button type="button" data-test-id="some-button">Button</button>
+        <Modal
+          @isOpen={{isOpen.current}}
+          @disableFocusTrap={{true}}
+          @preventAutoFocus={{preventAutoFocus.current}}
+          @disableTransitions={{true}}
+          data-test-id="modal"
+          as |m|
+        >
+          <m.Body>My Content</m.Body>
+        </Modal>
+      </template>
+    );
+
+    (find('[data-test-id="some-button"]') as HTMLButtonElement).focus();
+    isOpen.current = true;
+    await settled();
+    assert
+      .dom(document.activeElement)
+      .hasAttribute(
+        'data-component',
+        'overlay',
+        'auto focuses the modal by default'
+      );
+
+    isOpen.current = false;
+    await settled();
+
+    preventAutoFocus.current = true;
+    (find('[data-test-id="some-button"]') as HTMLButtonElement).focus();
+    isOpen.current = true;
+    await settled();
+    assert
+      .dom(document.activeElement)
+      .hasAttribute(
+        'data-test-id',
+        'some-button',
+        'does not steal focus when @preventAutoFocus={{true}}'
+      );
+  });
+
   test('it does not render aria-labelledby when no header is rendered, and warns', async function (assert) {
     const isOpen = cell(true);
 


### PR DESCRIPTION
## Summary

- `Overlay` already supports `@preventAutoFocus` to opt out of its auto-focus-on-open behavior when `@disableFocusTrap={{true}}`, but `Drawer` and `Modal` never forwarded it — it was missing from both `DrawerArgs`/`ModalArgs`' `Pick<...>` of `Overlay`'s args, and from their `<Overlay>` invocation.
- Adds `preventAutoFocus` to both components' picked args and forwards it to their internal `<Overlay>`, matching how every other `Overlay` arg is already forwarded.
- Updates the co-located `drawer.md`/`modal.md`/`overlay.md` docs to mention the auto-focus-without-a-trap behavior and the new escape hatch.

Fixes #551.

## Test plan

- [x] Added a failing-first test to both `drawer-test.gts` and `modal-test.gts` asserting the dialog auto-focuses by default when `@disableFocusTrap={{true}}`, and that `@preventAutoFocus={{true}}` prevents it — confirmed each fails without the fix and passes with it.
- [x] `pnpm --filter @frontile/theme build && pnpm --filter frontile build`
- [x] `cd test-app && pnpm ember test --filter="Drawer"` (28/28 pass), `--filter="Modal"` (32/32), `--filter="Overlay"` (109/109)
- [x] `pnpm exec eslint` / `pnpm exec ember-template-lint` on the changed files — clean
- [x] `pnpm --filter frontile lint:types` — clean
- [x] `cd test-app && pnpm lint:types` — no new errors (diffed against `main`; the pre-existing failures in unrelated files are unchanged)
