### PR TITLE
fix(theme): give the underline variant room between the labels and th…

### DIFF
--- a/packages/theme/src/components/tabs.ts
+++ b/packages/theme/src/components/tabs.ts
@@ -161,7 +161,13 @@ const tabs = tv({
       variant: 'underline',
       orientation: 'horizontal',
       class: {
-        list: 'gap-1 border-b border-neutral-mild dark:border-neutral-soft',
+        // `pb-2` is what separates the labels from the rule, and it belongs on
+        // the list rather than as a margin on each tab: an absolutely
+        // positioned box resolves its offsets against the padding box, so the
+        // bar stays welded to the rule at `bottom-0` while the padding pushes
+        // the tabs -- and with them their hover chips -- clear of it. A chip
+        // that runs into the rule is the thing this buys off.
+        list: 'gap-1 pb-2 border-b border-neutral-mild dark:border-neutral-soft',
         indicator: [
           'top-auto bottom-0 h-0.5 rounded-full',
           'w-[var(--fr-si-width)]',
@@ -173,7 +179,8 @@ const tabs = tv({
       variant: 'underline',
       orientation: 'vertical',
       class: {
-        list: 'gap-1 border-l border-neutral-mild dark:border-neutral-soft',
+        // The same gap, on the axis this orientation puts the rule on.
+        list: 'gap-1 ps-2 border-l border-neutral-mild dark:border-neutral-soft',
         indicator: [
           'left-0 w-0.5 rounded-full',
           'h-[var(--fr-si-height)]',


### PR DESCRIPTION
…e rule

The tab boxes ran flush to the rule, so the labels sat on top of it and the hover chip collided with it -- the chip's bottom edge and the line were the same pixel.

The gap goes on the list as padding rather than as a margin on each tab: an absolutely positioned box resolves its offsets against the padding box, so the bar stays welded to the rule at bottom-0 while the padding pushes the tabs, and with them their hover chips, clear of it. One class per orientation instead of one per size.