### PR TITLE
fix(theme): give the underline tabs room between labels and the rule

### DIFF
--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -161,7 +161,13 @@ const tabs = tv({
       variant: 'underline',
       orientation: 'horizontal',
       class: {
-        list: 'gap-1 border-b border-neutral-mild dark:border-neutral-soft',
+        // `pb-2` is what separates the labels from the rule, and it belongs on
+        // the list rather than as a margin on each tab: an absolutely
+        // positioned box resolves its offsets against the padding box, so the
+        // bar stays welded to the rule at `bottom-0` while the padding pushes
+        // the tabs -- and with them their hover chips -- clear of it. A chip
+        // that runs into the rule is the thing this buys off.
+        list: 'gap-1 pb-2 border-b border-neutral-mild dark:border-neutral-soft',
         indicator: [
           'top-auto bottom-0 h-0.5 rounded-full',
           'w-[var(--fr-si-width)]',
@@ -173,7 +179,8 @@ const tabs = tv({
       variant: 'underline',
       orientation: 'vertical',
       class: {
-        list: 'gap-1 border-l border-neutral-mild dark:border-neutral-soft',
+        // The same gap, on the axis this orientation puts the rule on.
+        list: 'gap-1 ps-2 border-l border-neutral-mild dark:border-neutral-soft',
         indicator: [
           'left-0 w-0.5 rounded-full',
           'h-[var(--fr-si-height)]',


### PR DESCRIPTION
Follow-up to #545 (merged). The `underline` variant's tab boxes ran flush to the rule, so the labels sat on top of it and the hover chip collided with it — the chip's bottom edge and the line were the same pixel.

**Before / after** (dark, hovering an unselected tab): the chip now clears the rule, and the selected label has room above the bar.

The gap goes on the **list as padding**, not as a margin on each tab. An absolutely positioned box resolves its offsets against the padding box, so the bar stays welded to the rule at `bottom-0` while the padding pushes the tabs — and with them their hover chips — clear of it. That's one class per orientation rather than one per size, and it keeps the bar and the rule from drifting apart.

Vertical gets the same gap on the axis its rule sits on (`ps-2` against `border-l`).

Measured after the change: list padding 8px, tab bottom to rule 9px, bar still flush at the rule, `solid` untouched (`p-1`).

**Verified:** 1435 tests / 0 failures, site 81 rendered / 0 failed, types clean, `lint:js` 0 errors. Checked in light and dark, horizontal and vertical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
