### PR TITLE
Apply the .demo-stack convention across the component docs

### DIFF
--- a/packages/frontile/src/components/collections/command.md
+++ b/packages/frontile/src/components/collections/command.md
@@ -88,41 +88,43 @@ export default class CommandDialogExample extends Component {
   };
 
   <template>
-    <div class='flex items-center gap-4'>
-      <Button @appearance='outlined' {{on 'click' this.open}}>
-        Open palette
-        <Kbd @keys='mod+k' @size='sm' @appearance='outlined' @class='ml-2' />
-      </Button>
-      {{#if this.lastSelected}}
-        <span class='font-body text-body-sm text-neutral'>Selected:
-          {{this.lastSelected}}</span>
-      {{/if}}
-    </div>
+    <div class='demo-stack items-center'>
+      <div class='flex items-center gap-4'>
+        <Button @appearance='outlined' {{on 'click' this.open}}>
+          Open palette
+          <Kbd @keys='mod+k' @size='sm' @appearance='outlined' @class='ml-2' />
+        </Button>
+        {{#if this.lastSelected}}
+          <span class='font-body text-body-sm text-neutral'>Selected:
+            {{this.lastSelected}}</span>
+        {{/if}}
+      </div>
 
-    <CommandDialog
-      @isOpen={{this.isOpen}}
-      @onOpen={{this.open}}
-      @onClose={{this.close}}
-      @onSelect={{this.select}}
-      @shortcut='mod+k'
-      @items={{commands}}
-      @groupBy='section'
-      @label='Search commands'
-      @placeholder='Type a command or search…'
-      as |c|
-    >
-      <c.Input />
-      <c.List>
-        <:item as |ctx|>
-          <ctx.Item @key={{ctx.key}} @shortcut={{ctx.item.shortcut}}>
-            <:start><ctx.item.Icon /></:start>
-            <:default>{{ctx.label}}</:default>
-          </ctx.Item>
-        </:item>
-        <:empty>No results for "{{c.query}}"</:empty>
-      </c.List>
-      <c.Footer />
-    </CommandDialog>
+      <CommandDialog
+        @isOpen={{this.isOpen}}
+        @onOpen={{this.open}}
+        @onClose={{this.close}}
+        @onSelect={{this.select}}
+        @shortcut='mod+k'
+        @items={{commands}}
+        @groupBy='section'
+        @label='Search commands'
+        @placeholder='Type a command or search…'
+        as |c|
+      >
+        <c.Input />
+        <c.List>
+          <:item as |ctx|>
+            <ctx.Item @key={{ctx.key}} @shortcut={{ctx.item.shortcut}}>
+              <:start><ctx.item.Icon /></:start>
+              <:default>{{ctx.label}}</:default>
+            </ctx.Item>
+          </:item>
+          <:empty>No results for "{{c.query}}"</:empty>
+        </c.List>
+        <c.Footer />
+      </CommandDialog>
+    </div>
   </template>
 }
 ```
@@ -145,25 +147,27 @@ const commands = [
 ];
 
 <template>
-  <Command @items={{commands}} @isBordered={{true}} as |c|>
-    {{! the search field — carries the combobox semantics }}
-    <c.Input @placeholder='Search…' />
+  <div class='demo-stack'>
+    <Command @items={{commands}} @isBordered={{true}} as |c|>
+      {{! the search field — carries the combobox semantics }}
+      <c.Input @placeholder='Search…' />
 
-    {{! the results — ranked, grouped, keyboard navigable }}
-    <c.List>
-      <:item as |ctx|>
-        {{! ctx yields the item, its key, its label, and a bound Item component }}
-        <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
-      </:item>
-      <:empty>Nothing matched.</:empty>
-      <:loading>Searching…</:loading>
-      {{! async only: shown before anything has been typed }}
-      <:prompt>Start typing to search.</:prompt>
-    </c.List>
+      {{! the results — ranked, grouped, keyboard navigable }}
+      <c.List>
+        <:item as |ctx|>
+          {{! ctx yields the item, its key, its label, and a bound Item component }}
+          <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
+        </:item>
+        <:empty>Nothing matched.</:empty>
+        <:loading>Searching…</:loading>
+        {{! async only: shown before anything has been typed }}
+        <:prompt>Start typing to search.</:prompt>
+      </c.List>
 
-    {{! keyboard hints; c.query, c.resultCount and c.isLoading are yielded too }}
-    <c.Footer />
-  </Command>
+      {{! keyboard hints; c.query, c.resultCount and c.isLoading are yielded too }}
+      <c.Footer />
+    </Command>
+  </div>
 </template>
 ```
 
@@ -184,19 +188,21 @@ const commands = [
 ];
 
 <template>
-  <Command
-    @items={{commands}}
-    @isBordered={{true}}
-    @placeholder='Type a command or search…'
-    as |c|
-  >
-    <c.Input />
-    <c.List>
-      <:item as |ctx|>
-        <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
-      </:item>
-    </c.List>
-  </Command>
+  <div class='demo-stack'>
+    <Command
+      @items={{commands}}
+      @isBordered={{true}}
+      @placeholder='Type a command or search…'
+      as |c|
+    >
+      <c.Input />
+      <c.List>
+        <:item as |ctx|>
+          <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
+        </:item>
+      </c.List>
+    </Command>
+  </div>
 </template>
 ```
 
@@ -220,19 +226,21 @@ const components = [
 ];
 
 <template>
-  <Command
-    @items={{components}}
-    @isBordered={{true}}
-    @placeholder="Try 'button' or 'bg'…"
-    as |c|
-  >
-    <c.Input />
-    <c.List>
-      <:item as |ctx|>
-        <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
-      </:item>
-    </c.List>
-  </Command>
+  <div class='demo-stack'>
+    <Command
+      @items={{components}}
+      @isBordered={{true}}
+      @placeholder="Try 'button' or 'bg'…"
+      as |c|
+    >
+      <c.Input />
+      <c.List>
+        <:item as |ctx|>
+          <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
+        </:item>
+      </c.List>
+    </Command>
+  </div>
 </template>
 ```
 
@@ -252,22 +260,24 @@ const components = [
 const searchFields = (item) => [item.label, item.section];
 
 <template>
-  <Command
-    @items={{components}}
-    @searchFields={{searchFields}}
-    @isBordered={{true}}
-    @placeholder="Try 'overlays'…"
-    as |c|
-  >
-    <c.Input />
-    <c.List>
-      <:item as |ctx|>
-        <ctx.Item @key={{ctx.key}} @description={{ctx.item.section}}>
-          {{ctx.label}}
-        </ctx.Item>
-      </:item>
-    </c.List>
-  </Command>
+  <div class='demo-stack'>
+    <Command
+      @items={{components}}
+      @searchFields={{searchFields}}
+      @isBordered={{true}}
+      @placeholder="Try 'overlays'…"
+      as |c|
+    >
+      <c.Input />
+      <c.List>
+        <:item as |ctx|>
+          <ctx.Item @key={{ctx.key}} @description={{ctx.item.section}}>
+            {{ctx.label}}
+          </ctx.Item>
+        </:item>
+      </c.List>
+    </Command>
+  </div>
 </template>
 ```
 
@@ -288,20 +298,22 @@ const components = [
 ];
 
 <template>
-  <Command
-    @items={{components}}
-    @filter={{looseFilter}}
-    @isBordered={{true}}
-    @placeholder="Try 'btn'…"
-    as |c|
-  >
-    <c.Input />
-    <c.List>
-      <:item as |ctx|>
-        <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
-      </:item>
-    </c.List>
-  </Command>
+  <div class='demo-stack'>
+    <Command
+      @items={{components}}
+      @filter={{looseFilter}}
+      @isBordered={{true}}
+      @placeholder="Try 'btn'…"
+      as |c|
+    >
+      <c.Input />
+      <c.List>
+        <:item as |ctx|>
+          <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
+        </:item>
+      </c.List>
+    </Command>
+  </div>
 </template>
 ```
 
@@ -329,22 +341,24 @@ const commands = [
 ];
 
 <template>
-  <Command
-    @items={{commands}}
-    @groupBy='section'
-    @groups={{array 'Suggestions' 'Settings'}}
-    @disabledKeys={{array 'calculator'}}
-    @isBordered={{true}}
-    @placeholder='Type a command or search…'
-    as |c|
-  >
-    <c.Input />
-    <c.List>
-      <:item as |ctx|>
-        <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
-      </:item>
-    </c.List>
-  </Command>
+  <div class='demo-stack'>
+    <Command
+      @items={{commands}}
+      @groupBy='section'
+      @groups={{array 'Suggestions' 'Settings'}}
+      @disabledKeys={{array 'calculator'}}
+      @isBordered={{true}}
+      @placeholder='Type a command or search…'
+      as |c|
+    >
+      <c.Input />
+      <c.List>
+        <:item as |ctx|>
+          <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
+        </:item>
+      </c.List>
+    </Command>
+  </div>
 </template>
 ```
 
@@ -364,17 +378,19 @@ const commands = [
 ];
 
 <template>
-  <Command @items={{commands}} @isBordered={{true}} as |c|>
-    <c.Input @placeholder='Search…' />
-    <c.List>
-      <:item as |ctx|>
-        <ctx.Item @key={{ctx.key}} @shortcut={{ctx.item.shortcut}}>
-          <:start><ctx.item.Icon /></:start>
-          <:default>{{ctx.label}}</:default>
-        </ctx.Item>
-      </:item>
-    </c.List>
-  </Command>
+  <div class='demo-stack'>
+    <Command @items={{commands}} @isBordered={{true}} as |c|>
+      <c.Input @placeholder='Search…' />
+      <c.List>
+        <:item as |ctx|>
+          <ctx.Item @key={{ctx.key}} @shortcut={{ctx.item.shortcut}}>
+            <:start><ctx.item.Icon /></:start>
+            <:default>{{ctx.label}}</:default>
+          </ctx.Item>
+        </:item>
+      </c.List>
+    </Command>
+  </div>
 </template>
 ```
 
@@ -393,18 +409,20 @@ const commands = [
 ];
 
 <template>
-  <Command @items={{commands}} @isBordered={{true}} @size='sm' as |c|>
-    <c.Input @placeholder='Search components…' />
-    <c.List>
-      <:item as |ctx|>
-        <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
-      </:item>
-    </c.List>
-    <c.Footer as |f|>
-      <f.Hint><f.Kbd @keys='enter' /> Go to page</f.Hint>
-      <f.Hint><f.Kbd @keys='mod+c' /> Copy link</f.Hint>
-    </c.Footer>
-  </Command>
+  <div class='demo-stack'>
+    <Command @items={{commands}} @isBordered={{true}} @size='sm' as |c|>
+      <c.Input @placeholder='Search components…' />
+      <c.List>
+        <:item as |ctx|>
+          <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
+        </:item>
+      </c.List>
+      <c.Footer as |f|>
+        <f.Hint><f.Kbd @keys='enter' /> Go to page</f.Hint>
+        <f.Hint><f.Kbd @keys='mod+c' /> Copy link</f.Hint>
+      </c.Footer>
+    </Command>
+  </div>
 </template>
 ```
 
@@ -455,22 +473,24 @@ export default class AsyncCommandExample extends Component {
   };
 
   <template>
-    <Command
-      @onSearch={{this.search}}
-      @isBordered={{true}}
-      @placeholder='Search countries…'
-      as |c|
-    >
-      <c.Input />
-      <c.List>
-        <:item as |ctx|>
-          <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
-        </:item>
-        <:loading>Searching…</:loading>
-        <:prompt>Search for a country…</:prompt>
-        <:empty>No matches for "{{c.query}}"</:empty>
-      </c.List>
-    </Command>
+    <div class='demo-stack'>
+      <Command
+        @onSearch={{this.search}}
+        @isBordered={{true}}
+        @placeholder='Search countries…'
+        as |c|
+      >
+        <c.Input />
+        <c.List>
+          <:item as |ctx|>
+            <ctx.Item @key={{ctx.key}}>{{ctx.label}}</ctx.Item>
+          </:item>
+          <:loading>Searching…</:loading>
+          <:prompt>Search for a country…</:prompt>
+          <:empty>No matches for "{{c.query}}"</:empty>
+        </c.List>
+      </Command>
+    </div>
   </template>
 }
 ```
@@ -542,28 +562,30 @@ export default class MixedCommandExample extends Component {
   }
 
   <template>
-    <Command
-      @items={{this.items}}
-      @query={{this.query}}
-      @onQueryChange={{this.updateQuery}}
-      @isLoading={{this.isLoading}}
-      @disableFiltering={{true}}
-      @groupBy='section'
-      @groups={{array 'Recent' 'Navigation' 'Accounts'}}
-      @isBordered={{true}}
-      @placeholder="Try 'acme'…"
-      as |c|
-    >
-      <c.Input />
-      <c.List>
-        <:item as |ctx|>
-          <ctx.Item @key={{ctx.key}} @description={{ctx.item.section}}>
-            {{ctx.label}}
-          </ctx.Item>
-        </:item>
-        <:empty>No results for "{{c.query}}"</:empty>
-      </c.List>
-    </Command>
+    <div class='demo-stack'>
+      <Command
+        @items={{this.items}}
+        @query={{this.query}}
+        @onQueryChange={{this.updateQuery}}
+        @isLoading={{this.isLoading}}
+        @disableFiltering={{true}}
+        @groupBy='section'
+        @groups={{array 'Recent' 'Navigation' 'Accounts'}}
+        @isBordered={{true}}
+        @placeholder="Try 'acme'…"
+        as |c|
+      >
+        <c.Input />
+        <c.List>
+          <:item as |ctx|>
+            <ctx.Item @key={{ctx.key}} @description={{ctx.item.section}}>
+              {{ctx.label}}
+            </ctx.Item>
+          </:item>
+          <:empty>No results for "{{c.query}}"</:empty>
+        </c.List>
+      </Command>
+    </div>
   </template>
 }
 ```
@@ -600,7 +622,7 @@ const commands = [
 ];
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{#each (array 'sm' 'md' 'lg') as |size|}}
       <Command @items={{commands}} @size={{size}} @isBordered={{true}} as |c|>
         <c.Input @placeholder='size={{size}}' />

--- a/packages/frontile/src/components/collections/dropdown.md
+++ b/packages/frontile/src/components/collections/dropdown.md
@@ -171,7 +171,7 @@ export default class SelectableDropdown extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-2'>
+    <div class='demo-stack items-center'>
       <Dropdown @closeOnItemSelect={{false}} as |d|>
         <d.Trigger @size='sm'>Text Formatting</d.Trigger>
 
@@ -308,7 +308,7 @@ export default class MenuPositioning extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <div class='flex gap-2 flex-wrap'>
         <ButtonGroup @size='xs' @intent='primary' as |g|>
           {{#each this.placements as |p|}}
@@ -401,7 +401,7 @@ export default class KeepOpenDropdown extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-2'>
+    <div class='demo-stack items-center'>
       <Dropdown @closeOnItemSelect={{false}} as |d|>
         <d.Trigger @size='sm'>Filter Options</d.Trigger>
 
@@ -547,7 +547,7 @@ export default class DropdownBackdrop extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <ButtonGroup @size='xs' @intent='primary' as |g|>
         <g.ToggleButton
           @isSelected={{this.isActiveBackdrop 'none'}}

--- a/packages/frontile/src/components/collections/listbox.md
+++ b/packages/frontile/src/components/collections/listbox.md
@@ -46,7 +46,7 @@ export default class BasicListbox extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <div class='w-[260px] border px-1 py-2 rounded border-neutral-subtle'>
         <Listbox
           @isKeyboardEventsEnabled={{true}}
@@ -96,7 +96,7 @@ export default class MultipleSelection extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <div class='w-[260px] border px-1 py-2 rounded border-neutral-subtle'>
         <Listbox
           @isKeyboardEventsEnabled={{true}}
@@ -259,7 +259,7 @@ export default class Appearances extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <ButtonGroup @size='xs' @intent='primary' as |g|>
         <g.ToggleButton
           @isSelected={{this.isSelected 'default'}}
@@ -345,7 +345,7 @@ export default class DisabledItems extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <div class='w-[260px] border px-1 py-2 rounded border-neutral-subtle'>
         <Listbox
           @isKeyboardEventsEnabled={{true}}
@@ -411,7 +411,7 @@ export default class CustomItems extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <div class='w-[320px] border px-1 py-2 rounded border-neutral-subtle'>
         <Listbox
           @isKeyboardEventsEnabled={{true}}
@@ -506,7 +506,7 @@ export default class EmptySelection extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack items-center'>
       <div class='flex items-center gap-2'>
         <Button @size='xs' @onPress={{this.toggleAllowEmpty}}>
           Toggle Allow Empty ({{if this.allowEmpty 'ON' 'OFF'}})
@@ -551,17 +551,19 @@ import { Listbox } from 'frontile';
 import { array } from '@ember/helper';
 
 <template>
-  <Listbox @selectionMode='single' @disabledKeys={{array 'calculator'}} as |l|>
-    <l.Group @title='Suggestions' @withDivider={{true}} as |g|>
-      <g.Item @key='calendar'>Calendar</g.Item>
-      <g.Item @key='emoji'>Search Emoji</g.Item>
-      <g.Item @key='calculator'>Calculator</g.Item>
-    </l.Group>
-    <l.Group @title='Settings' as |g|>
-      <g.Item @key='profile' @shortcut='mod+p'>Profile</g.Item>
-      <g.Item @key='billing' @shortcut='mod+b'>Billing</g.Item>
-    </l.Group>
-  </Listbox>
+  <div class='demo-stack'>
+    <Listbox @selectionMode='single' @disabledKeys={{array 'calculator'}} as |l|>
+      <l.Group @title='Suggestions' @withDivider={{true}} as |g|>
+        <g.Item @key='calendar'>Calendar</g.Item>
+        <g.Item @key='emoji'>Search Emoji</g.Item>
+        <g.Item @key='calculator'>Calculator</g.Item>
+      </l.Group>
+      <l.Group @title='Settings' as |g|>
+        <g.Item @key='profile' @shortcut='mod+p'>Profile</g.Item>
+        <g.Item @key='billing' @shortcut='mod+b'>Billing</g.Item>
+      </l.Group>
+    </Listbox>
+  </div>
 </template>
 ```
 

--- a/packages/frontile/src/components/collections/simple-table.md
+++ b/packages/frontile/src/components/collections/simple-table.md
@@ -38,24 +38,26 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <SimpleTable as |t|>
-      <t.Header>
-        <t.Column>ID</t.Column>
-        <t.Column>Name</t.Column>
-        <t.Column>Email</t.Column>
-        <t.Column>Role</t.Column>
-      </t.Header>
-      <t.Body>
-        {{#each this.items as |item|}}
-          <t.Row>
-            <t.Cell>{{item.id}}</t.Cell>
-            <t.Cell>{{item.name}}</t.Cell>
-            <t.Cell>{{item.email}}</t.Cell>
-            <t.Cell>{{item.role}}</t.Cell>
-          </t.Row>
-        {{/each}}
-      </t.Body>
-    </SimpleTable>
+    <div class='demo-stack demo-stack--wide'>
+      <SimpleTable as |t|>
+        <t.Header>
+          <t.Column>ID</t.Column>
+          <t.Column>Name</t.Column>
+          <t.Column>Email</t.Column>
+          <t.Column>Role</t.Column>
+        </t.Header>
+        <t.Body>
+          {{#each this.items as |item|}}
+            <t.Row>
+              <t.Cell>{{item.id}}</t.Cell>
+              <t.Cell>{{item.name}}</t.Cell>
+              <t.Cell>{{item.email}}</t.Cell>
+              <t.Cell>{{item.role}}</t.Cell>
+            </t.Row>
+          {{/each}}
+        </t.Body>
+      </SimpleTable>
+    </div>
   </template>
 }
 ```
@@ -97,53 +99,55 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <SimpleTable as |t|>
-      <t.Header>
-        <t.Column>
-          <span class='flex items-center gap-2'>
-            👤 User Info
-          </span>
-        </t.Column>
-        <t.Column>
-          <span class='flex items-center gap-2'>
-            📧 Contact
-          </span>
-        </t.Column>
-        <t.Column>
-          <span class='flex items-center gap-2'>
-            🔄 Status
-          </span>
-        </t.Column>
-        <t.Column>
-          <span class='flex items-center gap-2'>
-            ⚡ Actions
-          </span>
-        </t.Column>
-      </t.Header>
-      <t.Body>
-        {{#each this.users as |user|}}
-          <t.Row>
-            <t.Cell>
-              <div>
-                <div class='font-medium'>{{user.name}}</div>
-                <div class='text-sm text-neutral-soft'>ID: {{user.id}}</div>
-              </div>
-            </t.Cell>
-            <t.Cell>{{user.email}}</t.Cell>
-            <t.Cell>
-              <Chip @intent={{user.chipIntent}} @size='sm'>
-                {{user.status}}
-              </Chip>
-            </t.Cell>
-            <t.Cell>
-              <Button @variant='link' @size='sm'>
-                Edit
-              </Button>
-            </t.Cell>
-          </t.Row>
-        {{/each}}
-      </t.Body>
-    </SimpleTable>
+    <div class='demo-stack demo-stack--wide'>
+      <SimpleTable as |t|>
+        <t.Header>
+          <t.Column>
+            <span class='flex items-center gap-2'>
+              👤 User Info
+            </span>
+          </t.Column>
+          <t.Column>
+            <span class='flex items-center gap-2'>
+              📧 Contact
+            </span>
+          </t.Column>
+          <t.Column>
+            <span class='flex items-center gap-2'>
+              🔄 Status
+            </span>
+          </t.Column>
+          <t.Column>
+            <span class='flex items-center gap-2'>
+              ⚡ Actions
+            </span>
+          </t.Column>
+        </t.Header>
+        <t.Body>
+          {{#each this.users as |user|}}
+            <t.Row>
+              <t.Cell>
+                <div>
+                  <div class='font-medium'>{{user.name}}</div>
+                  <div class='text-sm text-neutral-soft'>ID: {{user.id}}</div>
+                </div>
+              </t.Cell>
+              <t.Cell>{{user.email}}</t.Cell>
+              <t.Cell>
+                <Chip @intent={{user.chipIntent}} @size='sm'>
+                  {{user.status}}
+                </Chip>
+              </t.Cell>
+              <t.Cell>
+                <Button @variant='link' @size='sm'>
+                  Edit
+                </Button>
+              </t.Cell>
+            </t.Row>
+          {{/each}}
+        </t.Body>
+      </SimpleTable>
+    </div>
   </template>
 }
 ```
@@ -186,47 +190,49 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <SimpleTable as |t|>
-      <t.Header>
-        <t.Column>Product</t.Column>
-        <t.Column>Price</t.Column>
-        <t.Column>Stock</t.Column>
-        <t.Column>Actions</t.Column>
-      </t.Header>
-      <t.Body>
-        {{#each this.products as |product|}}
-          <t.Row>
-            <t.Cell>
-              <div>
-                <div class='font-medium'>{{product.name}}</div>
-                <div class='text-sm text-neutral-soft'>ID: {{product.id}}</div>
-              </div>
-            </t.Cell>
-            <t.Cell>
-              <span class='font-medium'>${{product.price}}</span>
-            </t.Cell>
-            <t.Cell>
-              <div class='flex flex-col gap-1'>
-                <div class='font-medium'>{{product.stock}} units</div>
-                <Chip @intent={{product.stockChipIntent}} @size='sm'>
-                  {{product.stockStatus}}
-                </Chip>
-              </div>
-            </t.Cell>
-            <t.Cell>
-              <div class='flex gap-2'>
-                <Button @intent='primary' @size='sm'>
-                  Edit
-                </Button>
-                <Button @intent='danger' @size='sm'>
-                  Delete
-                </Button>
-              </div>
-            </t.Cell>
-          </t.Row>
-        {{/each}}
-      </t.Body>
-    </SimpleTable>
+    <div class='demo-stack demo-stack--wide'>
+      <SimpleTable as |t|>
+        <t.Header>
+          <t.Column>Product</t.Column>
+          <t.Column>Price</t.Column>
+          <t.Column>Stock</t.Column>
+          <t.Column>Actions</t.Column>
+        </t.Header>
+        <t.Body>
+          {{#each this.products as |product|}}
+            <t.Row>
+              <t.Cell>
+                <div>
+                  <div class='font-medium'>{{product.name}}</div>
+                  <div class='text-sm text-neutral-soft'>ID: {{product.id}}</div>
+                </div>
+              </t.Cell>
+              <t.Cell>
+                <span class='font-medium'>${{product.price}}</span>
+              </t.Cell>
+              <t.Cell>
+                <div class='flex flex-col gap-1'>
+                  <div class='font-medium'>{{product.stock}} units</div>
+                  <Chip @intent={{product.stockChipIntent}} @size='sm'>
+                    {{product.stockStatus}}
+                  </Chip>
+                </div>
+              </t.Cell>
+              <t.Cell>
+                <div class='flex gap-2'>
+                  <Button @intent='primary' @size='sm'>
+                    Edit
+                  </Button>
+                  <Button @intent='danger' @size='sm'>
+                    Delete
+                  </Button>
+                </div>
+              </t.Cell>
+            </t.Row>
+          {{/each}}
+        </t.Body>
+      </SimpleTable>
+    </div>
   </template>
 }
 ```
@@ -248,59 +254,61 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <div class='space-y-6'>
-      <div>
-        <h4 class='font-medium mb-2'>Small (sm) - Compact spacing</h4>
-        <SimpleTable @size='sm' as |t|>
-          <t.Header>
-            <t.Column>Name</t.Column>
-            <t.Column>Role</t.Column>
-          </t.Header>
-          <t.Body>
-            {{#each this.data as |item|}}
-              <t.Row>
-                <t.Cell>{{item.name}}</t.Cell>
-                <t.Cell>{{item.role}}</t.Cell>
-              </t.Row>
-            {{/each}}
-          </t.Body>
-        </SimpleTable>
-      </div>
+    <div class='demo-stack demo-stack--wide'>
+      <div class='space-y-6'>
+        <div>
+          <h4 class='font-medium mb-2'>Small (sm) - Compact spacing</h4>
+          <SimpleTable @size='sm' as |t|>
+            <t.Header>
+              <t.Column>Name</t.Column>
+              <t.Column>Role</t.Column>
+            </t.Header>
+            <t.Body>
+              {{#each this.data as |item|}}
+                <t.Row>
+                  <t.Cell>{{item.name}}</t.Cell>
+                  <t.Cell>{{item.role}}</t.Cell>
+                </t.Row>
+              {{/each}}
+            </t.Body>
+          </SimpleTable>
+        </div>
 
-      <div>
-        <h4 class='font-medium mb-2'>Medium (md) - Default spacing</h4>
-        <SimpleTable @size='md' as |t|>
-          <t.Header>
-            <t.Column>Name</t.Column>
-            <t.Column>Role</t.Column>
-          </t.Header>
-          <t.Body>
-            {{#each this.data as |item|}}
-              <t.Row>
-                <t.Cell>{{item.name}}</t.Cell>
-                <t.Cell>{{item.role}}</t.Cell>
-              </t.Row>
-            {{/each}}
-          </t.Body>
-        </SimpleTable>
-      </div>
+        <div>
+          <h4 class='font-medium mb-2'>Medium (md) - Default spacing</h4>
+          <SimpleTable @size='md' as |t|>
+            <t.Header>
+              <t.Column>Name</t.Column>
+              <t.Column>Role</t.Column>
+            </t.Header>
+            <t.Body>
+              {{#each this.data as |item|}}
+                <t.Row>
+                  <t.Cell>{{item.name}}</t.Cell>
+                  <t.Cell>{{item.role}}</t.Cell>
+                </t.Row>
+              {{/each}}
+            </t.Body>
+          </SimpleTable>
+        </div>
 
-      <div>
-        <h4 class='font-medium mb-2'>Large (lg) - Spacious layout</h4>
-        <SimpleTable @size='lg' as |t|>
-          <t.Header>
-            <t.Column>Name</t.Column>
-            <t.Column>Role</t.Column>
-          </t.Header>
-          <t.Body>
-            {{#each this.data as |item|}}
-              <t.Row>
-                <t.Cell>{{item.name}}</t.Cell>
-                <t.Cell>{{item.role}}</t.Cell>
-              </t.Row>
-            {{/each}}
-          </t.Body>
-        </SimpleTable>
+        <div>
+          <h4 class='font-medium mb-2'>Large (lg) - Spacious layout</h4>
+          <SimpleTable @size='lg' as |t|>
+            <t.Header>
+              <t.Column>Name</t.Column>
+              <t.Column>Role</t.Column>
+            </t.Header>
+            <t.Body>
+              {{#each this.data as |item|}}
+                <t.Row>
+                  <t.Cell>{{item.name}}</t.Cell>
+                  <t.Cell>{{item.role}}</t.Cell>
+                </t.Row>
+              {{/each}}
+            </t.Body>
+          </SimpleTable>
+        </div>
       </div>
     </div>
   </template>
@@ -332,50 +340,52 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <div class='space-y-6'>
-      <div>
-        <h4 class='font-medium mb-2'>Auto Layout (default) - Content-based
-          sizing</h4>
-        <SimpleTable @layout='auto' as |t|>
-          <t.Header>
-            <t.Column>ID</t.Column>
-            <t.Column>Name</t.Column>
-            <t.Column>Email</t.Column>
-            <t.Column>Department</t.Column>
-          </t.Header>
-          <t.Body>
-            {{#each this.data as |item|}}
-              <t.Row>
-                <t.Cell>{{item.id}}</t.Cell>
-                <t.Cell>{{item.name}}</t.Cell>
-                <t.Cell>{{item.email}}</t.Cell>
-                <t.Cell>{{item.department}}</t.Cell>
-              </t.Row>
-            {{/each}}
-          </t.Body>
-        </SimpleTable>
-      </div>
+    <div class='demo-stack demo-stack--wide'>
+      <div class='space-y-6'>
+        <div>
+          <h4 class='font-medium mb-2'>Auto Layout (default) - Content-based
+            sizing</h4>
+          <SimpleTable @layout='auto' as |t|>
+            <t.Header>
+              <t.Column>ID</t.Column>
+              <t.Column>Name</t.Column>
+              <t.Column>Email</t.Column>
+              <t.Column>Department</t.Column>
+            </t.Header>
+            <t.Body>
+              {{#each this.data as |item|}}
+                <t.Row>
+                  <t.Cell>{{item.id}}</t.Cell>
+                  <t.Cell>{{item.name}}</t.Cell>
+                  <t.Cell>{{item.email}}</t.Cell>
+                  <t.Cell>{{item.department}}</t.Cell>
+                </t.Row>
+              {{/each}}
+            </t.Body>
+          </SimpleTable>
+        </div>
 
-      <div>
-        <h4 class='font-medium mb-2'>Fixed Layout - Equal column widths</h4>
-        <SimpleTable @layout='fixed' as |t|>
-          <t.Header>
-            <t.Column>ID</t.Column>
-            <t.Column>Name</t.Column>
-            <t.Column>Email</t.Column>
-            <t.Column>Department</t.Column>
-          </t.Header>
-          <t.Body>
-            {{#each this.data as |item|}}
-              <t.Row>
-                <t.Cell>{{item.id}}</t.Cell>
-                <t.Cell>{{item.name}}</t.Cell>
-                <t.Cell>{{item.email}}</t.Cell>
-                <t.Cell>{{item.department}}</t.Cell>
-              </t.Row>
-            {{/each}}
-          </t.Body>
-        </SimpleTable>
+        <div>
+          <h4 class='font-medium mb-2'>Fixed Layout - Equal column widths</h4>
+          <SimpleTable @layout='fixed' as |t|>
+            <t.Header>
+              <t.Column>ID</t.Column>
+              <t.Column>Name</t.Column>
+              <t.Column>Email</t.Column>
+              <t.Column>Department</t.Column>
+            </t.Header>
+            <t.Body>
+              {{#each this.data as |item|}}
+                <t.Row>
+                  <t.Cell>{{item.id}}</t.Cell>
+                  <t.Cell>{{item.name}}</t.Cell>
+                  <t.Cell>{{item.email}}</t.Cell>
+                  <t.Cell>{{item.department}}</t.Cell>
+                </t.Row>
+              {{/each}}
+            </t.Body>
+          </SimpleTable>
+        </div>
       </div>
     </div>
   </template>
@@ -420,26 +430,28 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <SimpleTable @isStriped={{true}} as |t|>
-      <t.Header>
-        <t.Column>Name</t.Column>
-        <t.Column>Email</t.Column>
-        <t.Column>Status</t.Column>
-      </t.Header>
-      <t.Body>
-        {{#each this.users as |user|}}
-          <t.Row>
-            <t.Cell>{{user.name}}</t.Cell>
-            <t.Cell>{{user.email}}</t.Cell>
-            <t.Cell>
-              <Chip @intent={{user.statusIntent}} @size='sm'>
-                {{user.status}}
-              </Chip>
-            </t.Cell>
-          </t.Row>
-        {{/each}}
-      </t.Body>
-    </SimpleTable>
+    <div class='demo-stack demo-stack--wide'>
+      <SimpleTable @isStriped={{true}} as |t|>
+        <t.Header>
+          <t.Column>Name</t.Column>
+          <t.Column>Email</t.Column>
+          <t.Column>Status</t.Column>
+        </t.Header>
+        <t.Body>
+          {{#each this.users as |user|}}
+            <t.Row>
+              <t.Cell>{{user.name}}</t.Cell>
+              <t.Cell>{{user.email}}</t.Cell>
+              <t.Cell>
+                <Chip @intent={{user.statusIntent}} @size='sm'>
+                  {{user.status}}
+                </Chip>
+              </t.Cell>
+            </t.Row>
+          {{/each}}
+        </t.Body>
+      </SimpleTable>
+    </div>
   </template>
 }
 ```
@@ -477,36 +489,38 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <SimpleTable
-      @classes={{hash
-        wrapper='border-2 border-primary-soft rounded-lg overflow-hidden'
-        table='border-separate border-spacing-0'
-        thead='bg-gradient-to-r from-primary-subtle to-primary-soft'
-        th='font-bold text-primary-strong border-b border-primary-soft'
-        tr='hover:bg-primary-subtle transition-colors'
-        td='border-b border-primary-subtle'
-      }}
-      as |t|
-    >
-      <t.Header>
-        <t.Column>Task Name</t.Column>
-        <t.Column>Estimated Value</t.Column>
-        <t.Column>Priority</t.Column>
-      </t.Header>
-      <t.Body>
-        {{#each this.items as |item|}}
-          <t.Row>
-            <t.Cell>{{item.name}}</t.Cell>
-            <t.Cell class='font-mono'>{{item.value}}</t.Cell>
-            <t.Cell>
-              <Chip @intent={{item.priorityIntent}} @size='sm'>
-                {{item.priority}}
-              </Chip>
-            </t.Cell>
-          </t.Row>
-        {{/each}}
-      </t.Body>
-    </SimpleTable>
+    <div class='demo-stack demo-stack--wide'>
+      <SimpleTable
+        @classes={{hash
+          wrapper='border-2 border-primary-soft rounded-lg overflow-hidden'
+          table='border-separate border-spacing-0'
+          thead='bg-gradient-to-r from-primary-subtle to-primary-soft'
+          th='font-bold text-primary-strong border-b border-primary-soft'
+          tr='hover:bg-primary-subtle transition-colors'
+          td='border-b border-primary-subtle'
+        }}
+        as |t|
+      >
+        <t.Header>
+          <t.Column>Task Name</t.Column>
+          <t.Column>Estimated Value</t.Column>
+          <t.Column>Priority</t.Column>
+        </t.Header>
+        <t.Body>
+          {{#each this.items as |item|}}
+            <t.Row>
+              <t.Cell>{{item.name}}</t.Cell>
+              <t.Cell class='font-mono'>{{item.value}}</t.Cell>
+              <t.Cell>
+                <Chip @intent={{item.priorityIntent}} @size='sm'>
+                  {{item.priority}}
+                </Chip>
+              </t.Cell>
+            </t.Row>
+          {{/each}}
+        </t.Body>
+      </SimpleTable>
+    </div>
   </template>
 }
 ```
@@ -540,32 +554,34 @@ export default class DemoComponent extends Component {
   calculateTotal = (quantity, price) => (quantity * price).toFixed(2);
 
   <template>
-    <SimpleTable as |t|>
-      <t.Header>
-        <t.Column>Order ID</t.Column>
-        <t.Column>Product</t.Column>
-        <t.Column>Quantity</t.Column>
-        <t.Column>Unit Price</t.Column>
-        <t.Column>Total</t.Column>
-      </t.Header>
-      <t.Body>
-        {{#each this.orders as |order|}}
-          <t.Row>
-            <t.Cell>{{order.id}}</t.Cell>
-            <t.Cell>{{order.product}}</t.Cell>
-            <t.Cell>{{order.quantity}}</t.Cell>
-            <t.Cell>${{order.price}}</t.Cell>
-            <t.Cell>${{this.calculateTotal order.quantity order.price}}</t.Cell>
-          </t.Row>
-        {{/each}}
-      </t.Body>
-      <t.Footer>
-        <t.Column colspan='2' class='font-semibold'>Order Summary</t.Column>
-        <t.Column class='font-semibold'>{{this.totalQuantity}} items</t.Column>
-        <t.Column />
-        <t.Column class='font-bold text-lg'>${{this.totalValue}}</t.Column>
-      </t.Footer>
-    </SimpleTable>
+    <div class='demo-stack demo-stack--wide'>
+      <SimpleTable as |t|>
+        <t.Header>
+          <t.Column>Order ID</t.Column>
+          <t.Column>Product</t.Column>
+          <t.Column>Quantity</t.Column>
+          <t.Column>Unit Price</t.Column>
+          <t.Column>Total</t.Column>
+        </t.Header>
+        <t.Body>
+          {{#each this.orders as |order|}}
+            <t.Row>
+              <t.Cell>{{order.id}}</t.Cell>
+              <t.Cell>{{order.product}}</t.Cell>
+              <t.Cell>{{order.quantity}}</t.Cell>
+              <t.Cell>${{order.price}}</t.Cell>
+              <t.Cell>${{this.calculateTotal order.quantity order.price}}</t.Cell>
+            </t.Row>
+          {{/each}}
+        </t.Body>
+        <t.Footer>
+          <t.Column colspan='2' class='font-semibold'>Order Summary</t.Column>
+          <t.Column class='font-semibold'>{{this.totalQuantity}} items</t.Column>
+          <t.Column />
+          <t.Column class='font-bold text-lg'>${{this.totalValue}}</t.Column>
+        </t.Footer>
+      </SimpleTable>
+    </div>
   </template>
 }
 ```
@@ -624,49 +640,51 @@ export default class DemoComponent extends Component {
   }
 
   <template>
-    <div class='space-y-4'>
-      <div class='flex items-end space-x-4 justify-center'>
-        <Button
-          @onPress={{this.toggleLoading}}
-          @size='sm'
-          @appearance='outlined'
-          @intent={{if this.isLoading 'danger' 'primary'}}
+    <div class='demo-stack demo-stack--wide'>
+      <div class='space-y-4'>
+        <div class='flex items-end space-x-4 justify-center'>
+          <Button
+            @onPress={{this.toggleLoading}}
+            @size='sm'
+            @appearance='outlined'
+            @intent={{if this.isLoading 'danger' 'primary'}}
+          >
+            {{if this.isLoading 'Stop Loading' 'Start Loading'}}
+          </Button>
+
+          <Select
+            @inputSize='sm'
+            @label='Color'
+            @items={{this.colorOptions}}
+            @selectedKey={{this.loadingColor}}
+            @onSelectionChange={{this.updateLoadingColor}}
+            class='w-32'
+          />
+        </div>
+
+        <SimpleTable
+          @isLoading={{this.isLoading}}
+          @loadingColor={{this.loadingColor}}
+          as |t|
         >
-          {{if this.isLoading 'Stop Loading' 'Start Loading'}}
-        </Button>
-
-        <Select
-          @inputSize='sm'
-          @label='Color'
-          @items={{this.colorOptions}}
-          @selectedKey={{this.loadingColor}}
-          @onSelectionChange={{this.updateLoadingColor}}
-          class='w-32'
-        />
+          <t.Header>
+            <t.Column>ID</t.Column>
+            <t.Column>Product</t.Column>
+            <t.Column>Price</t.Column>
+            <t.Column>Category</t.Column>
+          </t.Header>
+          <t.Body>
+            {{#each this.items as |item|}}
+              <t.Row>
+                <t.Cell>{{item.id}}</t.Cell>
+                <t.Cell>{{item.name}}</t.Cell>
+                <t.Cell>${{item.price}}</t.Cell>
+                <t.Cell>{{item.category}}</t.Cell>
+              </t.Row>
+            {{/each}}
+          </t.Body>
+        </SimpleTable>
       </div>
-
-      <SimpleTable
-        @isLoading={{this.isLoading}}
-        @loadingColor={{this.loadingColor}}
-        as |t|
-      >
-        <t.Header>
-          <t.Column>ID</t.Column>
-          <t.Column>Product</t.Column>
-          <t.Column>Price</t.Column>
-          <t.Column>Category</t.Column>
-        </t.Header>
-        <t.Body>
-          {{#each this.items as |item|}}
-            <t.Row>
-              <t.Cell>{{item.id}}</t.Cell>
-              <t.Cell>{{item.name}}</t.Cell>
-              <t.Cell>${{item.price}}</t.Cell>
-              <t.Cell>{{item.category}}</t.Cell>
-            </t.Row>
-          {{/each}}
-        </t.Body>
-      </SimpleTable>
     </div>
   </template>
 }

--- a/packages/frontile/src/components/collections/table.md
+++ b/packages/frontile/src/components/collections/table.md
@@ -43,7 +43,11 @@ export default class DemoComponent extends Component {
     { key: 'role', name: 'Role' }
   ] as const satisfies ColumnConfig<User>[];
 
-  <template><Table @columns={{this.columns}} @items={{users}} /></template>
+  <template>
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{users}} />
+    </div>
+  </template>
 }
 ```
 
@@ -73,7 +77,11 @@ export default class DemoComponent extends Component {
     }
   ] as const satisfies ColumnConfig<User>[];
 
-  <template><Table @columns={{this.columns}} @items={{users}} /></template>
+  <template>
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{users}} />
+    </div>
+  </template>
 }
 ```
 
@@ -106,7 +114,11 @@ export default class DemoComponent extends Component {
     { key: 'status', name: 'Status', Cell: StatusCell }
   ] as const satisfies ColumnConfig<User>[];
 
-  <template><Table @columns={{this.columns}} @items={{users}} /></template>
+  <template>
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{users}} />
+    </div>
+  </template>
 }
 
 function eq(a: string | undefined, b: string) {
@@ -132,13 +144,15 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig<User>[];
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{users}}
-      @size='sm'
-      @isStriped={{true}}
-      @classes={{hash wrapper='shadow-lg rounded-xl'}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{users}}
+        @size='sm'
+        @isStriped={{true}}
+        @classes={{hash wrapper='shadow-lg rounded-xl'}}
+      />
+    </div>
   </template>
 }
 ```
@@ -170,12 +184,14 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig<Employee>[];
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{employees}}
-      @isScrollable={{true}}
-      @classes={{hash wrapper='h-48'}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{employees}}
+        @isScrollable={{true}}
+        @classes={{hash wrapper='h-48'}}
+      />
+    </div>
   </template>
 }
 ```
@@ -226,13 +242,15 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{this.moreUsers}}
-      @isStickyHeader={{true}}
-      @isScrollable={{true}}
-      @classes={{hash wrapper='h-48'}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{this.moreUsers}}
+        @isStickyHeader={{true}}
+        @isScrollable={{true}}
+        @classes={{hash wrapper='h-48'}}
+      />
+    </div>
   </template>
 }
 ```
@@ -271,12 +289,14 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig<Employee>[];
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{employees}}
-      @isScrollable={{true}}
-      @classes={{hash wrapper='max-w-2xl'}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{employees}}
+        @isScrollable={{true}}
+        @classes={{hash wrapper='max-w-2xl'}}
+      />
+    </div>
   </template>
 }
 ```
@@ -323,13 +343,15 @@ export default class DemoComponent extends Component {
   ];
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{this.items}}
-      @stickyKeys={{array 'admin' 'guest'}}
-      @isScrollable={{true}}
-      @classes={{hash wrapper='h-48'}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{this.items}}
+        @stickyKeys={{array 'admin' 'guest'}}
+        @isScrollable={{true}}
+        @classes={{hash wrapper='h-48'}}
+      />
+    </div>
   </template>
 }
 ```
@@ -357,11 +379,13 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig[];
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{products}}
-      @footerColumns={{this.footerColumns}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{products}}
+        @footerColumns={{this.footerColumns}}
+      />
+    </div>
   </template>
 }
 ```
@@ -408,31 +432,33 @@ export default class DemoComponent extends Component {
   }
 
   <template>
-    <div class='space-y-4'>
-      <div class='flex items-end space-x-4 justify-center'>
-        <Button
-          @onPress={{this.toggleLoading}}
-          @size='sm'
-          @appearance='outlined'
-          @intent={{if this.isLoading 'danger' 'primary'}}
-        >
-          {{if this.isLoading 'Stop Loading' 'Start Loading'}}
-        </Button>
-        <Select
-          @inputSize='sm'
-          @label='Color'
-          @items={{this.colorOptions}}
-          @selectedKey={{this.loadingColor}}
-          @onSelectionChange={{this.updateLoadingColor}}
-          class='w-32'
+    <div class='demo-stack demo-stack--wide'>
+      <div class='space-y-4'>
+        <div class='flex items-end space-x-4 justify-center'>
+          <Button
+            @onPress={{this.toggleLoading}}
+            @size='sm'
+            @appearance='outlined'
+            @intent={{if this.isLoading 'danger' 'primary'}}
+          >
+            {{if this.isLoading 'Stop Loading' 'Start Loading'}}
+          </Button>
+          <Select
+            @inputSize='sm'
+            @label='Color'
+            @items={{this.colorOptions}}
+            @selectedKey={{this.loadingColor}}
+            @onSelectionChange={{this.updateLoadingColor}}
+            class='w-32'
+          />
+        </div>
+        <Table
+          @columns={{this.columns}}
+          @items={{products}}
+          @isLoading={{this.isLoading}}
+          @loadingColor={{this.loadingColor}}
         />
       </div>
-      <Table
-        @columns={{this.columns}}
-        @items={{products}}
-        @isLoading={{this.isLoading}}
-        @loadingColor={{this.loadingColor}}
-      />
     </div>
   </template>
 }
@@ -488,22 +514,24 @@ export default class DemoComponent extends Component {
   }
 
   <template>
-    <div class='w-full space-y-3'>
-      <div class='flex gap-2'>
-        <Button @size='sm' @intent='primary' {{on 'click' this.load}}>
-          Load data
-        </Button>
-        <Button @size='sm' @appearance='outlined' {{on 'click' this.reset}}>
-          Back to loading
-        </Button>
-      </div>
+    <div class='demo-stack demo-stack--wide'>
+      <div class='w-full space-y-3'>
+        <div class='flex gap-2'>
+          <Button @size='sm' @intent='primary' {{on 'click' this.load}}>
+            Load data
+          </Button>
+          <Button @size='sm' @appearance='outlined' {{on 'click' this.reset}}>
+            Back to loading
+          </Button>
+        </div>
 
-      <Table
-        @columns={{this.columns}}
-        @items={{this.items}}
-        @isLoading={{this.isLoading}}
-        @skeletonRows={{5}}
-      />
+        <Table
+          @columns={{this.columns}}
+          @items={{this.items}}
+          @isLoading={{this.isLoading}}
+          @skeletonRows={{5}}
+        />
+      </div>
     </div>
   </template>
 }
@@ -539,12 +567,14 @@ const columns = [
 ];
 
 <template>
-  <Table
-    @columns={{columns}}
-    @items={{(array)}}
-    @isLoading={{true}}
-    @skeletonRows={{4}}
-  />
+  <div class='demo-stack demo-stack--wide'>
+    <Table
+      @columns={{columns}}
+      @items={{(array)}}
+      @isLoading={{true}}
+      @skeletonRows={{4}}
+    />
+  </div>
 </template>
 ```
 
@@ -587,24 +617,26 @@ export default class DemoComponent extends Component {
   }
 
   <template>
-    <div class='space-y-4'>
-      <Button @onPress={{this.toggleLoading}} @size='sm' @appearance='outlined'>
-        {{if this.isLoading 'Stop Loading' 'Start Loading'}}
-      </Button>
-      <div class='relative'>
-        <Table
-          @columns={{this.columns}}
-          @items={{products}}
-          @isLoading={{this.isLoading}}
-        >
-          <:loading>
-            <div
-              class='absolute inset-0 z-10 bg-surface-canvas/80 backdrop-blur-sm flex items-center justify-center'
-            >
-              <Spinner @size='lg' />
-            </div>
-          </:loading>
-        </Table>
+    <div class='demo-stack demo-stack--wide'>
+      <div class='space-y-4'>
+        <Button @onPress={{this.toggleLoading}} @size='sm' @appearance='outlined'>
+          {{if this.isLoading 'Stop Loading' 'Start Loading'}}
+        </Button>
+        <div class='relative'>
+          <Table
+            @columns={{this.columns}}
+            @items={{products}}
+            @isLoading={{this.isLoading}}
+          >
+            <:loading>
+              <div
+                class='absolute inset-0 z-10 bg-surface-canvas/80 backdrop-blur-sm flex items-center justify-center'
+              >
+                <Spinner @size='lg' />
+              </div>
+            </:loading>
+          </Table>
+        </div>
       </div>
     </div>
   </template>
@@ -633,15 +665,17 @@ export default class DemoComponent extends Component {
   emptyItems: User[] = [];
 
   <template>
-    <Table @columns={{this.columns}} @items={{this.emptyItems}}>
-      <:empty>
-        <div class='text-center py-8'>
-          <h3 class='text-lg font-medium mb-2'>No Users Found</h3>
-          <p class='text-muted mb-4'>Get started by adding your first user.</p>
-          <Button @intent='primary' @size='sm'>Add User</Button>
-        </div>
-      </:empty>
-    </Table>
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{this.emptyItems}}>
+        <:empty>
+          <div class='text-center py-8'>
+            <h3 class='text-lg font-medium mb-2'>No Users Found</h3>
+            <p class='text-muted mb-4'>Get started by adding your first user.</p>
+            <Button @intent='primary' @size='sm'>Add User</Button>
+          </div>
+        </:empty>
+      </Table>
+    </div>
   </template>
 }
 ```
@@ -665,11 +699,13 @@ export default class DemoComponent extends Component {
   emptyItems: User[] = [];
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{this.emptyItems}}
-      @emptyContent='No users available'
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{this.emptyItems}}
+        @emptyContent='No users available'
+      />
+    </div>
   </template>
 }
 ```
@@ -694,36 +730,38 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig<User>[];
 
   <template>
-    <Table @columns={{this.columns}} @items={{users}}>
-      <:cell as |c|>
-        <c.For @key='name'>
-          <div class='flex items-center space-x-2'>
-            <Avatar
-              @name={{c.value}}
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{users}}>
+        <:cell as |c|>
+          <c.For @key='name'>
+            <div class='flex items-center space-x-2'>
+              <Avatar
+                @name={{c.value}}
+                @size='sm'
+                @src='https://i.pravatar.cc/150?img={{c.value}}'
+              />
+              <span class='font-medium'>{{c.value}}</span>
+            </div>
+          </c.For>
+
+          <c.For @key='status'>
+            <Chip
               @size='sm'
-              @src='https://i.pravatar.cc/150?img={{c.value}}'
-            />
-            <span class='font-medium'>{{c.value}}</span>
-          </div>
-        </c.For>
+              @appearance='outlined'
+              @intent='{{if (eq c.value "active") "success" "danger"}}'
+              @withDot={{true}}
+            >
+              {{c.value}}
+            </Chip>
 
-        <c.For @key='status'>
-          <Chip
-            @size='sm'
-            @appearance='outlined'
-            @intent='{{if (eq c.value "active") "success" "danger"}}'
-            @withDot={{true}}
-          >
+          </c.For>
+
+          <c.Default>
             {{c.value}}
-          </Chip>
-
-        </c.For>
-
-        <c.Default>
-          {{c.value}}
-        </c.Default>
-      </:cell>
-    </Table>
+          </c.Default>
+        </:cell>
+      </Table>
+    </div>
   </template>
 }
 
@@ -758,18 +796,20 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig<User>[];
 
   <template>
-    <Table @columns={{this.columns}} @items={{users}}>
-      <:header as |h|>
-        {{#if (eq h.column.key 'name')}}
-          <div class='flex items-center space-x-2'>
-            <UserIcon />
-            <span>{{h.column.name}}</span>
-          </div>
-        {{else}}
-          {{h.column.name}}
-        {{/if}}
-      </:header>
-    </Table>
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{users}}>
+        <:header as |h|>
+          {{#if (eq h.column.key 'name')}}
+            <div class='flex items-center space-x-2'>
+              <UserIcon />
+              <span>{{h.column.name}}</span>
+            </div>
+          {{else}}
+            {{h.column.name}}
+          {{/if}}
+        </:header>
+      </Table>
+    </div>
   </template>
 }
 
@@ -798,23 +838,25 @@ export default class DemoComponent extends Component {
   }
 
   <template>
-    <Table @columns={{this.columns}} @items={{products}}>
-      <:bodyTop>
-        <tr>
-          <td colspan='2' class='bg-muted/30 px-4 py-2 font-medium'>
-            Order Summary
-          </td>
-        </tr>
-      </:bodyTop>
-      <:bodyBottom>
-        <tr>
-          <td colspan='2' class='bg-muted/50 px-4 py-3 flex justify-between'>
-            <span>Total:</span>
-            <span class='font-semibold'>${{this.total}}</span>
-          </td>
-        </tr>
-      </:bodyBottom>
-    </Table>
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{products}}>
+        <:bodyTop>
+          <tr>
+            <td colspan='2' class='bg-muted/30 px-4 py-2 font-medium'>
+              Order Summary
+            </td>
+          </tr>
+        </:bodyTop>
+        <:bodyBottom>
+          <tr>
+            <td colspan='2' class='bg-muted/50 px-4 py-3 flex justify-between'>
+              <span>Total:</span>
+              <span class='font-semibold'>${{this.total}}</span>
+            </td>
+          </tr>
+        </:bodyBottom>
+      </Table>
+    </div>
   </template>
 }
 ```
@@ -837,17 +879,19 @@ const columns = [
 ];
 
 <template>
-  <Table @columns={{columns}} @items={{(array)}}>
-    <:bodyTop as |b|>
-      <b.Row>
-        {{#each b.columns as |column|}}
-          <b.Cell data-column={{column.key}}>
-            <Skeleton />
-          </b.Cell>
-        {{/each}}
-      </b.Row>
-    </:bodyTop>
-  </Table>
+  <div class='demo-stack demo-stack--wide'>
+    <Table @columns={{columns}} @items={{(array)}}>
+      <:bodyTop as |b|>
+        <b.Row>
+          {{#each b.columns as |column|}}
+            <b.Cell data-column={{column.key}}>
+              <Skeleton />
+            </b.Cell>
+          {{/each}}
+        </b.Row>
+      </:bodyTop>
+    </Table>
+  </div>
 </template>
 ```
 
@@ -893,14 +937,16 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig<User>[];
 
   <template>
-    <Table @columns={{this.columns}} @items={{users}}>
-      <:toolbar as |t|>
-        <div class='flex items-center justify-between mb-4'>
-          <h3 class='font-semibold'>User Management</h3>
-          <t.ColumnVisibility />
-        </div>
-      </:toolbar>
-    </Table>
+    <div class='demo-stack demo-stack--wide'>
+      <Table @columns={{this.columns}} @items={{users}}>
+        <:toolbar as |t|>
+          <div class='flex items-center justify-between mb-4'>
+            <h3 class='font-semibold'>User Management</h3>
+            <t.ColumnVisibility />
+          </div>
+        </:toolbar>
+      </Table>
+    </div>
   </template>
 }
 ```
@@ -946,11 +992,13 @@ export default class DemoComponent extends Component {
   };
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{this.items}}
-      @onSort={{this.handleSort}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{this.items}}
+        @onSort={{this.handleSort}}
+      />
+    </div>
   </template>
 }
 ```
@@ -995,19 +1043,21 @@ export default class DemoComponent extends Component {
   };
 
   <template>
-    <div>
-      <p class='mb-4 text-sm'>
-        Selected:
-        {{this.selectedKeys.size}}
-        row(s)
-      </p>
-      <Table
-        @columns={{this.columns}}
-        @items={{this.items}}
-        @selectionMode='multiple'
-        @selectedKeys={{this.selectedKeys}}
-        @onSelectionChange={{this.handleSelectionChange}}
-      />
+    <div class='demo-stack demo-stack--wide'>
+      <div>
+        <p class='mb-4 text-sm'>
+          Selected:
+          {{this.selectedKeys.size}}
+          row(s)
+        </p>
+        <Table
+          @columns={{this.columns}}
+          @items={{this.items}}
+          @selectionMode='multiple'
+          @selectedKeys={{this.selectedKeys}}
+          @onSelectionChange={{this.handleSelectionChange}}
+        />
+      </div>
     </div>
   </template>
 }
@@ -1048,18 +1098,20 @@ export default class DemoComponent extends Component {
   }
 
   <template>
-    <div>
-      <p class='mb-4 text-sm'>
-        Selected:
-        {{if this.selectedUser this.selectedUser.name 'None'}}
-      </p>
-      <Table
-        @columns={{this.columns}}
-        @items={{this.items}}
-        @selectionMode='single'
-        @selectedKeys={{this.selectedKeys}}
-        @onSelectionChange={{this.handleSelectionChange}}
-      />
+    <div class='demo-stack demo-stack--wide'>
+      <div>
+        <p class='mb-4 text-sm'>
+          Selected:
+          {{if this.selectedUser this.selectedUser.name 'None'}}
+        </p>
+        <Table
+          @columns={{this.columns}}
+          @items={{this.items}}
+          @selectionMode='single'
+          @selectedKeys={{this.selectedKeys}}
+          @onSelectionChange={{this.handleSelectionChange}}
+        />
+      </div>
     </div>
   </template>
 }
@@ -1097,18 +1149,20 @@ export default class DemoComponent extends Component {
   };
 
   <template>
-    <div>
-      <p class='mb-4 text-sm'>
-        Note: Admin users cannot be selected
-      </p>
-      <Table
-        @columns={{this.columns}}
-        @items={{this.items}}
-        @selectionMode='multiple'
-        @selectedKeys={{this.selectedKeys}}
-        @onSelectionChange={{this.handleSelectionChange}}
-        @disabledKeys={{this.disabledKeys}}
-      />
+    <div class='demo-stack demo-stack--wide'>
+      <div>
+        <p class='mb-4 text-sm'>
+          Note: Admin users cannot be selected
+        </p>
+        <Table
+          @columns={{this.columns}}
+          @items={{this.items}}
+          @selectionMode='multiple'
+          @selectedKeys={{this.selectedKeys}}
+          @onSelectionChange={{this.handleSelectionChange}}
+          @disabledKeys={{this.disabledKeys}}
+        />
+      </div>
     </div>
   </template>
 }
@@ -1151,14 +1205,16 @@ export default class DemoComponent extends Component {
   };
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{this.items}}
-      @selectionMode='multiple'
-      @selectedKeys={{this.selectedKeys}}
-      @onSelectionChange={{this.handleSelectionChange}}
-      @getKey={{this.getItemKey}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{this.items}}
+        @selectionMode='multiple'
+        @selectedKeys={{this.selectedKeys}}
+        @onSelectionChange={{this.handleSelectionChange}}
+        @getKey={{this.getItemKey}}
+      />
+    </div>
   </template>
 }
 ```
@@ -1190,12 +1246,14 @@ export default class DemoComponent extends Component {
   };
 
   <template>
-    <Table
-      @columns={{this.columns}}
-      @items={{this.items}}
-      @selectionMode='multiple'
-      @onSelectionChange={{this.handleSelectionChange}}
-    />
+    <div class='demo-stack demo-stack--wide'>
+      <Table
+        @columns={{this.columns}}
+        @items={{this.items}}
+        @selectionMode='multiple'
+        @onSelectionChange={{this.handleSelectionChange}}
+      />
+    </div>
   </template>
 }
 ```
@@ -1245,15 +1303,17 @@ export default class DemoComponent extends Component {
   ] as const satisfies ColumnConfig<User>[];
 
   <template>
-    <div>
-      <p class='mb-4 text-sm text-neutral-strong'>
-        Focus a row and press Space or Enter to select it
-      </p>
-      <Table
-        @columns={{this.columns}}
-        @items={{this.items}}
-        @selectionMode='multiple'
-      />
+    <div class='demo-stack demo-stack--wide'>
+      <div>
+        <p class='mb-4 text-sm text-neutral-strong'>
+          Focus a row and press Space or Enter to select it
+        </p>
+        <Table
+          @columns={{this.columns}}
+          @items={{this.items}}
+          @selectionMode='multiple'
+        />
+      </div>
     </div>
   </template>
 }
@@ -1304,25 +1364,27 @@ export default class DemoComponent extends Component {
   }
 
   <template>
-    <div class='space-y-4'>
-      <div class='flex items-end justify-center'>
-        <Select
-          @inputSize='sm'
-          @label='Selection Color'
-          @items={{this.colorOptions}}
-          @selectedKey={{this.selectionColor}}
-          @onSelectionChange={{this.updateSelectionColor}}
-          class='w-40'
+    <div class='demo-stack demo-stack--wide'>
+      <div class='space-y-4'>
+        <div class='flex items-end justify-center'>
+          <Select
+            @inputSize='sm'
+            @label='Selection Color'
+            @items={{this.colorOptions}}
+            @selectedKey={{this.selectionColor}}
+            @onSelectionChange={{this.updateSelectionColor}}
+            class='w-40'
+          />
+        </div>
+        <Table
+          @columns={{this.columns}}
+          @items={{this.items}}
+          @selectionMode='multiple'
+          @selectedKeys={{this.selectedKeys}}
+          @onSelectionChange={{this.handleSelectionChange}}
+          @selectionColor={{this.selectionColor}}
         />
       </div>
-      <Table
-        @columns={{this.columns}}
-        @items={{this.items}}
-        @selectionMode='multiple'
-        @selectedKeys={{this.selectedKeys}}
-        @onSelectionChange={{this.handleSelectionChange}}
-        @selectionColor={{this.selectionColor}}
-      />
     </div>
   </template>
 }

--- a/packages/frontile/src/components/forms/autocomplete.md
+++ b/packages/frontile/src/components/forms/autocomplete.md
@@ -47,7 +47,9 @@ const countries = [
 ];
 
 <template>
-  <Autocomplete @placeholder='Search countries' @items={{countries}} />
+  <div class='demo-stack'>
+    <Autocomplete @placeholder='Search countries' @items={{countries}} />
+  </div>
 </template>
 ```
 
@@ -78,14 +80,16 @@ export default class LanguagePicker extends Component {
   };
 
   <template>
-    <Autocomplete
-      @label='Primary language'
-      @placeholder='Search languages'
-      @items={{languages}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
-    <p class='mt-4'>Selected: {{if this.selectedKey this.selectedKey 'none'}}</p>
+    <div class='demo-stack'>
+      <Autocomplete
+        @label='Primary language'
+        @placeholder='Search languages'
+        @items={{languages}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+      <p class='mt-4'>Selected: {{if this.selectedKey this.selectedKey 'none'}}</p>
+    </div>
   </template>
 }
 ```
@@ -142,16 +146,18 @@ export default class CitySearch extends Component {
   };
 
   <template>
-    <Autocomplete
-      @label='Destination'
-      @placeholder='Search cities'
-      @searchMessage='Type to search for a city...'
-      @onSearch={{searchCities}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    >
-      <:emptyContent>No cities match your search.</:emptyContent>
-    </Autocomplete>
+    <div class='demo-stack'>
+      <Autocomplete
+        @label='Destination'
+        @placeholder='Search cities'
+        @searchMessage='Type to search for a city...'
+        @onSearch={{searchCities}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      >
+        <:emptyContent>No cities match your search.</:emptyContent>
+      </Autocomplete>
+    </div>
   </template>
 }
 ```
@@ -191,13 +197,15 @@ export default class TimezonePicker extends Component {
   };
 
   <template>
-    <Autocomplete
-      @label='Time zone'
-      @placeholder='Search time zones'
-      @items={{this.items}}
-      @disableFiltering={{true}}
-      @onInputChange={{this.onInputChange}}
-    />
+    <div class='demo-stack'>
+      <Autocomplete
+        @label='Time zone'
+        @placeholder='Search time zones'
+        @items={{this.items}}
+        @disableFiltering={{true}}
+        @onInputChange={{this.onInputChange}}
+      />
+    </div>
   </template>
 }
 ```
@@ -215,11 +223,13 @@ const startsWith = (itemValue: string, inputValue: string) =>
   itemValue.toLowerCase().startsWith(inputValue.toLowerCase());
 
 <template>
-  <Autocomplete
-    @placeholder="Try typing 'ap'"
-    @items={{fruits}}
-    @filter={{startsWith}}
-  />
+  <div class='demo-stack'>
+    <Autocomplete
+      @placeholder="Try typing 'ap'"
+      @items={{fruits}}
+      @filter={{startsWith}}
+    />
+  </div>
 </template>
 ```
 
@@ -248,19 +258,21 @@ export default class AssigneePicker extends Component {
   };
 
   <template>
-    <Autocomplete
-      @label='Assignee'
-      @placeholder='Search teammates'
-      @items={{teammates}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    >
-      <:item as |l|>
-        <l.Item @key={{l.key}} @description={{l.item.role}}>
-          {{l.label}}
-        </l.Item>
-      </:item>
-    </Autocomplete>
+    <div class='demo-stack'>
+      <Autocomplete
+        @label='Assignee'
+        @placeholder='Search teammates'
+        @items={{teammates}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      >
+        <:item as |l|>
+          <l.Item @key={{l.key}} @description={{l.item.role}}>
+            {{l.label}}
+          </l.Item>
+        </:item>
+      </Autocomplete>
+    </div>
   </template>
 }
 ```
@@ -284,14 +296,16 @@ export default class RoleInput extends Component {
   };
 
   <template>
-    <Autocomplete
-      @label='Role'
-      @description='Pick a suggestion or type your own'
-      @items={{commonRoles}}
-      @allowsCustomValue={{true}}
-      @onInputChange={{this.onInputChange}}
-    />
-    <p class='mt-4'>Value: {{this.value}}</p>
+    <div class='demo-stack'>
+      <Autocomplete
+        @label='Role'
+        @description='Pick a suggestion or type your own'
+        @items={{commonRoles}}
+        @allowsCustomValue={{true}}
+        @onInputChange={{this.onInputChange}}
+      />
+      <p class='mt-4'>Value: {{this.value}}</p>
+    </div>
   </template>
 }
 ```
@@ -318,13 +332,15 @@ export default class BrowserPicker extends Component {
   };
 
   <template>
-    <Autocomplete
-      @label='Browser'
-      @items={{browsers}}
-      @isClearable={{true}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
+    <div class='demo-stack'>
+      <Autocomplete
+        @label='Browser'
+        @items={{browsers}}
+        @isClearable={{true}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+    </div>
   </template>
 }
 ```
@@ -344,7 +360,7 @@ import { array } from '@ember/helper';
 const plans = ['Free', 'Pro', 'Enterprise'];
 
 <template>
-  <div class='flex flex-col gap-4'>
+  <div class='demo-stack'>
     <Autocomplete @inputSize='sm' @placeholder='Small' @items={{plans}} />
     <Autocomplete @inputSize='md' @placeholder='Medium' @items={{plans}} />
     <Autocomplete @inputSize='lg' @placeholder='Large' @items={{plans}} />

--- a/packages/frontile/src/components/forms/checkbox-group.md
+++ b/packages/frontile/src/components/forms/checkbox-group.md
@@ -23,11 +23,13 @@ The most basic usage of the CheckboxGroup component with a label and options.
 import { CheckboxGroup } from 'frontile';
 
 <template>
-  <CheckboxGroup @label='Interests' as |Checkbox|>
-    <Checkbox @label='Music' />
-    <Checkbox @label='Sports' />
-    <Checkbox @label='Technology' />
-  </CheckboxGroup>
+  <div class='demo-stack'>
+    <CheckboxGroup @label='Interests' as |Checkbox|>
+      <Checkbox @label='Music' />
+      <Checkbox @label='Sports' />
+      <Checkbox @label='Technology' />
+    </CheckboxGroup>
+  </div>
 </template>
 ```
 
@@ -77,7 +79,7 @@ export default class ControlledCheckboxGroup extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <CheckboxGroup @label='What are your interests?' as |Checkbox|>
         <Checkbox
           value='music'
@@ -187,7 +189,7 @@ export default class ValidatedCheckboxGroup extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -315,7 +317,7 @@ export default class CompleteFormWithCheckbox extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -430,7 +432,7 @@ import { CheckboxGroup } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{! Horizontal Orientation }}
     <CheckboxGroup
       @label='Horizontal Layout'

--- a/packages/frontile/src/components/forms/checkbox.md
+++ b/packages/frontile/src/components/forms/checkbox.md
@@ -22,7 +22,11 @@ The most basic usage of a Checkbox component with a label.
 ```gts preview
 import { Checkbox } from 'frontile';
 
-<template><Checkbox @label='Subscribe to newsletter' /></template>
+<template>
+  <div class='demo-stack'>
+    <Checkbox @label='Subscribe to newsletter' />
+  </div>
+</template>
 ```
 
 ### Controlled Checkbox
@@ -42,7 +46,7 @@ export default class ControlledCheckbox extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Checkbox
         @label='Subscribe to newsletter'
         @checked={{this.isSubscribed}}
@@ -96,7 +100,7 @@ export default class IndependentCheckboxes extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Checkbox
         @name='email-notifications'
         @label='Email notifications'
@@ -162,7 +166,7 @@ export default class CheckboxSizes extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Checkbox
         @name='small-checkbox'
         @label='Small Checkbox'
@@ -201,7 +205,7 @@ import { Checkbox } from 'frontile';
 
 export default class DisabledCheckbox extends Component {
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Checkbox
         @name='disabled-checked'
         @label='Disabled Checked Checkbox'
@@ -274,7 +278,7 @@ export default class IndeterminateCheckbox extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-2'>
+    <div class='demo-stack'>
       <Checkbox
         @name='select-all'
         @label='Select All'
@@ -322,7 +326,7 @@ export default class CheckboxWithDescription extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Checkbox
         @name='terms-acceptance'
         @label='I agree to the terms and conditions'
@@ -386,7 +390,7 @@ export default class ValidatedCheckbox extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -452,7 +456,7 @@ export default class HorizontalCheckboxes extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <fieldset>
         <legend class='text-lg font-medium mb-3'>Email Preferences</legend>
         <div class='flex gap-4'>
@@ -539,7 +543,7 @@ export default class CompleteFormWithCheckbox extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -617,19 +621,21 @@ export default class CustomStyledCheckbox extends Component {
   };
 
   <template>
-    <Checkbox
-      @name='custom-styled'
-      @label='Custom Styled Checkbox'
-      @description='This checkbox has custom styling applied'
-      @checked={{this.customChecked}}
-      @onChange={{this.updateCustomChecked}}
-      @classes={{hash
-        base='my-custom-checkbox-base'
-        input='my-custom-checkbox-input'
-        labelContainer='my-custom-label-container'
-        label='my-custom-checkbox-label'
-      }}
-    />
+    <div class='demo-stack'>
+      <Checkbox
+        @name='custom-styled'
+        @label='Custom Styled Checkbox'
+        @description='This checkbox has custom styling applied'
+        @checked={{this.customChecked}}
+        @onChange={{this.updateCustomChecked}}
+        @classes={{hash
+          base='my-custom-checkbox-base'
+          input='my-custom-checkbox-input'
+          labelContainer='my-custom-label-container'
+          label='my-custom-checkbox-label'
+        }}
+      />
+    </div>
   </template>
 }
 ```

--- a/packages/frontile/src/components/forms/field.md
+++ b/packages/frontile/src/components/forms/field.md
@@ -70,34 +70,36 @@ export default class BasicFieldExample extends Component {
   }
 
   <template>
-    <Form
-      @data={{this.formData}}
-      @schema={{schema}}
-      @onChange={{this.handleFormChange}}
-      @onSubmit={{this.handleFormSubmit}}
-      as |form|
-    >
-      <div class='flex flex-col gap-4'>
-        {{! Field component automatically handles error binding }}
-        <form.Field @name='username' as |field|>
-          <field.Input @label='Username' @isRequired={{true}} />
-        </form.Field>
+    <div class='demo-stack'>
+      <Form
+        @data={{this.formData}}
+        @schema={{schema}}
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+        as |form|
+      >
+        <div class='flex flex-col gap-4'>
+          {{! Field component automatically handles error binding }}
+          <form.Field @name='username' as |field|>
+            <field.Input @label='Username' @isRequired={{true}} />
+          </form.Field>
 
-        <form.Field @name='email' as |field|>
-          <field.Input
-            @label='Email Address'
-            @type='email'
-            @isRequired={{true}}
-          />
-        </form.Field>
+          <form.Field @name='email' as |field|>
+            <field.Input
+              @label='Email Address'
+              @type='email'
+              @isRequired={{true}}
+            />
+          </form.Field>
 
-        <Button type='submit'>
-          Submit
-        </Button>
+          <Button type='submit'>
+            Submit
+          </Button>
 
-        <Button @onPress={{this.changeEmail}}>Update Email via formData</Button>
-      </div>
-    </Form>
+          <Button @onPress={{this.changeEmail}}>Update Email via formData</Button>
+        </div>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -150,52 +152,54 @@ export default class FieldComponentTypes extends Component {
   };
 
   <template>
-    <Form
-      @data={{this.data}}
-      @schema={{schema}}
-      @onSubmit={{this.handleFormSubmit}}
-      as |form|
-    >
-      <div class='flex flex-col gap-4'>
-        {{! Input field }}
-        <form.Field @name='name' as |field|>
-          <field.Input @label='Full Name' @isRequired={{true}} />
-        </form.Field>
+    <div class='demo-stack'>
+      <Form
+        @data={{this.data}}
+        @schema={{schema}}
+        @onSubmit={{this.handleFormSubmit}}
+        as |form|
+      >
+        <div class='flex flex-col gap-4'>
+          {{! Input field }}
+          <form.Field @name='name' as |field|>
+            <field.Input @label='Full Name' @isRequired={{true}} />
+          </form.Field>
 
-        {{! Textarea field }}
-        <form.Field @name='bio' as |field|>
-          <field.Textarea
-            @label='Biography'
-            @description='Tell us about yourself'
-            @isRequired={{true}}
-            rows='4'
-          />
-        </form.Field>
+          {{! Textarea field }}
+          <form.Field @name='bio' as |field|>
+            <field.Textarea
+              @label='Biography'
+              @description='Tell us about yourself'
+              @isRequired={{true}}
+              rows='4'
+            />
+          </form.Field>
 
-        {{! Select field }}
-        <form.Field @name='accountType' as |field|>
-          <field.SingleSelect
-            @label='Account Type'
-            @items={{this.accountTypes}}
-            @placeholder='Choose account type'
-            @allowEmpty={{true}}
-            @isRequired={{true}}
-          />
-        </form.Field>
+          {{! Select field }}
+          <form.Field @name='accountType' as |field|>
+            <field.SingleSelect
+              @label='Account Type'
+              @items={{this.accountTypes}}
+              @placeholder='Choose account type'
+              @allowEmpty={{true}}
+              @isRequired={{true}}
+            />
+          </form.Field>
 
-        {{! Checkbox field }}
-        <form.Field @name='newsletter' as |field|>
-          <field.Checkbox
-            @label='Subscribe to newsletter'
-            @isRequired={{true}}
-          />
-        </form.Field>
+          {{! Checkbox field }}
+          <form.Field @name='newsletter' as |field|>
+            <field.Checkbox
+              @label='Subscribe to newsletter'
+              @isRequired={{true}}
+            />
+          </form.Field>
 
-        <Button type='submit'>
-          Create Account
-        </Button>
-      </div>
-    </Form>
+          <Button type='submit'>
+            Create Account
+          </Button>
+        </div>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -245,35 +249,37 @@ export default class CustomValidationField extends Component {
   };
 
   <template>
-    <Form
-      @schema={{schema}}
-      @validate={{this.customValidator}}
-      @onSubmit={{this.handleFormSubmit}}
-      as |form|
-    >
-      <div class='flex flex-col gap-4'>
-        <form.Field @name='password' as |field|>
-          <field.Input
-            @label='Password'
-            @type='password'
-            @description='Must be 8+ characters with uppercase and number'
-            @isRequired={{true}}
-          />
-        </form.Field>
+    <div class='demo-stack'>
+      <Form
+        @schema={{schema}}
+        @validate={{this.customValidator}}
+        @onSubmit={{this.handleFormSubmit}}
+        as |form|
+      >
+        <div class='flex flex-col gap-4'>
+          <form.Field @name='password' as |field|>
+            <field.Input
+              @label='Password'
+              @type='password'
+              @description='Must be 8+ characters with uppercase and number'
+              @isRequired={{true}}
+            />
+          </form.Field>
 
-        <form.Field @name='confirmPassword' as |field|>
-          <field.Input
-            @label='Confirm Password'
-            @type='password'
-            @isRequired={{true}}
-          />
-        </form.Field>
+          <form.Field @name='confirmPassword' as |field|>
+            <field.Input
+              @label='Confirm Password'
+              @type='password'
+              @isRequired={{true}}
+            />
+          </form.Field>
 
-        <Button type='submit'>
-          Set Password
-        </Button>
-      </div>
-    </Form>
+          <Button type='submit'>
+            Set Password
+          </Button>
+        </div>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -313,42 +319,44 @@ export default class FieldWithGroups extends Component {
   };
 
   <template>
-    <Form @schema={{schema}} @onSubmit={{this.handleFormSubmit}} as |form|>
-      <div class='flex flex-col gap-4'>
-        {{! RadioGroup field }}
-        <form.Field @name='experience' as |field|>
-          <field.RadioGroup
-            @label='Experience Level'
-            @isRequired={{true}}
-            as |Radio|
-          >
-            <Radio @label='Junior (0-2 years)' @value='junior' />
-            <Radio @label='Mid-level (3-5 years)' @value='mid' />
-            <Radio @label='Senior (6+ years)' @value='senior' />
-            <Radio @label='Lead/Principal' @value='lead' />
-          </field.RadioGroup>
-        </form.Field>
+    <div class='demo-stack'>
+      <Form @schema={{schema}} @onSubmit={{this.handleFormSubmit}} as |form|>
+        <div class='flex flex-col gap-4'>
+          {{! RadioGroup field }}
+          <form.Field @name='experience' as |field|>
+            <field.RadioGroup
+              @label='Experience Level'
+              @isRequired={{true}}
+              as |Radio|
+            >
+              <Radio @label='Junior (0-2 years)' @value='junior' />
+              <Radio @label='Mid-level (3-5 years)' @value='mid' />
+              <Radio @label='Senior (6+ years)' @value='senior' />
+              <Radio @label='Lead/Principal' @value='lead' />
+            </field.RadioGroup>
+          </form.Field>
 
-        {{! CheckboxGroup field }}
-        <form.Field @name='skills' as |field|>
-          <field.CheckboxGroup
-            @label='Technical Skills'
-            @description='Select at least 2 skills'
-            @isRequired={{true}}
-            as |Checkbox|
-          >
-            <Checkbox @label='Frontend Development' value='skill-frontend' />
-            <Checkbox @label='Backend Development' value='skill-backend' />
-            <Checkbox @label='Mobile Development' value='skill-mobile' />
-            <Checkbox @label='DevOps & Infrastructure' value='skill-infra' />
-          </field.CheckboxGroup>
-        </form.Field>
+          {{! CheckboxGroup field }}
+          <form.Field @name='skills' as |field|>
+            <field.CheckboxGroup
+              @label='Technical Skills'
+              @description='Select at least 2 skills'
+              @isRequired={{true}}
+              as |Checkbox|
+            >
+              <Checkbox @label='Frontend Development' value='skill-frontend' />
+              <Checkbox @label='Backend Development' value='skill-backend' />
+              <Checkbox @label='Mobile Development' value='skill-mobile' />
+              <Checkbox @label='DevOps & Infrastructure' value='skill-infra' />
+            </field.CheckboxGroup>
+          </form.Field>
 
-        <Button type='submit'>
-          Submit Application
-        </Button>
-      </div>
-    </Form>
+          <Button type='submit'>
+            Submit Application
+          </Button>
+        </div>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -442,7 +450,7 @@ export default class CompleteFieldForm extends Component {
   };
 
   <template>
-    <div class='max-w-2xl'>
+    <div class='demo-stack'>
       <Form @schema={{schema}} @onSubmit={{this.handleFormSubmit}} as |form|>
         <div class='flex flex-col gap-6'>
           {{! Personal Information Section }}

--- a/packages/frontile/src/components/forms/form-control.md
+++ b/packages/frontile/src/components/forms/form-control.md
@@ -27,13 +27,15 @@ associates the rendered `<label>` with your control.
 import { FormControl } from 'frontile';
 
 <template>
-  <FormControl @label='Attachment' as |c|>
-    <input
-      type='file'
-      id={{c.id}}
-      class='text-neutral-strong font-body text-base'
-    />
-  </FormControl>
+  <div class='demo-stack'>
+    <FormControl @label='Attachment' as |c|>
+      <input
+        type='file'
+        id={{c.id}}
+        class='text-neutral-strong font-body text-base'
+      />
+    </FormControl>
+  </div>
 </template>
 ```
 
@@ -52,21 +54,23 @@ ARIA, using the two values FormControl yields for exactly that.
 import { FormControl } from 'frontile';
 
 <template>
-  <FormControl
-    @label='Budget'
-    @description='Whole dollars, no separators.'
-    @errors='Enter an amount above 0'
-    as |c|
-  >
-    <input
-      type='number'
-      id={{c.id}}
-      value='0'
-      aria-invalid={{if c.isInvalid 'true'}}
-      aria-describedby={{c.describedBy true c.isInvalid}}
-      class='bg-surface-input text-neutral-strong border-neutral-soft aria-invalid:border-danger-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
-    />
-  </FormControl>
+  <div class='demo-stack'>
+    <FormControl
+      @label='Budget'
+      @description='Whole dollars, no separators.'
+      @errors='Enter an amount above 0'
+      as |c|
+    >
+      <input
+        type='number'
+        id={{c.id}}
+        value='0'
+        aria-invalid={{if c.isInvalid 'true'}}
+        aria-describedby={{c.describedBy true c.isInvalid}}
+        class='bg-surface-input text-neutral-strong border-neutral-soft aria-invalid:border-danger-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
+      />
+    </FormControl>
+  </div>
 </template>
 ```
 
@@ -96,22 +100,24 @@ invocation site wins over the one FormControl bound.
 import { FormControl } from 'frontile';
 
 <template>
-  <FormControl
-    @errors='Accept the terms to continue'
-    @preventErrorFeedback={{true}}
-    as |c|
-  >
-    <c.Feedback />
-    <div class='flex items-center gap-2'>
-      <input
-        type='checkbox'
-        id={{c.id}}
-        aria-invalid={{if c.isInvalid 'true'}}
-        aria-describedby={{c.describedBy false c.isInvalid}}
-      />
-      <c.Label>I accept the terms</c.Label>
-    </div>
-  </FormControl>
+  <div class='demo-stack'>
+    <FormControl
+      @errors='Accept the terms to continue'
+      @preventErrorFeedback={{true}}
+      as |c|
+    >
+      <c.Feedback />
+      <div class='flex items-center gap-2'>
+        <input
+          type='checkbox'
+          id={{c.id}}
+          aria-invalid={{if c.isInvalid 'true'}}
+          aria-describedby={{c.describedBy false c.isInvalid}}
+        />
+        <c.Label>I accept the terms</c.Label>
+      </div>
+    </FormControl>
+  </div>
 </template>
 ```
 
@@ -122,19 +128,21 @@ it renders inside the same `<label>` element that `@label` would have produced.
 import { FormControl } from 'frontile';
 
 <template>
-  <FormControl @isRequired={{true}}>
-    <:label>
-      API token
-      <a href='#docs' class='text-primary underline'>Where do I find this?</a>
-    </:label>
-    <:default as |c|>
-      <input
-        id={{c.id}}
-        required
-        class='bg-surface-input text-neutral-strong border-neutral-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
-      />
-    </:default>
-  </FormControl>
+  <div class='demo-stack'>
+    <FormControl @isRequired={{true}}>
+      <:label>
+        API token
+        <a href='#docs' class='text-primary underline'>Where do I find this?</a>
+      </:label>
+      <:default as |c|>
+        <input
+          id={{c.id}}
+          required
+          class='bg-surface-input text-neutral-strong border-neutral-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
+        />
+      </:default>
+    </FormControl>
+  </div>
 </template>
 ```
 
@@ -146,19 +154,21 @@ renders inside the same description element that `@description` would have produ
 import { FormControl } from 'frontile';
 
 <template>
-  <FormControl @label='Webhook URL'>
-    <:description>
-      Must be publicly reachable over HTTPS.
-      <a href='#docs' class='text-primary underline'>Read the requirements</a>
-    </:description>
-    <:default as |c|>
-      <input
-        id={{c.id}}
-        aria-describedby={{c.describedBy true false}}
-        class='bg-surface-input text-neutral-strong border-neutral-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
-      />
-    </:default>
-  </FormControl>
+  <div class='demo-stack'>
+    <FormControl @label='Webhook URL'>
+      <:description>
+        Must be publicly reachable over HTTPS.
+        <a href='#docs' class='text-primary underline'>Read the requirements</a>
+      </:description>
+      <:default as |c|>
+        <input
+          id={{c.id}}
+          aria-describedby={{c.describedBy true false}}
+          class='bg-surface-input text-neutral-strong border-neutral-soft focus:ring-focus w-full rounded-xl border p-3 leading-tight focus:ring-3 focus:outline-hidden'
+        />
+      </:default>
+    </FormControl>
+  </div>
 </template>
 ```
 
@@ -172,7 +182,7 @@ import { array } from '@ember/helper';
 import { FormControl } from 'frontile';
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{#each (array 'sm' 'md' 'lg') as |size|}}
       <FormControl
         @size={{size}}

--- a/packages/frontile/src/components/forms/form.md
+++ b/packages/frontile/src/components/forms/form.md
@@ -33,7 +33,7 @@ export default class SimpleForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4 w-80'>
+    <div class='demo-stack'>
       <Form @onSubmit={{this.handleSubmit}}>
         <div class='flex flex-col gap-4'>
           <Input @name='firstName' @label='First Name' />
@@ -97,7 +97,7 @@ export default class BasicForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4 w-80'>
+    <div class='demo-stack'>
       <Form
         @onChange={{this.handleFormChange}}
         @onSubmit={{this.handleFormSubmit}}
@@ -201,7 +201,7 @@ export default class ComprehensiveForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @onChange={{this.handleFormChange}}
         @onSubmit={{this.handleFormSubmit}}
@@ -413,7 +413,7 @@ export default class ValidatedForm extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4 w-80'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -576,7 +576,7 @@ export default class DirtyTrackingForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4 w-96'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleFormChange}}
@@ -761,7 +761,7 @@ export default class CustomHandlingForm extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @onChange={{this.handleFormChange}}
         @onSubmit={{this.handleFormSubmit}}
@@ -873,7 +873,7 @@ export default class NestedForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4 w-96'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleFormChange}}
@@ -1007,7 +1007,7 @@ export default class ValidatedNestedForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4 w-96'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{userSchema}}
@@ -1109,7 +1109,7 @@ export default class MixedFieldsForm extends Component {
   };
 
   <template>
-    <div class='w-96'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onSubmit={{this.handleFormSubmit}}
@@ -1183,7 +1183,7 @@ export default class ResetForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4 w-96'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleChange}}
@@ -1275,7 +1275,7 @@ export default class ResetValidationForm extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4 w-96'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -1377,7 +1377,7 @@ export default class DisabledForm extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4 w-80'>
+    <div class='demo-stack'>
       <div class='flex items-center gap-2 p-3 bg-neutral-subtle rounded'>
         <label class='flex items-center gap-2 cursor-pointer'>
           <input
@@ -1452,7 +1452,7 @@ cases where you want to turn announcing back on.
 import { FormFeedback } from 'frontile';
 
 <template>
-  <div class='flex flex-col gap-2'>
+  <div class='demo-stack'>
     <FormFeedback @intent='primary' @messages='Your changes are being saved.' />
     <FormFeedback
       @intent='secondary'

--- a/packages/frontile/src/components/forms/input-otp.md
+++ b/packages/frontile/src/components/forms/input-otp.md
@@ -21,7 +21,11 @@ import { InputOtp } from 'frontile';
 ```gts preview
 import { InputOtp } from 'frontile';
 
-<template><InputOtp @label='Verification code' /></template>
+<template>
+  <div class='demo-stack'>
+    <InputOtp @label='Verification code' />
+  </div>
+</template>
 ```
 
 ## Groups
@@ -38,7 +42,9 @@ import { InputOtp } from 'frontile';
 import { array } from '@ember/helper';
 
 <template>
-  <InputOtp @label='Card verification' @length={{6}} @groups={{array 3 3}} @separator='-' />
+  <div class='demo-stack'>
+    <InputOtp @label='Card verification' @length={{6}} @groups={{array 3 3}} @separator='-' />
+  </div>
 </template>
 ```
 
@@ -60,7 +66,7 @@ export default class VerifyCodeExample extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-2'>
+    <div class='demo-stack'>
       <InputOtp @label='Verification code' @onComplete={{this.handleComplete}} />
       <p>Submitted: {{this.submittedCode}}</p>
     </div>
@@ -87,7 +93,7 @@ export default class ControlledOtpExample extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-2'>
+    <div class='demo-stack'>
       <InputOtp @label='Verification code' @value={{this.code}} @onInput={{this.handleInput}} />
       <p>Current value: {{this.code}}</p>
     </div>
@@ -113,7 +119,7 @@ export default class OtpFormExample extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form @data={{this.formData}} @onChange={{this.handleFormChange}} as |form|>
         <form.Field @name='code' as |field|>
           <field.InputOtp @label='Verification code' />
@@ -139,7 +145,7 @@ first `@length` characters, and those are what the rule checks.
 import { InputOtp } from 'frontile';
 
 <template>
-  <div class='flex flex-col gap-4'>
+  <div class='demo-stack'>
     <InputOtp @label='Digits' @allowedChars='digits' @length={{4}} />
     <InputOtp @label='Letters' @allowedChars='letters' @length={{4}} />
     <InputOtp @label='Alphanumeric' @allowedChars='alphanumeric' @length={{4}} />
@@ -167,7 +173,9 @@ export default class EvenDigitsExample extends Component {
   evenDigitsPattern = /^[02468]*$/;
 
   <template>
-    <InputOtp @label='Even digits only' @length={{4}} @pattern={{this.evenDigitsPattern}} />
+    <div class='demo-stack'>
+      <InputOtp @label='Even digits only' @length={{4}} @pattern={{this.evenDigitsPattern}} />
+    </div>
   </template>
 }
 ```
@@ -180,7 +188,11 @@ display changes: autofill and password managers keep working.
 ```gts preview
 import { InputOtp } from 'frontile';
 
-<template><InputOtp @label='PIN' @length={{4}} @isMasked={{true}} /></template>
+<template>
+  <div class='demo-stack'>
+    <InputOtp @label='PIN' @length={{4}} @isMasked={{true}} />
+  </div>
+</template>
 ```
 
 ## Placeholder
@@ -193,7 +205,9 @@ in the demo below to watch it go.
 import { InputOtp } from 'frontile';
 
 <template>
-  <InputOtp @label='Verification code' @length={{6}} @placeholder='000000' />
+  <div class='demo-stack'>
+    <InputOtp @label='Verification code' @length={{6}} @placeholder='000000' />
+  </div>
 </template>
 ```
 
@@ -203,7 +217,7 @@ import { InputOtp } from 'frontile';
 import { InputOtp } from 'frontile';
 
 <template>
-  <div class='flex flex-col gap-4'>
+  <div class='demo-stack'>
     <InputOtp @label='Small' @size='sm' />
     <InputOtp @label='Medium' @size='md' />
     <InputOtp @label='Large' @size='lg' />
@@ -217,7 +231,7 @@ import { InputOtp } from 'frontile';
 import { InputOtp } from 'frontile';
 
 <template>
-  <div class='flex flex-col gap-4'>
+  <div class='demo-stack'>
     <InputOtp @label='Disabled' @isDisabled={{true}} @value='123' />
     <InputOtp @label='Verification code' @isRequired={{true}} />
     <InputOtp

--- a/packages/frontile/src/components/forms/input.md
+++ b/packages/frontile/src/components/forms/input.md
@@ -21,7 +21,11 @@ The most basic usage of the Input component with only a label.
 
 ```gts preview
 import { Input } from 'frontile';
-<template><Input @label='Full Name' /></template>
+<template>
+  <div class='demo-stack'>
+    <Input @label='Full Name' />
+  </div>
+</template>
 ```
 
 ### Controlled Input
@@ -41,7 +45,7 @@ export default class ControlledInput extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form @data={{this.formData}} @onChange={{this.handleFormChange}} as |form|>
         <form.Field @name='name' as |field|>
           <field.Input @label='Your Name' />
@@ -63,7 +67,7 @@ import { Input } from 'frontile';
 
 export default class InputTypes extends Component {
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Input @label='Email' @type='email' />
       <Input @label='Password' @type='password' />
       <Input @label='Phone Number' @type='tel' />
@@ -86,7 +90,7 @@ import { SearchIcon } from 'site/components/icons';
 
 export default class InputWithContent extends Component {
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Input @label='Price'>
         <:startContent>
           <span class='text-neutral-soft'>$</span>
@@ -125,20 +129,22 @@ export default class SearchInput extends Component {
   };
 
   <template>
-    <Input
-      @label='Search with Button'
-      @startContentPointerEvents='none'
-      @endContentPointerEvents='auto'
-    >
-      <:startContent>
-        <SearchIcon />
-      </:startContent>
-      <:endContent>
-        <button type='button' {{on 'click' this.handleSearch}}>
-          Search
-        </button>
-      </:endContent>
-    </Input>
+    <div class='demo-stack'>
+      <Input
+        @label='Search with Button'
+        @startContentPointerEvents='none'
+        @endContentPointerEvents='auto'
+      >
+        <:startContent>
+          <SearchIcon />
+        </:startContent>
+        <:endContent>
+          <button type='button' {{on 'click' this.handleSearch}}>
+            Search
+          </button>
+        </:endContent>
+      </Input>
+    </div>
   </template>
 }
 ```
@@ -160,15 +166,17 @@ export default class ClearableInput extends Component {
   };
 
   <template>
-    <Form @data={{this.formData}} @onChange={{this.handleFormChange}} as |form|>
-      <form.Field @name='searchQuery' as |field|>
-        <field.Input
-          @label='Search Query'
-          @isClearable={{true}}
-          placeholder='Type to search...'
-        />
-      </form.Field>
-    </Form>
+    <div class='demo-stack'>
+      <Form @data={{this.formData}} @onChange={{this.handleFormChange}} as |form|>
+        <form.Field @name='searchQuery' as |field|>
+          <field.Input
+            @label='Search Query'
+            @isClearable={{true}}
+            placeholder='Type to search...'
+          />
+        </form.Field>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -219,28 +227,30 @@ export default class ValidatedInput extends Component {
   };
 
   <template>
-    <Form
-      @data={{this.formData}}
-      @schema={{schema}}
-      @onChange={{this.handleFormChange}}
-      @onSubmit={{this.handleFormSubmit}}
-      @onError={{this.handleFormError}}
-      as |form|
-    >
-      <form.Field @name='name' as |field|>
-        <field.Input @label='Name' @isRequired={{true}} />
-      </form.Field>
+    <div class='demo-stack'>
+      <Form
+        @data={{this.formData}}
+        @schema={{schema}}
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+        @onError={{this.handleFormError}}
+        as |form|
+      >
+        <form.Field @name='name' as |field|>
+          <field.Input @label='Name' @isRequired={{true}} />
+        </form.Field>
 
-      <form.Field @name='email' as |field|>
-        <field.Input
-          @label='Email Address'
-          @type='email'
-          @isRequired={{true}}
-        />
-      </form.Field>
+        <form.Field @name='email' as |field|>
+          <field.Input
+            @label='Email Address'
+            @type='email'
+            @isRequired={{true}}
+          />
+        </form.Field>
 
-      <Button type='submit'>Submit</Button>
-    </Form>
+        <Button type='submit'>Submit</Button>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -254,7 +264,7 @@ import { Input } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{! Size variants }}
     <div>
       <h4 class='text-sm font-medium mb-2'>Size Variants</h4>

--- a/packages/frontile/src/components/forms/native-select.md
+++ b/packages/frontile/src/components/forms/native-select.md
@@ -33,13 +33,15 @@ export default class NativeSelectUsage extends Component {
   };
 
   <template>
-    <NativeSelect
-      @label='Favorite animal'
-      @items={{animals}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
-    <p class='mt-4 text-sm text-neutral'>Selected: {{this.selectedKey}}</p>
+    <div class='demo-stack'>
+      <NativeSelect
+        @label='Favorite animal'
+        @items={{animals}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+      <p class='mt-4 text-sm text-neutral'>Selected: {{this.selectedKey}}</p>
+    </div>
   </template>
 }
 ```
@@ -69,17 +71,19 @@ export default class NativeSelectItemBlock extends Component {
   };
 
   <template>
-    <NativeSelect
-      @label='Country'
-      @items={{countries}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    >
-      <:item as |o|>
-        <o.Item @key={{o.item.code}}>{{o.item.country}}</o.Item>
-      </:item>
-    </NativeSelect>
-    <p class='mt-4 text-sm text-neutral'>Selected: {{this.selectedKey}}</p>
+    <div class='demo-stack'>
+      <NativeSelect
+        @label='Country'
+        @items={{countries}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      >
+        <:item as |o|>
+          <o.Item @key={{o.item.code}}>{{o.item.country}}</o.Item>
+        </:item>
+      </NativeSelect>
+      <p class='mt-4 text-sm text-neutral'>Selected: {{this.selectedKey}}</p>
+    </div>
   </template>
 }
 ```
@@ -100,17 +104,19 @@ export default class NativeSelectStaticItems extends Component {
   };
 
   <template>
-    <NativeSelect
-      @label='Shipping'
-      @selectedKey={{this.selectedKey}}
-      @disabledKeys={{(array 'overnight')}}
-      @onSelectionChange={{this.onSelectionChange}}
-      as |l|
-    >
-      <l.Item @key='standard'>Standard — 5 business days</l.Item>
-      <l.Item @key='express'>Express — 2 business days</l.Item>
-      <l.Item @key='overnight'>Overnight — unavailable</l.Item>
-    </NativeSelect>
+    <div class='demo-stack'>
+      <NativeSelect
+        @label='Shipping'
+        @selectedKey={{this.selectedKey}}
+        @disabledKeys={{(array 'overnight')}}
+        @onSelectionChange={{this.onSelectionChange}}
+        as |l|
+      >
+        <l.Item @key='standard'>Standard — 5 business days</l.Item>
+        <l.Item @key='express'>Express — 2 business days</l.Item>
+        <l.Item @key='overnight'>Overnight — unavailable</l.Item>
+      </NativeSelect>
+    </div>
   </template>
 }
 ```
@@ -136,16 +142,18 @@ export default class NativeSelectAllowEmpty extends Component {
   };
 
   <template>
-    <NativeSelect
-      @label='Role'
-      @items={{roles}}
-      @allowEmpty={{true}}
-      @placeholder='Select a role'
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
-    <p class='mt-4 text-sm text-neutral'>Selected:
-      {{if this.selectedKey this.selectedKey 'none'}}</p>
+    <div class='demo-stack'>
+      <NativeSelect
+        @label='Role'
+        @items={{roles}}
+        @allowEmpty={{true}}
+        @placeholder='Select a role'
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+      <p class='mt-4 text-sm text-neutral'>Selected:
+        {{if this.selectedKey this.selectedKey 'none'}}</p>
+    </div>
   </template>
 }
 ```
@@ -169,14 +177,16 @@ export default class NativeSelectMultiple extends Component {
   };
 
   <template>
-    <NativeSelect
-      @label='Languages'
-      @description='Hold Cmd or Ctrl to select more than one.'
-      @selectionMode='multiple'
-      @items={{languages}}
-      @selectedKeys={{this.selectedKeys}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
+    <div class='demo-stack'>
+      <NativeSelect
+        @label='Languages'
+        @description='Hold Cmd or Ctrl to select more than one.'
+        @selectionMode='multiple'
+        @items={{languages}}
+        @selectedKeys={{this.selectedKeys}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+    </div>
   </template>
 }
 ```
@@ -192,7 +202,7 @@ import { NativeSelect } from 'frontile';
 const plans = ['Basic', 'Pro'];
 
 <template>
-  <div class='flex flex-col gap-4'>
+  <div class='demo-stack'>
     {{#each (array 'sm' 'md' 'lg') as |size|}}
       <NativeSelect
         @label={{concat 'Plan (' size ')'}}
@@ -215,7 +225,7 @@ import { NativeSelect } from 'frontile';
 const environments = ['Development', 'Staging', 'Production'];
 
 <template>
-  <div class='flex flex-col gap-4'>
+  <div class='demo-stack'>
     <NativeSelect
       @label='Environment'
       @description='Where the build will be deployed.'
@@ -247,11 +257,13 @@ import { SearchIcon } from 'site/components/icons';
 const teams = ['Design', 'Engineering', 'Support'];
 
 <template>
-  <NativeSelect @label='Team' @items={{teams}}>
-    <:startContent>
-      <SearchIcon class='size-icon-md text-neutral' />
-    </:startContent>
-  </NativeSelect>
+  <div class='demo-stack'>
+    <NativeSelect @label='Team' @items={{teams}}>
+      <:startContent>
+        <SearchIcon class='size-icon-md text-neutral' />
+      </:startContent>
+    </NativeSelect>
+  </div>
 </template>
 ```
 

--- a/packages/frontile/src/components/forms/radio-group.md
+++ b/packages/frontile/src/components/forms/radio-group.md
@@ -23,11 +23,13 @@ The most basic usage of the RadioGroup component with a label and options.
 import { RadioGroup } from 'frontile';
 
 <template>
-  <RadioGroup @name='interests' @label='Interests' as |Radio|>
-    <Radio @label='Music' @value='music' />
-    <Radio @label='Sports' @value='sports' />
-    <Radio @label='Technology' @value='technology' />
-  </RadioGroup>
+  <div class='demo-stack'>
+    <RadioGroup @name='interests' @label='Interests' as |Radio|>
+      <Radio @label='Music' @value='music' />
+      <Radio @label='Sports' @value='sports' />
+      <Radio @label='Technology' @value='technology' />
+    </RadioGroup>
+  </div>
 </template>
 ```
 
@@ -52,7 +54,7 @@ export default class ControlledRadioGroup extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form @data={{this.formData}} @onChange={{this.handleFormChange}} as |form|>
         <form.Field @name='theme' as |field|>
           <field.RadioGroup @label='Theme Preference' as |Radio|>
@@ -116,48 +118,50 @@ export default class FormValidation extends Component {
   };
 
   <template>
-    <Form
-      @data={{this.formData}}
-      @schema={{schema}}
-      @onChange={{this.handleFormChange}}
-      @onSubmit={{this.handleSubmit}}
-      @validateOn={{array 'change' 'submit'}}
-      as |form|
-    >
-      <form.Field @name='fullName' as |field|>
-        <field.Input @label='Full Name' @isRequired={{true}} />
-      </form.Field>
+    <div class='demo-stack'>
+      <Form
+        @data={{this.formData}}
+        @schema={{schema}}
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleSubmit}}
+        @validateOn={{array 'change' 'submit'}}
+        as |form|
+      >
+        <form.Field @name='fullName' as |field|>
+          <field.Input @label='Full Name' @isRequired={{true}} />
+        </form.Field>
 
-      <form.Field @name='experience' as |field|>
-        <field.RadioGroup
-          @label='Experience Level'
-          @isRequired={{true}}
-          as |Radio|
-        >
-          <Radio
-            @label='Junior'
-            @value='junior'
-            @description='0-2 years of experience'
-          />
-          <Radio
-            @label='Mid-level'
-            @value='mid'
-            @description='3-5 years of experience'
-          />
-          <Radio
-            @label='Senior'
-            @value='senior'
-            @description='5+ years of experience'
-          />
-        </field.RadioGroup>
-      </form.Field>
+        <form.Field @name='experience' as |field|>
+          <field.RadioGroup
+            @label='Experience Level'
+            @isRequired={{true}}
+            as |Radio|
+          >
+            <Radio
+              @label='Junior'
+              @value='junior'
+              @description='0-2 years of experience'
+            />
+            <Radio
+              @label='Mid-level'
+              @value='mid'
+              @description='3-5 years of experience'
+            />
+            <Radio
+              @label='Senior'
+              @value='senior'
+              @description='5+ years of experience'
+            />
+          </field.RadioGroup>
+        </form.Field>
 
-      <form.Field @name='newsletter' as |field|>
-        <field.Checkbox @label='Subscribe to our newsletter' />
-      </form.Field>
+        <form.Field @name='newsletter' as |field|>
+          <field.Checkbox @label='Subscribe to our newsletter' />
+        </form.Field>
 
-      <Button type='submit'>Submit Application</Button>
-    </Form>
+        <Button type='submit'>Submit Application</Button>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -171,7 +175,7 @@ import { RadioGroup } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{! Orientation }}
     <div>
       <h4 class='text-sm font-medium mb-2'>Orientation</h4>

--- a/packages/frontile/src/components/forms/radio.md
+++ b/packages/frontile/src/components/forms/radio.md
@@ -22,7 +22,11 @@ The most basic usage of a Radio component with a label and value.
 ```gts preview
 import { Radio } from 'frontile';
 
-<template><Radio @name='terms' @label='Accept Terms' @value='accepted' /></template>
+<template>
+  <div class='demo-stack'>
+    <Radio @name='terms' @label='Accept Terms' @value='accepted' />
+  </div>
+</template>
 ```
 
 > **Modern Usage:** For most use cases, prefer using Radio components with the Form and Field components. This provides automatic data binding, validation, and state management without manual `@onChange` handlers. See the "Controlled with Form/Field" example below.
@@ -46,7 +50,7 @@ export default class ControlledRadio extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form @data={{this.formData}} @onChange={{this.handleFormChange}} as |form|>
         <form.Field @name='newsletter' as |field|>
           <field.RadioGroup @label='Newsletter Preference' as |Radio|>
@@ -117,44 +121,46 @@ export default class FormValidationExample extends Component {
   };
 
   <template>
-    <Form
-      @data={{this.formData}}
-      @schema={{schema}}
-      @onChange={{this.handleFormChange}}
-      @onSubmit={{this.handleSubmit}}
-      @validateOn={{array 'change' 'submit'}}
-      as |form|
-    >
-      <div class='flex flex-col gap-4'>
-        <form.Field @name='fullName' as |field|>
-          <field.Input @label='Full Name' @isRequired={{true}} />
-        </form.Field>
+    <div class='demo-stack'>
+      <Form
+        @data={{this.formData}}
+        @schema={{schema}}
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleSubmit}}
+        @validateOn={{array 'change' 'submit'}}
+        as |form|
+      >
+        <div class='flex flex-col gap-4'>
+          <form.Field @name='fullName' as |field|>
+            <field.Input @label='Full Name' @isRequired={{true}} />
+          </form.Field>
 
-        <form.Field @name='email' as |field|>
-          <field.Input
-            @label='Email Address'
-            @type='email'
-            @isRequired={{true}}
-          />
-        </form.Field>
+          <form.Field @name='email' as |field|>
+            <field.Input
+              @label='Email Address'
+              @type='email'
+              @isRequired={{true}}
+            />
+          </form.Field>
 
-        <form.Field @name='experience' as |field|>
-          <field.RadioGroup @label='Experience Level' @isRequired={{true}} as |Radio|>
-            <Radio @label='Junior (0-2 years)' @value='junior' />
-            <Radio @label='Mid-level (3-5 years)' @value='mid' />
-            <Radio @label='Senior (5+ years)' @value='senior' />
-          </field.RadioGroup>
-        </form.Field>
+          <form.Field @name='experience' as |field|>
+            <field.RadioGroup @label='Experience Level' @isRequired={{true}} as |Radio|>
+              <Radio @label='Junior (0-2 years)' @value='junior' />
+              <Radio @label='Mid-level (3-5 years)' @value='mid' />
+              <Radio @label='Senior (5+ years)' @value='senior' />
+            </field.RadioGroup>
+          </form.Field>
 
-        <form.Field @name='remoteWork' as |field|>
-          <field.Checkbox @label='Open to remote work' />
-        </form.Field>
+          <form.Field @name='remoteWork' as |field|>
+            <field.Checkbox @label='Open to remote work' />
+          </form.Field>
 
-        <div>
-          <Button type='submit'>Submit Application</Button>
+          <div>
+            <Button type='submit'>Submit Application</Button>
+          </div>
         </div>
-      </div>
-    </Form>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -168,7 +174,7 @@ import { Radio, RadioGroup } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{! Size variants }}
     <div>
       <h4 class='text-sm font-medium mb-2'>Size Variants</h4>

--- a/packages/frontile/src/components/forms/select.md
+++ b/packages/frontile/src/components/forms/select.md
@@ -25,7 +25,9 @@ import { Select } from 'frontile';
 const options = ['Option 1', 'Option 2', 'Option 3'];
 
 <template>
-  <Select @placeholder='Select an option' @items={{options}} />
+  <div class='demo-stack'>
+    <Select @placeholder='Select an option' @items={{options}} />
+  </div>
 </template>
 ```
 
@@ -43,14 +45,16 @@ import { Select } from 'frontile';
 const options = ['Option 1', 'Option 2', 'Option 3'];
 
 <template>
-  <div class='grid grid-cols-2 gap-4'>
-    <Select @intent='default' @placeholder='Default' @items={{options}} />
-    <Select @intent='primary' @placeholder='Primary' @items={{options}} />
-    <Select @intent='secondary' @placeholder='Secondary' @items={{options}} />
-    <Select @intent='tertiary' @placeholder='Tertiary' @items={{options}} />
-    <Select @intent='success' @placeholder='Success' @items={{options}} />
-    <Select @intent='warning' @placeholder='Warning' @items={{options}} />
-    <Select @intent='danger' @placeholder='Danger' @items={{options}} />
+  <div class='demo-stack'>
+    <div class='grid grid-cols-2 gap-4'>
+      <Select @intent='default' @placeholder='Default' @items={{options}} />
+      <Select @intent='primary' @placeholder='Primary' @items={{options}} />
+      <Select @intent='secondary' @placeholder='Secondary' @items={{options}} />
+      <Select @intent='tertiary' @placeholder='Tertiary' @items={{options}} />
+      <Select @intent='success' @placeholder='Success' @items={{options}} />
+      <Select @intent='warning' @placeholder='Warning' @items={{options}} />
+      <Select @intent='danger' @placeholder='Danger' @items={{options}} />
+    </div>
   </div>
 </template>
 ```
@@ -74,7 +78,7 @@ export default class DataBoundSingleSelect extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleFormChange}}
@@ -173,7 +177,7 @@ export default class SelectFormValidation extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-6'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -258,7 +262,7 @@ export default class FilterableSelect extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleFormChange}}
@@ -313,30 +317,32 @@ export default class CustomUserSelect extends Component {
   };
 
   <template>
-    <Select
-      @isFilterable={{true}}
-      @placeholder='Select a user'
-      @items={{users}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    >
-      <:item as |o|>
-        <o.Item>
-          <div class='flex items-center space-x-4'>
-            <img
-              src='{{o.item.avatar}}'
-              alt='{{o.item.name}}'
-              class='w-10 h-10 rounded-full'
-            />
-            <div>
-              <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
-              <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+    <div class='demo-stack'>
+      <Select
+        @isFilterable={{true}}
+        @placeholder='Select a user'
+        @items={{users}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      >
+        <:item as |o|>
+          <o.Item>
+            <div class='flex items-center space-x-4'>
+              <img
+                src='{{o.item.avatar}}'
+                alt='{{o.item.name}}'
+                class='w-10 h-10 rounded-full'
+              />
+              <div>
+                <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
+                <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+              </div>
             </div>
-          </div>
-        </o.Item>
-      </:item>
-    </Select>
-    <p class='mt-4'>Selected: {{this.selectedKey}}</p>
+          </o.Item>
+        </:item>
+      </Select>
+      <p class='mt-4'>Selected: {{this.selectedKey}}</p>
+    </div>
   </template>
 }
 
@@ -412,80 +418,82 @@ export default class CustomSelectedItem extends Component {
   };
 
   <template>
-    <Select
-      @label='Assignee'
-      @placeholder='Select a user'
-      @items={{people}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    >
-      <:item as |o|>
-        <o.Item>
-          <div class='flex items-center space-x-4'>
-            <img
-              src='{{o.item.avatar}}'
-              alt=''
-              class='w-10 h-10 rounded-full'
-            />
-            <div>
-              <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
-              <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+    <div class='demo-stack'>
+      <Select
+        @label='Assignee'
+        @placeholder='Select a user'
+        @items={{people}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      >
+        <:item as |o|>
+          <o.Item>
+            <div class='flex items-center space-x-4'>
+              <img
+                src='{{o.item.avatar}}'
+                alt=''
+                class='w-10 h-10 rounded-full'
+              />
+              <div>
+                <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
+                <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+              </div>
             </div>
-          </div>
-        </o.Item>
-      </:item>
-      <:selectedItem as |selected|>
-        <span class='flex items-center space-x-2'>
-          {{#if selected.item}}
-            <img
-              src='{{selected.item.avatar}}'
-              alt=''
-              class='w-5 h-5 rounded-full'
-            />
-          {{/if}}
-          <span>{{selected.label}}</span>
-        </span>
-      </:selectedItem>
-    </Select>
+          </o.Item>
+        </:item>
+        <:selectedItem as |selected|>
+          <span class='flex items-center space-x-2'>
+            {{#if selected.item}}
+              <img
+                src='{{selected.item.avatar}}'
+                alt=''
+                class='w-5 h-5 rounded-full'
+              />
+            {{/if}}
+            <span>{{selected.label}}</span>
+          </span>
+        </:selectedItem>
+      </Select>
 
-    <Select
-      @label='Reviewers'
-      @selectionMode='multiple'
-      @allowEmpty={{true}}
-      @placeholder='Select reviewers'
-      @items={{people}}
-      @selectedKeys={{this.selectedKeys}}
-      @onSelectionChange={{this.onMultipleSelectionChange}}
-      class='mt-6'
-    >
-      <:item as |o|>
-        <o.Item>
-          <div class='flex items-center space-x-4'>
-            <img
-              src='{{o.item.avatar}}'
-              alt=''
-              class='w-10 h-10 rounded-full'
-            />
-            <div>
-              <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
-              <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+      <Select
+        @label='Reviewers'
+        @selectionMode='multiple'
+        @allowEmpty={{true}}
+        @placeholder='Select reviewers'
+        @items={{people}}
+        @selectedKeys={{this.selectedKeys}}
+        @onSelectionChange={{this.onMultipleSelectionChange}}
+        class='mt-6'
+      >
+        <:item as |o|>
+          <o.Item>
+            <div class='flex items-center space-x-4'>
+              <img
+                src='{{o.item.avatar}}'
+                alt=''
+                class='w-10 h-10 rounded-full'
+              />
+              <div>
+                <div class='font-medium text-neutral-strong'>{{o.item.name}}</div>
+                <div class='text-sm text-neutral-soft'>{{o.item.email}}</div>
+              </div>
             </div>
-          </div>
-        </o.Item>
-      </:item>
-      <:selectedItem as |selected|>
-        <span class='flex items-center space-x-1'>
-          {{#if selected.item}}
-            <img
-              src='{{selected.item.avatar}}'
-              alt=''
-              class='w-4 h-4 rounded-full'
-            />
-          {{/if}}
-          <span>{{selected.label}}</span>
-        </span>
-      </:selectedItem>
-    </Select>
+          </o.Item>
+        </:item>
+        <:selectedItem as |selected|>
+          <span class='flex items-center space-x-1'>
+            {{#if selected.item}}
+              <img
+                src='{{selected.item.avatar}}'
+                alt=''
+                class='w-4 h-4 rounded-full'
+              />
+            {{/if}}
+            <span>{{selected.label}}</span>
+          </span>
+        </:selectedItem>
+      </Select>
+    </div>
   </template>
 }
 
@@ -535,21 +543,23 @@ export default class DeclarativeItemsSelect extends Component {
   };
 
   <template>
-    <Select
-      @placeholder='Select...'
-      @onSelectionChange={{this.onSelectionChange}}
-      @selectedKeys={{this.selectedKeys}}
-      @disabledKeys={{array 'item-3' 'item-4'}}
-      @allowEmpty={{true}}
-      as |l|
-    >
-      <l.Item @key='item-1'>Item 1</l.Item>
-      <l.Item @key='item-2'>Item 2</l.Item>
-      <l.Item @key='item-3'>Item 3</l.Item>
-      <l.Item @key='item-4'>Item 4</l.Item>
-      <l.Item @key='item-5'>Item 5</l.Item>
-    </Select>
-    <p>Selected: {{this.selectedKeys}}</p>
+    <div class='demo-stack'>
+      <Select
+        @placeholder='Select...'
+        @onSelectionChange={{this.onSelectionChange}}
+        @selectedKeys={{this.selectedKeys}}
+        @disabledKeys={{array 'item-3' 'item-4'}}
+        @allowEmpty={{true}}
+        as |l|
+      >
+        <l.Item @key='item-1'>Item 1</l.Item>
+        <l.Item @key='item-2'>Item 2</l.Item>
+        <l.Item @key='item-3'>Item 3</l.Item>
+        <l.Item @key='item-4'>Item 4</l.Item>
+        <l.Item @key='item-5'>Item 5</l.Item>
+      </Select>
+      <p>Selected: {{this.selectedKeys}}</p>
+    </div>
   </template>
 }
 ```
@@ -579,14 +589,16 @@ export default class ClearableSelectExample extends Component {
   };
 
   <template>
-    <Select
-      @placeholder='Select a color'
-      @items={{colors}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-      @isClearable={{true}}
-    />
-    <p>Selected: {{this.selectedKey}}</p>
+    <div class='demo-stack'>
+      <Select
+        @placeholder='Select a color'
+        @items={{colors}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+        @isClearable={{true}}
+      />
+      <p>Selected: {{this.selectedKey}}</p>
+    </div>
   </template>
 }
 ```
@@ -612,14 +624,16 @@ export default class LoadingSelectExample extends Component {
   };
 
   <template>
-    <Select
-      @placeholder='Select a size'
-      @items={{sizes}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-      @isLoading={{true}}
-    />
-    <p>Selected: {{this.selectedKey}}</p>
+    <div class='demo-stack'>
+      <Select
+        @placeholder='Select a size'
+        @items={{sizes}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+        @isLoading={{true}}
+      />
+      <p>Selected: {{this.selectedKey}}</p>
+    </div>
   </template>
 }
 ```
@@ -645,26 +659,28 @@ export default class CustomContentBlocksSelect extends Component {
   };
 
   <template>
-    <Select
-      @isFilterable={{true}}
-      @placeholder='Search fruits...'
-      @items={{fruits}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    >
-      <:startContent>
-        <span class='mr-2'>🔍</span>
-      </:startContent>
-      <:endContent>
-        <span class='ml-2'>▼</span>
-      </:endContent>
-      <:emptyContent>
-        <div class='p-2 text-center text-neutral'>
-          No fruits found.
-        </div>
-      </:emptyContent>
-    </Select>
-    <p>Selected: {{this.selectedKey}}</p>
+    <div class='demo-stack'>
+      <Select
+        @isFilterable={{true}}
+        @placeholder='Search fruits...'
+        @items={{fruits}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      >
+        <:startContent>
+          <span class='mr-2'>🔍</span>
+        </:startContent>
+        <:endContent>
+          <span class='ml-2'>▼</span>
+        </:endContent>
+        <:emptyContent>
+          <div class='p-2 text-center text-neutral'>
+            No fruits found.
+          </div>
+        </:emptyContent>
+      </Select>
+      <p>Selected: {{this.selectedKey}}</p>
+    </div>
   </template>
 }
 ```
@@ -688,14 +704,16 @@ export default class NativeSelectExample extends Component {
   };
 
   <template>
-    <NativeSelect
-      @allowEmpty={{true}}
-      @placeholder='Select an option'
-      @items={{options}}
-      @selectedKey={{this.selectedKey}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
-    <p class='mt-4'>Selected: {{this.selectedKey}}</p>
+    <div class='demo-stack'>
+      <NativeSelect
+        @allowEmpty={{true}}
+        @placeholder='Select an option'
+        @items={{options}}
+        @selectedKey={{this.selectedKey}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+      <p class='mt-4'>Selected: {{this.selectedKey}}</p>
+    </div>
   </template>
 }
 ```
@@ -730,15 +748,17 @@ export default class BasicMultipleSelect extends Component {
   };
 
   <template>
-    <Select
-      @selectionMode='multiple'
-      @label='Languages'
-      @placeholder='Select languages'
-      @items={{languages}}
-      @selectedKeys={{this.selectedKeys}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
-    <p class='mt-4'>Selected: {{this.selectedKeys}}</p>
+    <div class='demo-stack'>
+      <Select
+        @selectionMode='multiple'
+        @label='Languages'
+        @placeholder='Select languages'
+        @items={{languages}}
+        @selectedKeys={{this.selectedKeys}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+      <p class='mt-4'>Selected: {{this.selectedKeys}}</p>
+    </div>
   </template>
 }
 ```
@@ -781,25 +801,27 @@ export default class RemovableChipsSelect extends Component {
   };
 
   <template>
-    <div class='grid gap-4 md:grid-cols-2'>
-      <Select
-        @selectionMode='multiple'
-        @label='At least one topping'
-        @placeholder='Select toppings'
-        @items={{toppings}}
-        @selectedKeys={{this.required}}
-        @onSelectionChange={{this.onRequiredChange}}
-      />
-      <Select
-        @selectionMode='multiple'
-        @label='Any number of toppings'
-        @placeholder='Select toppings'
-        @items={{toppings}}
-        @selectedKeys={{this.optional}}
-        @onSelectionChange={{this.onOptionalChange}}
-        @allowEmpty={{true}}
-        @isClearable={{true}}
-      />
+    <div class='demo-stack'>
+      <div class='grid gap-4 md:grid-cols-2'>
+        <Select
+          @selectionMode='multiple'
+          @label='At least one topping'
+          @placeholder='Select toppings'
+          @items={{toppings}}
+          @selectedKeys={{this.required}}
+          @onSelectionChange={{this.onRequiredChange}}
+        />
+        <Select
+          @selectionMode='multiple'
+          @label='Any number of toppings'
+          @placeholder='Select toppings'
+          @items={{toppings}}
+          @selectedKeys={{this.optional}}
+          @onSelectionChange={{this.onOptionalChange}}
+          @allowEmpty={{true}}
+          @isClearable={{true}}
+        />
+      </div>
     </div>
   </template>
 }
@@ -835,31 +857,33 @@ export default class ChipOptionsSelect extends Component {
   };
 
   <template>
-    <div class='grid gap-4 md:grid-cols-2'>
-      <Select
-        @selectionMode='multiple'
-        @intent='primary'
-        @label='Inherits @intent'
-        @placeholder='Select tags'
-        @items={{tags}}
-        @selectedKeys={{this.inherited}}
-        @onSelectionChange={{this.onInheritedChange}}
-      />
-      <Select
-        @selectionMode='multiple'
-        @label='Custom @chip'
-        @placeholder='Select tags'
-        @items={{tags}}
-        @selectedKeys={{this.customized}}
-        @onSelectionChange={{this.onCustomizedChange}}
-        @chip={{hash
-          appearance='outlined'
-          intent='success'
-          size='md'
-          radius='full'
-          withDot=true
-        }}
-      />
+    <div class='demo-stack'>
+      <div class='grid gap-4 md:grid-cols-2'>
+        <Select
+          @selectionMode='multiple'
+          @intent='primary'
+          @label='Inherits @intent'
+          @placeholder='Select tags'
+          @items={{tags}}
+          @selectedKeys={{this.inherited}}
+          @onSelectionChange={{this.onInheritedChange}}
+        />
+        <Select
+          @selectionMode='multiple'
+          @label='Custom @chip'
+          @placeholder='Select tags'
+          @items={{tags}}
+          @selectedKeys={{this.customized}}
+          @onSelectionChange={{this.onCustomizedChange}}
+          @chip={{hash
+            appearance='outlined'
+            intent='success'
+            size='md'
+            radius='full'
+            withDot=true
+          }}
+        />
+      </div>
     </div>
   </template>
 }
@@ -887,15 +911,17 @@ export default class TextDisplayMultipleSelect extends Component {
   };
 
   <template>
-    <Select
-      @selectionMode='multiple'
-      @selectedItemsDisplay='text'
-      @label='Permissions'
-      @placeholder='Select permissions'
-      @items={{permissions}}
-      @selectedKeys={{this.selectedKeys}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
+    <div class='demo-stack'>
+      <Select
+        @selectionMode='multiple'
+        @selectedItemsDisplay='text'
+        @label='Permissions'
+        @placeholder='Select permissions'
+        @items={{permissions}}
+        @selectedKeys={{this.selectedKeys}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+    </div>
   </template>
 }
 ```
@@ -937,16 +963,18 @@ export default class FilterableMultipleSelect extends Component {
   };
 
   <template>
-    <Select
-      @selectionMode='multiple'
-      @isFilterable={{true}}
-      @allowEmpty={{true}}
-      @label='Countries'
-      @placeholder='Search countries'
-      @items={{countries}}
-      @selectedKeys={{this.selectedKeys}}
-      @onSelectionChange={{this.onSelectionChange}}
-    />
+    <div class='demo-stack'>
+      <Select
+        @selectionMode='multiple'
+        @isFilterable={{true}}
+        @allowEmpty={{true}}
+        @label='Countries'
+        @placeholder='Search countries'
+        @items={{countries}}
+        @selectedKeys={{this.selectedKeys}}
+        @onSelectionChange={{this.onSelectionChange}}
+      />
+    </div>
   </template>
 }
 ```
@@ -973,20 +1001,22 @@ export default class StyledChipsSelect extends Component {
   };
 
   <template>
-    <Select
-      @selectionMode='multiple'
-      @label='Teams'
-      @placeholder='Select teams'
-      @items={{teams}}
-      @selectedKeys={{this.selectedKeys}}
-      @onSelectionChange={{this.onSelectionChange}}
-      @allowEmpty={{true}}
-      @classes={{hash
-        chipsField='border-primary-soft'
-        chipsContainer='gap-2'
-        chip='bg-primary-subtle text-primary-strong'
-      }}
-    />
+    <div class='demo-stack'>
+      <Select
+        @selectionMode='multiple'
+        @label='Teams'
+        @placeholder='Select teams'
+        @items={{teams}}
+        @selectedKeys={{this.selectedKeys}}
+        @onSelectionChange={{this.onSelectionChange}}
+        @allowEmpty={{true}}
+        @classes={{hash
+          chipsField='border-primary-soft'
+          chipsContainer='gap-2'
+          chip='bg-primary-subtle text-primary-strong'
+        }}
+      />
+    </div>
   </template>
 }
 ```

--- a/packages/frontile/src/components/forms/switch.md
+++ b/packages/frontile/src/components/forms/switch.md
@@ -26,7 +26,11 @@ The most basic usage of a Switch component with a label.
 ```gts preview
 import { Switch } from 'frontile';
 
-<template><Switch @label='Enable Notifications' /></template>
+<template>
+  <div class='demo-stack'>
+    <Switch @label='Enable Notifications' />
+  </div>
+</template>
 ```
 
 ### Controlled with Form/Field
@@ -46,7 +50,7 @@ export default class ControlledSwitch extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleFormChange}}
@@ -123,7 +127,7 @@ export default class ValidatedSwitch extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -196,14 +200,16 @@ import { SunIcon, MoonIcon } from 'site/components/icons';
 
 export default class CustomContentSwitchExample extends Component {
   <template>
-    <Switch @label='Dark Mode'>
-      <:startContent>
-        <SunIcon />
-      </:startContent>
-      <:endContent>
-        <MoonIcon />
-      </:endContent>
-    </Switch>
+    <div class='demo-stack'>
+      <Switch @label='Dark Mode'>
+        <:startContent>
+          <SunIcon />
+        </:startContent>
+        <:endContent>
+          <MoonIcon />
+        </:endContent>
+      </Switch>
+    </div>
   </template>
 }
 ```
@@ -215,15 +221,17 @@ import { SunIcon, MoonIcon } from 'site/components/icons';
 
 export default class CustomContentSwitchExample extends Component {
   <template>
-    <Switch @label='Dark Mode'>
-      <:thumbContent as |o|>
-        {{#if o.isSelected}}
-          <MoonIcon class='size-3' />
-        {{else}}
-          <SunIcon class='size-3' />
-        {{/if}}
-      </:thumbContent>
-    </Switch>
+    <div class='demo-stack'>
+      <Switch @label='Dark Mode'>
+        <:thumbContent as |o|>
+          {{#if o.isSelected}}
+            <MoonIcon class='size-3' />
+          {{else}}
+            <SunIcon class='size-3' />
+          {{/if}}
+        </:thumbContent>
+      </Switch>
+    </div>
   </template>
 }
 ```
@@ -237,7 +245,7 @@ import { Switch } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{! Size variants }}
     <div>
       <h4 class='text-sm font-medium mb-2'>Size Variants</h4>

--- a/packages/frontile/src/components/forms/textarea.md
+++ b/packages/frontile/src/components/forms/textarea.md
@@ -22,7 +22,11 @@ The most basic usage of the Textarea component with only a label.
 ```gts preview
 import { Textarea } from 'frontile';
 
-<template><Textarea @label='Message' /></template>
+<template>
+  <div class='demo-stack'>
+    <Textarea @label='Message' />
+  </div>
+</template>
 ```
 
 ### Controlled Textarea
@@ -44,7 +48,7 @@ export default class ControlledTextarea extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleFormChange}}
@@ -78,7 +82,7 @@ import { Textarea } from 'frontile';
 
 export default class DisabledTextarea extends Component {
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Textarea
         @label='Disabled Basic Textarea'
         @value='This text cannot be edited or modified. The textarea is in a disabled state.'
@@ -117,7 +121,7 @@ export default class TextareaWithFormChange extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @onChange={{this.handleFormChange}}
@@ -203,7 +207,7 @@ export default class ValidatedTextarea extends Component {
   };
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack'>
       <Form
         @data={{this.formData}}
         @schema={{schema}}
@@ -289,41 +293,43 @@ export default class CompleteFormWithTextarea extends Component {
   };
 
   <template>
-    <Form
-      @data={{this.formData}}
-      @schema={{schema}}
-      @onChange={{this.handleFormChange}}
-      @onSubmit={{this.handleFormSubmit}}
-      @validateOn={{array 'change' 'submit'}}
-      as |form|
-    >
-      <form.Field @name='email' as |field|>
-        <field.Input
-          @label='Email Address'
-          @type='email'
-          @isRequired={{true}}
-        />
-      </form.Field>
+    <div class='demo-stack'>
+      <Form
+        @data={{this.formData}}
+        @schema={{schema}}
+        @onChange={{this.handleFormChange}}
+        @onSubmit={{this.handleFormSubmit}}
+        @validateOn={{array 'change' 'submit'}}
+        as |form|
+      >
+        <form.Field @name='email' as |field|>
+          <field.Input
+            @label='Email Address'
+            @type='email'
+            @isRequired={{true}}
+          />
+        </form.Field>
 
-      <form.Field @name='subject' as |field|>
-        <field.Input
-          @label='Subject'
-          @isRequired={{true}}
-        />
-      </form.Field>
+        <form.Field @name='subject' as |field|>
+          <field.Input
+            @label='Subject'
+            @isRequired={{true}}
+          />
+        </form.Field>
 
-      <form.Field @name='message' as |field|>
-        <field.Textarea
-          @label='Message'
-          @isRequired={{true}}
-          rows='6'
-        />
-      </form.Field>
+        <form.Field @name='message' as |field|>
+          <field.Textarea
+            @label='Message'
+            @isRequired={{true}}
+            rows='6'
+          />
+        </form.Field>
 
-      <Button type='submit'>
-        Send Message
-      </Button>
-    </Form>
+        <Button type='submit'>
+          Send Message
+        </Button>
+      </Form>
+    </div>
   </template>
 }
 ```
@@ -337,7 +343,7 @@ import { Textarea } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col gap-6'>
+  <div class='demo-stack'>
     {{! Size variants }}
     <div>
       <h4 class='text-sm font-medium mb-2'>Size Variants</h4>

--- a/packages/frontile/src/components/navigation/tab-nav.md
+++ b/packages/frontile/src/components/navigation/tab-nav.md
@@ -46,29 +46,31 @@ export default class Example extends Component {
   };
 
   <template>
-    <TabNav @label='Settings' as |nav|>
-      <nav.Item
-        @href='#account'
-        @isActive={{this.isCurrent 'account'}}
-        {{on 'click' (fn this.select 'account')}}
-      >
-        Account
-      </nav.Item>
-      <nav.Item
-        @href='#security'
-        @isActive={{this.isCurrent 'security'}}
-        {{on 'click' (fn this.select 'security')}}
-      >
-        Security
-      </nav.Item>
-      <nav.Item
-        @href='#billing'
-        @isActive={{this.isCurrent 'billing'}}
-        {{on 'click' (fn this.select 'billing')}}
-      >
-        Billing
-      </nav.Item>
-    </TabNav>
+    <div class='demo-stack items-center'>
+      <TabNav @label='Settings' as |nav|>
+        <nav.Item
+          @href='#account'
+          @isActive={{this.isCurrent 'account'}}
+          {{on 'click' (fn this.select 'account')}}
+        >
+          Account
+        </nav.Item>
+        <nav.Item
+          @href='#security'
+          @isActive={{this.isCurrent 'security'}}
+          {{on 'click' (fn this.select 'security')}}
+        >
+          Security
+        </nav.Item>
+        <nav.Item
+          @href='#billing'
+          @isActive={{this.isCurrent 'billing'}}
+          {{on 'click' (fn this.select 'billing')}}
+        >
+          Billing
+        </nav.Item>
+      </TabNav>
+    </div>
   </template>
 }
 ```
@@ -137,7 +139,7 @@ behave the same way — see [Tabs](./tabs) for each option.
 import { TabNav } from 'frontile';
 
 <template>
-  <div class='flex flex-col items-start gap-6'>
+  <div class='demo-stack items-center'>
     <TabNav @label='Solid' @variant='solid' @intent='primary' as |nav|>
       <nav.Item @href='#account' @isActive={{true}}>Account</nav.Item>
       <nav.Item @href='#security'>Security</nav.Item>
@@ -157,11 +159,13 @@ import { TabNav } from 'frontile';
 import { TabNav } from 'frontile';
 
 <template>
-  <TabNav @label='Settings' @orientation='vertical' as |nav|>
-    <nav.Item @href='#account' @isActive={{true}}>Account</nav.Item>
-    <nav.Item @href='#security'>Security</nav.Item>
-    <nav.Item @href='#billing'>Billing</nav.Item>
-  </TabNav>
+  <div class='demo-stack items-center'>
+    <TabNav @label='Settings' @orientation='vertical' as |nav|>
+      <nav.Item @href='#account' @isActive={{true}}>Account</nav.Item>
+      <nav.Item @href='#security'>Security</nav.Item>
+      <nav.Item @href='#billing'>Billing</nav.Item>
+    </TabNav>
+  </div>
 </template>
 ```
 
@@ -174,11 +178,13 @@ link equal width.
 import { TabNav } from 'frontile';
 
 <template>
-  <div class='w-96 max-w-full rounded-lg border border-neutral-soft p-4'>
-    <TabNav @label='Settings' @isFullWidth={{true}} as |nav|>
-      <nav.Item @href='#account' @isActive={{true}}>Account</nav.Item>
-      <nav.Item @href='#security'>Security</nav.Item>
-    </TabNav>
+  <div class='demo-stack items-center'>
+    <div class='w-96 max-w-full rounded-lg border border-neutral-soft p-4'>
+      <TabNav @label='Settings' @isFullWidth={{true}} as |nav|>
+        <nav.Item @href='#account' @isActive={{true}}>Account</nav.Item>
+        <nav.Item @href='#security'>Security</nav.Item>
+      </TabNav>
+    </div>
   </div>
 </template>
 ```
@@ -193,11 +199,13 @@ stops navigation.
 import { TabNav } from 'frontile';
 
 <template>
-  <TabNav @label='Settings' as |nav|>
-    <nav.Item @href='#account' @isActive={{true}}>Account</nav.Item>
-    <nav.Item @href='#billing' @isDisabled={{true}}>Billing</nav.Item>
-    <nav.Item @href='#security'>Security</nav.Item>
-  </TabNav>
+  <div class='demo-stack items-center'>
+    <TabNav @label='Settings' as |nav|>
+      <nav.Item @href='#account' @isActive={{true}}>Account</nav.Item>
+      <nav.Item @href='#billing' @isDisabled={{true}}>Billing</nav.Item>
+      <nav.Item @href='#security'>Security</nav.Item>
+    </TabNav>
+  </div>
 </template>
 ```
 

--- a/packages/frontile/src/components/navigation/tabs.md
+++ b/packages/frontile/src/components/navigation/tabs.md
@@ -28,17 +28,19 @@ one renders.
 import { Tabs } from 'frontile';
 
 <template>
-  <Tabs @defaultValue='account' as |t|>
-    <t.List @label='Settings'>
-      <t.Tab @value='account'>Account</t.Tab>
-      <t.Tab @value='security'>Security</t.Tab>
-      <t.Tab @value='billing'>Billing</t.Tab>
-    </t.List>
+  <div class='demo-stack items-center'>
+    <Tabs @defaultValue='account' as |t|>
+      <t.List @label='Settings'>
+        <t.Tab @value='account'>Account</t.Tab>
+        <t.Tab @value='security'>Security</t.Tab>
+        <t.Tab @value='billing'>Billing</t.Tab>
+      </t.List>
 
-    <t.Panel @value='account'>Update your name, email, and photo.</t.Panel>
-    <t.Panel @value='security'>Manage passwords and two-factor auth.</t.Panel>
-    <t.Panel @value='billing'>View invoices and update your plan.</t.Panel>
-  </Tabs>
+      <t.Panel @value='account'>Update your name, email, and photo.</t.Panel>
+      <t.Panel @value='security'>Manage passwords and two-factor auth.</t.Panel>
+      <t.Panel @value='billing'>View invoices and update your plan.</t.Panel>
+    </Tabs>
+  </div>
 </template>
 ```
 
@@ -68,7 +70,7 @@ export default class Example extends Component {
   };
 
   <template>
-    <div class='flex flex-col items-start gap-3'>
+    <div class='demo-stack items-center'>
       <Tabs @value={{this.section}} @onChange={{this.onChange}} as |t|>
         <t.List @label='Settings'>
           <t.Tab @value='account'>Account</t.Tab>
@@ -96,7 +98,7 @@ header, where the solid track would compete with surrounding content.
 import { Tabs } from 'frontile';
 
 <template>
-  <div class='flex flex-col items-start gap-6'>
+  <div class='demo-stack items-center'>
     <Tabs @defaultValue='account' @variant='solid' as |t|>
       <t.List @label='Solid'>
         <t.Tab @value='account'>Account</t.Tab>
@@ -128,7 +130,7 @@ import { Tabs } from 'frontile';
 import { array } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col items-start gap-3'>
+  <div class='demo-stack items-center'>
     {{#each
       (array
         'default' 'primary' 'secondary' 'tertiary' 'success' 'warning' 'danger'
@@ -153,7 +155,7 @@ import { Tabs } from 'frontile';
 import { array } from '@ember/helper';
 
 <template>
-  <div class='flex flex-col items-start gap-3'>
+  <div class='demo-stack items-center'>
     {{#each (array 'sm' 'md' 'lg') as |size|}}
       <Tabs @defaultValue='account' @size={{size}} as |t|>
         <t.List @label='{{size}} size'>
@@ -176,17 +178,19 @@ list rather than beneath it.
 import { Tabs } from 'frontile';
 
 <template>
-  <Tabs @defaultValue='account' @orientation='vertical' as |t|>
-    <t.List @label='Settings'>
-      <t.Tab @value='account'>Account</t.Tab>
-      <t.Tab @value='security'>Security</t.Tab>
-      <t.Tab @value='billing'>Billing</t.Tab>
-    </t.List>
+  <div class='demo-stack items-center'>
+    <Tabs @defaultValue='account' @orientation='vertical' as |t|>
+      <t.List @label='Settings'>
+        <t.Tab @value='account'>Account</t.Tab>
+        <t.Tab @value='security'>Security</t.Tab>
+        <t.Tab @value='billing'>Billing</t.Tab>
+      </t.List>
 
-    <t.Panel @value='account'>Update your name, email, and photo.</t.Panel>
-    <t.Panel @value='security'>Manage passwords and two-factor auth.</t.Panel>
-    <t.Panel @value='billing'>View invoices and update your plan.</t.Panel>
-  </Tabs>
+      <t.Panel @value='account'>Update your name, email, and photo.</t.Panel>
+      <t.Panel @value='security'>Manage passwords and two-factor auth.</t.Panel>
+      <t.Panel @value='billing'>View invoices and update your plan.</t.Panel>
+    </Tabs>
+  </div>
 </template>
 ```
 
@@ -198,22 +202,24 @@ sidebar where a filled track would compete with the panel beside it.
 import { Tabs } from 'frontile';
 
 <template>
-  <Tabs
-    @defaultValue='account'
-    @orientation='vertical'
-    @variant='underline'
-    as |t|
-  >
-    <t.List @label='Settings'>
-      <t.Tab @value='account'>Account</t.Tab>
-      <t.Tab @value='security'>Security</t.Tab>
-      <t.Tab @value='billing'>Billing</t.Tab>
-    </t.List>
+  <div class='demo-stack items-center'>
+    <Tabs
+      @defaultValue='account'
+      @orientation='vertical'
+      @variant='underline'
+      as |t|
+    >
+      <t.List @label='Settings'>
+        <t.Tab @value='account'>Account</t.Tab>
+        <t.Tab @value='security'>Security</t.Tab>
+        <t.Tab @value='billing'>Billing</t.Tab>
+      </t.List>
 
-    <t.Panel @value='account'>Update your name, email, and photo.</t.Panel>
-    <t.Panel @value='security'>Manage passwords and two-factor auth.</t.Panel>
-    <t.Panel @value='billing'>View invoices and update your plan.</t.Panel>
-  </Tabs>
+      <t.Panel @value='account'>Update your name, email, and photo.</t.Panel>
+      <t.Panel @value='security'>Manage passwords and two-factor auth.</t.Panel>
+      <t.Panel @value='billing'>View invoices and update your plan.</t.Panel>
+    </Tabs>
+  </div>
 </template>
 ```
 
@@ -226,22 +232,24 @@ every tab equal width.
 import { Tabs } from 'frontile';
 
 <template>
-  <div
-    class='flex w-96 max-w-full flex-col items-start gap-3 rounded-lg border border-neutral-soft p-4'
-  >
-    <Tabs @defaultValue='account' as |t|>
-      <t.List @label='Default width'>
-        <t.Tab @value='account'>Account</t.Tab>
-        <t.Tab @value='security'>Security</t.Tab>
-      </t.List>
-    </Tabs>
+  <div class='demo-stack items-center'>
+    <div
+      class='flex w-96 max-w-full flex-col items-start gap-3 rounded-lg border border-neutral-soft p-4'
+    >
+      <Tabs @defaultValue='account' as |t|>
+        <t.List @label='Default width'>
+          <t.Tab @value='account'>Account</t.Tab>
+          <t.Tab @value='security'>Security</t.Tab>
+        </t.List>
+      </Tabs>
 
-    <Tabs @defaultValue='account' @isFullWidth={{true}} as |t|>
-      <t.List @label='Full width'>
-        <t.Tab @value='account'>Account</t.Tab>
-        <t.Tab @value='security'>Security</t.Tab>
-      </t.List>
-    </Tabs>
+      <Tabs @defaultValue='account' @isFullWidth={{true}} as |t|>
+        <t.List @label='Full width'>
+          <t.Tab @value='account'>Account</t.Tab>
+          <t.Tab @value='security'>Security</t.Tab>
+        </t.List>
+      </Tabs>
+    </div>
   </div>
 </template>
 ```
@@ -256,13 +264,15 @@ navigation skips it and it cannot be clicked or selected. `@isDisabled` on
 import { Tabs } from 'frontile';
 
 <template>
-  <Tabs @defaultValue='account' as |t|>
-    <t.List @label='Settings'>
-      <t.Tab @value='account'>Account</t.Tab>
-      <t.Tab @value='billing' @isDisabled={{true}}>Billing</t.Tab>
-      <t.Tab @value='security'>Security</t.Tab>
-    </t.List>
-  </Tabs>
+  <div class='demo-stack items-center'>
+    <Tabs @defaultValue='account' as |t|>
+      <t.List @label='Settings'>
+        <t.Tab @value='account'>Account</t.Tab>
+        <t.Tab @value='billing' @isDisabled={{true}}>Billing</t.Tab>
+        <t.Tab @value='security'>Security</t.Tab>
+      </t.List>
+    </Tabs>
+  </div>
 </template>
 ```
 
@@ -279,17 +289,19 @@ shouldn't trigger it each time.
 import { Tabs } from 'frontile';
 
 <template>
-  <Tabs @defaultValue='account' @activationMode='manual' as |t|>
-    <t.List @label='Settings'>
-      <t.Tab @value='account'>Account</t.Tab>
-      <t.Tab @value='security'>Security</t.Tab>
-      <t.Tab @value='billing'>Billing</t.Tab>
-    </t.List>
+  <div class='demo-stack items-center'>
+    <Tabs @defaultValue='account' @activationMode='manual' as |t|>
+      <t.List @label='Settings'>
+        <t.Tab @value='account'>Account</t.Tab>
+        <t.Tab @value='security'>Security</t.Tab>
+        <t.Tab @value='billing'>Billing</t.Tab>
+      </t.List>
 
-    <t.Panel @value='account'>Account panel</t.Panel>
-    <t.Panel @value='security'>Security panel</t.Panel>
-    <t.Panel @value='billing'>Billing panel</t.Panel>
-  </Tabs>
+      <t.Panel @value='account'>Account panel</t.Panel>
+      <t.Panel @value='security'>Security panel</t.Panel>
+      <t.Panel @value='billing'>Billing panel</t.Panel>
+    </Tabs>
+  </div>
 </template>
 ```
 
@@ -305,19 +317,21 @@ import { Tabs } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <Tabs
-    @defaultValue='account'
-    @classes={{hash
-      tab='data-[selected=true]:text-on-primary'
-      indicator='bg-primary'
-    }}
-    as |t|
-  >
-    <t.List @label='Settings'>
-      <t.Tab @value='account'>Account</t.Tab>
-      <t.Tab @value='security'>Security</t.Tab>
-    </t.List>
-  </Tabs>
+  <div class='demo-stack items-center'>
+    <Tabs
+      @defaultValue='account'
+      @classes={{hash
+        tab='data-[selected=true]:text-on-primary'
+        indicator='bg-primary'
+      }}
+      as |t|
+    >
+      <t.List @label='Settings'>
+        <t.Tab @value='account'>Account</t.Tab>
+        <t.Tab @value='security'>Security</t.Tab>
+      </t.List>
+    </Tabs>
+  </div>
 </template>
 ```
 

--- a/packages/frontile/src/components/overlays/drawer.md
+++ b/packages/frontile/src/components/overlays/drawer.md
@@ -35,7 +35,7 @@ export default class BasicDrawer extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggle}}>
         Open Drawer
       </Button>
@@ -123,7 +123,7 @@ export default class DrawerPlacements extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='grid grid-cols-2 gap-2'>
         {{#each this.placements as |placement|}}
           <Button @onPress={{fn this.openDrawer placement.key}}>
@@ -218,7 +218,7 @@ export default class DrawerSizes extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='grid grid-cols-3 gap-2'>
         {{#each this.sizeOptions as |option|}}
           <Button @onPress={{fn this.openDrawer option.key}}>
@@ -296,7 +296,7 @@ export default class DrawerBackdrops extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='grid grid-cols-2 gap-2'>
         {{#each this.backdropOptions as |option|}}
           <Button @onPress={{fn this.openDrawer option.key}}>
@@ -357,7 +357,7 @@ export default class DrawerCloseButton extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.toggleNormal}}>
           Normal Close Button
@@ -462,7 +462,7 @@ export default class DrawerForm extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggle}}>
         Open Contact Form
       </Button>
@@ -559,7 +559,7 @@ export default class NonDismissibleDrawer extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggle}}>
         Open Processing Drawer
       </Button>
@@ -638,7 +638,7 @@ export default class NavigationDrawer extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggle}}>
         Open Navigation
       </Button>

--- a/packages/frontile/src/components/overlays/modal.md
+++ b/packages/frontile/src/components/overlays/modal.md
@@ -35,7 +35,7 @@ export default class BasicModal extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggle}}>
         Open Modal
       </Button>
@@ -139,7 +139,7 @@ export default class ModalSizes extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='grid grid-cols-3 gap-2'>
         {{#each this.sizeOptions as |option|}}
           <Button @onPress={{fn this.openModal option.key}}>
@@ -192,7 +192,7 @@ export default class ModalPositioning extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.toggleStandard}}>
           Standard Position
@@ -289,7 +289,7 @@ export default class ModalBackdrops extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='grid grid-cols-2 gap-2'>
         {{#each this.backdropOptions as |option|}}
           <Button @onPress={{fn this.openModal option.key}}>
@@ -361,7 +361,7 @@ export default class ConfirmationDialog extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @intent='danger' @onPress={{this.openDialog}}>
         Delete Item
       </Button>
@@ -510,7 +510,7 @@ export default class FormModal extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggle}}>
         Open Contact Form
       </Button>
@@ -614,7 +614,7 @@ export default class ModalCloseButton extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.toggleNormal}}>
           Normal Close Button
@@ -715,7 +715,7 @@ export default class NestedModals extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggleFirst}}>
         Open First Modal
       </Button>

--- a/packages/frontile/src/components/overlays/overlay.md
+++ b/packages/frontile/src/components/overlays/overlay.md
@@ -34,7 +34,7 @@ export default class BasicOverlay extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <Button @onPress={{this.toggle}}>
         Open Overlay
       </Button>
@@ -88,7 +88,7 @@ export default class BackdropTypes extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.toggleFaded}}>
           Faded Backdrop
@@ -165,7 +165,7 @@ export default class RenderInPlace extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.togglePortal}}>
           Portal Overlay (Default)
@@ -250,7 +250,7 @@ export default class CustomCloseBehavior extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='grid grid-cols-2 gap-2'>
         <Button @onPress={{this.toggleNormal}}>
           Normal Overlay
@@ -340,7 +340,7 @@ export default class FocusManagement extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.toggleFocusTrap}} data-test-trigger>
           Focus Trap Enabled
@@ -428,7 +428,7 @@ export default class AnimationsAndTransitions extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.toggleFast}}>
           Fast Animation (100ms)
@@ -508,7 +508,7 @@ export default class OverlayElementClick extends Component {
   }
 
   <template>
-    <div class='flex flex-col gap-4'>
+    <div class='demo-stack demo-stack--wide items-center'>
       <div class='flex gap-2'>
         <Button @onPress={{this.toggleDefault}}>
           Default Behavior

--- a/packages/frontile/src/components/status/progress-bar.md
+++ b/packages/frontile/src/components/status/progress-bar.md
@@ -18,7 +18,11 @@ import { ProgressBar } from 'frontile';
 ```gts preview
 import { ProgressBar } from 'frontile';
 
-<template><ProgressBar @progress={{50}} @label='Progress' /></template>
+<template>
+  <div class='demo-stack'>
+    <ProgressBar @progress={{50}} @label='Progress' />
+  </div>
+</template>
 ```
 
 ## ProgressBar Intents
@@ -27,38 +31,40 @@ import { ProgressBar } from 'frontile';
 import { ProgressBar } from 'frontile';
 
 <template>
-  <div class='grid grid-cols-6 gap-4'>
-    <ProgressBar @progress={{50}} @label='Default' @showValueLabel={{false}} />
-    <ProgressBar
-      @progress={{50}}
-      @label='Primary'
-      @intent='primary'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @progress={{50}}
-      @label='Secondary'
-      @intent='secondary'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @progress={{50}}
-      @label='Success'
-      @intent='success'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @progress={{50}}
-      @label='Warning'
-      @intent='warning'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @progress={{50}}
-      @label='Danger'
-      @intent='danger'
-      @showValueLabel={{false}}
-    />
+  <div class='demo-stack'>
+    <div class='grid grid-cols-6 gap-4'>
+      <ProgressBar @progress={{50}} @label='Default' @showValueLabel={{false}} />
+      <ProgressBar
+        @progress={{50}}
+        @label='Primary'
+        @intent='primary'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @progress={{50}}
+        @label='Secondary'
+        @intent='secondary'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @progress={{50}}
+        @label='Success'
+        @intent='success'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @progress={{50}}
+        @label='Warning'
+        @intent='warning'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @progress={{50}}
+        @label='Danger'
+        @intent='danger'
+        @showValueLabel={{false}}
+      />
+    </div>
   </div>
 </template>
 ```
@@ -69,26 +75,28 @@ import { ProgressBar } from 'frontile';
 import { ProgressBar } from 'frontile';
 
 <template>
-  <div class='mt-6 grid grid-cols-4 gap-4 items-center'>
-    <ProgressBar
-      @progress={{50}}
-      @size='xs'
-      @label='XSmall'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @progress={{50}}
-      @size='sm'
-      @label='Small'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar @progress={{50}} @label='Normal' @showValueLabel={{false}} />
-    <ProgressBar
-      @progress={{50}}
-      @size='lg'
-      @label='Large'
-      @showValueLabel={{false}}
-    />
+  <div class='demo-stack'>
+    <div class='mt-6 grid grid-cols-4 gap-4 items-center'>
+      <ProgressBar
+        @progress={{50}}
+        @size='xs'
+        @label='XSmall'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @progress={{50}}
+        @size='sm'
+        @label='Small'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar @progress={{50}} @label='Normal' @showValueLabel={{false}} />
+      <ProgressBar
+        @progress={{50}}
+        @size='lg'
+        @label='Large'
+        @showValueLabel={{false}}
+      />
+    </div>
   </div>
 </template>
 ```
@@ -99,35 +107,37 @@ import { ProgressBar } from 'frontile';
 import { ProgressBar } from 'frontile';
 
 <template>
-  <div class='mt-6 grid grid-cols-4 gap-4'>
-    <ProgressBar
-      @size='lg'
-      @progress={{50}}
-      @radius='none'
-      @label='None'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @size='lg'
-      @progress={{50}}
-      @radius='sm'
-      @label='Small'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @size='lg'
-      @progress={{50}}
-      @radius='lg'
-      @label='Large'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @size='lg'
-      @progress={{50}}
-      @radius='full'
-      @label='Full'
-      @showValueLabel={{false}}
-    />
+  <div class='demo-stack'>
+    <div class='mt-6 grid grid-cols-4 gap-4'>
+      <ProgressBar
+        @size='lg'
+        @progress={{50}}
+        @radius='none'
+        @label='None'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @size='lg'
+        @progress={{50}}
+        @radius='sm'
+        @label='Small'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @size='lg'
+        @progress={{50}}
+        @radius='lg'
+        @label='Large'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @size='lg'
+        @progress={{50}}
+        @radius='full'
+        @label='Full'
+        @showValueLabel={{false}}
+      />
+    </div>
   </div>
 </template>
 ```
@@ -139,23 +149,25 @@ import { ProgressBar } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='mt-6 grid grid-cols-2 gap-4 items-end'>
-    <ProgressBar @progress={{50}} @label='With label' />
-    <ProgressBar
-      @progress={{50}}
-      @label='Hiding label value'
-      @showValueLabel={{false}}
-    />
-    <ProgressBar
-      @progress={{50}}
-      @label='Custom label value'
-      @valueLabel='4 out of 8'
-    />
-    <ProgressBar
-      @progress={{50}}
-      @label='Custom formatter'
-      @formatOptions={{(hash style='currency' currency='USD')}}
-    />
+  <div class='demo-stack'>
+    <div class='mt-6 grid grid-cols-2 gap-4 items-end'>
+      <ProgressBar @progress={{50}} @label='With label' />
+      <ProgressBar
+        @progress={{50}}
+        @label='Hiding label value'
+        @showValueLabel={{false}}
+      />
+      <ProgressBar
+        @progress={{50}}
+        @label='Custom label value'
+        @valueLabel='4 out of 8'
+      />
+      <ProgressBar
+        @progress={{50}}
+        @label='Custom formatter'
+        @formatOptions={{(hash style='currency' currency='USD')}}
+      />
+    </div>
   </div>
 </template>
 ```
@@ -180,19 +192,21 @@ import { ProgressBar } from 'frontile';
 import { hash } from '@ember/helper';
 
 <template>
-  <div class='mt-6 grid grid-cols-2 gap-4 items-end'>
-    <ProgressBar
-      @progress={{50}}
-      @label='Percent style'
-      @formatOptions={{(hash style='percent')}}
-    />
-    <ProgressBar
-      @progress={{20}}
-      @minValue={{10}}
-      @maxValue={{30}}
-      @label='Percent style, 10–30 scale'
-      @formatOptions={{(hash style='percent')}}
-    />
+  <div class='demo-stack'>
+    <div class='mt-6 grid grid-cols-2 gap-4 items-end'>
+      <ProgressBar
+        @progress={{50}}
+        @label='Percent style'
+        @formatOptions={{(hash style='percent')}}
+      />
+      <ProgressBar
+        @progress={{20}}
+        @minValue={{10}}
+        @maxValue={{30}}
+        @label='Percent style, 10–30 scale'
+        @formatOptions={{(hash style='percent')}}
+      />
+    </div>
   </div>
 </template>
 ```
@@ -221,9 +235,11 @@ matching what they render.
 import { ProgressBar } from 'frontile';
 
 <template>
-  <div class='grid grid-cols-2 gap-4 items-end'>
-    <ProgressBar @progress={{150}} @label='Progress of 150' />
-    <ProgressBar @progress={{-20}} @label='Progress of -20' />
+  <div class='demo-stack'>
+    <div class='grid grid-cols-2 gap-4 items-end'>
+      <ProgressBar @progress={{150}} @label='Progress of 150' />
+      <ProgressBar @progress={{-20}} @label='Progress of -20' />
+    </div>
   </div>
 </template>
 ```
@@ -239,11 +255,13 @@ signal.
 import { ProgressBar } from 'frontile';
 
 <template>
-  <ProgressBar
-    @progress={{50}}
-    @label='Uploading'
-    @description='Estimated time left'
-  />
+  <div class='demo-stack'>
+    <ProgressBar
+      @progress={{50}}
+      @label='Uploading'
+      @description='Estimated time left'
+    />
+  </div>
 </template>
 ```
 
@@ -255,7 +273,9 @@ You can pass the argument `@isIndeterminate` to represent when the effort or dur
 import { ProgressBar } from 'frontile';
 
 <template>
-  <ProgressBar @size='md' @label='Progress' @isIndeterminate={{true}} />
+  <div class='demo-stack'>
+    <ProgressBar @size='md' @label='Progress' @isIndeterminate={{true}} />
+  </div>
 </template>
 ```
 
@@ -268,13 +288,15 @@ conflicting utility replaces the theme's rather than fighting it.
 import { ProgressBar } from 'frontile';
 
 <template>
-  <div class='grid grid-cols-2 gap-4'>
-    <ProgressBar @progress={{70}} @label='Default track' />
-    <ProgressBar
-      @progress={{70}}
-      @label='Taller track'
-      @class='h-6 rounded-none'
-    />
+  <div class='demo-stack'>
+    <div class='grid grid-cols-2 gap-4'>
+      <ProgressBar @progress={{70}} @label='Default track' />
+      <ProgressBar
+        @progress={{70}}
+        @label='Taller track'
+        @class='h-6 rounded-none'
+      />
+    </div>
   </div>
 </template>
 ```
@@ -308,7 +330,7 @@ value; keep `@label` and hide the whole row visually instead:
 import { ProgressBar, VisuallyHidden } from 'frontile';
 
 <template>
-  <div class='flex flex-col gap-4'>
+  <div class='demo-stack'>
     <ProgressBar @progress={{40}} @label='Visible label' />
 
     <VisuallyHidden>

--- a/packages/frontile/src/components/utilities/skeleton.md
+++ b/packages/frontile/src/components/utilities/skeleton.md
@@ -24,10 +24,12 @@ and use `@class` for anything they don't cover.
 import { Skeleton } from 'frontile';
 
 <template>
-  <div class='not-prose w-80 space-y-3'>
-    <Skeleton @shape='rounded' @class='h-32' />
-    <Skeleton @size='sm' />
-    <Skeleton @size='sm' @class='w-2/3' />
+  <div class='demo-stack items-center'>
+    <div class='not-prose w-80 space-y-3'>
+      <Skeleton @shape='rounded' @class='h-32' />
+      <Skeleton @size='sm' />
+      <Skeleton @size='sm' @class='w-2/3' />
+    </div>
   </div>
 </template>
 ```
@@ -45,13 +47,15 @@ content-sized parent collapses to nothing.
 import { Skeleton } from 'frontile';
 
 <template>
-  <div class='not-prose flex w-96 items-end gap-4'>
-    <div class='flex-1 space-y-2'>
-      <Skeleton @shape='text' />
-      <Skeleton @shape='text' @class='w-2/3' />
+  <div class='demo-stack items-center'>
+    <div class='not-prose flex w-96 items-end gap-4'>
+      <div class='flex-1 space-y-2'>
+        <Skeleton @shape='text' />
+        <Skeleton @shape='text' @class='w-2/3' />
+      </div>
+      <Skeleton @shape='circle' @size='xl' />
+      <Skeleton @shape='square' @size='xl' />
     </div>
-    <Skeleton @shape='circle' @size='xl' />
-    <Skeleton @shape='square' @size='xl' />
   </div>
 </template>
 ```
@@ -71,11 +75,13 @@ lines up with the real thing it stands in for:
 import { Skeleton, Avatar } from 'frontile';
 
 <template>
-  <div class='not-prose flex items-center gap-4'>
-    <Skeleton @shape='circle' @size='lg' />
-    <Avatar @name='Ada Lovelace' @size='lg' />
-    <Skeleton @shape='square' @size='lg' />
-    <Avatar @name='Ada Lovelace' @shape='square' @size='lg' />
+  <div class='demo-stack items-center'>
+    <div class='not-prose flex items-center gap-4'>
+      <Skeleton @shape='circle' @size='lg' />
+      <Avatar @name='Ada Lovelace' @size='lg' />
+      <Skeleton @shape='square' @size='lg' />
+      <Avatar @name='Ada Lovelace' @shape='square' @size='lg' />
+    </div>
   </div>
 </template>
 ```
@@ -91,12 +97,14 @@ invisible, which makes a loading state look like an empty one.
 import { Skeleton } from 'frontile';
 
 <template>
-  <div class='not-prose flex w-96 items-center gap-4'>
-    <Skeleton @shape='circle' @size='xs' />
-    <Skeleton @shape='circle' @size='sm' />
-    <Skeleton @shape='circle' @size='md' />
-    <Skeleton @shape='circle' @size='lg' />
-    <Skeleton @shape='circle' @size='xl' />
+  <div class='demo-stack items-center'>
+    <div class='not-prose flex w-96 items-center gap-4'>
+      <Skeleton @shape='circle' @size='xs' />
+      <Skeleton @shape='circle' @size='sm' />
+      <Skeleton @shape='circle' @size='md' />
+      <Skeleton @shape='circle' @size='lg' />
+      <Skeleton @shape='circle' @size='xl' />
+    </div>
   </div>
 </template>
 ```
@@ -109,11 +117,13 @@ import { Skeleton } from 'frontile';
 import { Skeleton } from 'frontile';
 
 <template>
-  <div class='not-prose w-72 space-y-3'>
-    <Skeleton @shape='rounded' @class='h-40' />
-    <Skeleton @shape='text' @size='lg' @class='w-3/4' />
-    <Skeleton @shape='text' @size='sm' />
-    <Skeleton @shape='text' @size='sm' @class='w-1/2' />
+  <div class='demo-stack items-center'>
+    <div class='not-prose w-72 space-y-3'>
+      <Skeleton @shape='rounded' @class='h-40' />
+      <Skeleton @shape='text' @size='lg' @class='w-3/4' />
+      <Skeleton @shape='text' @size='sm' />
+      <Skeleton @shape='text' @size='sm' @class='w-1/2' />
+    </div>
   </div>
 </template>
 ```
@@ -126,11 +136,13 @@ Compose several to sketch the shape of the real content.
 import { Skeleton } from 'frontile';
 
 <template>
-  <div class='not-prose flex w-80 items-center gap-3'>
-    <Skeleton @shape='circle' @size='lg' @class='shrink-0' />
-    <div class='flex-1 space-y-2'>
-      <Skeleton @size='sm' />
-      <Skeleton @size='sm' @class='w-2/3' />
+  <div class='demo-stack items-center'>
+    <div class='not-prose flex w-80 items-center gap-3'>
+      <Skeleton @shape='circle' @size='lg' @class='shrink-0' />
+      <div class='flex-1 space-y-2'>
+        <Skeleton @size='sm' />
+        <Skeleton @size='sm' @class='w-2/3' />
+      </div>
     </div>
   </div>
 </template>
@@ -145,18 +157,20 @@ unaffected by an app that redefines Tailwind's `pulse`.
 import { Skeleton } from 'frontile';
 
 <template>
-  <div class='not-prose w-80 space-y-4'>
-    <div>
-      <p class='mb-1 text-body-2xs text-neutral-soft'>shimmer (default)</p>
-      <Skeleton @class='h-4' @animation='shimmer' />
-    </div>
-    <div>
-      <p class='mb-1 text-body-2xs text-neutral-soft'>pulse</p>
-      <Skeleton @class='h-4' @animation='pulse' />
-    </div>
-    <div>
-      <p class='mb-1 text-body-2xs text-neutral-soft'>none</p>
-      <Skeleton @class='h-4' @animation='none' />
+  <div class='demo-stack items-center'>
+    <div class='not-prose w-80 space-y-4'>
+      <div>
+        <p class='mb-1 text-body-2xs text-neutral-soft'>shimmer (default)</p>
+        <Skeleton @class='h-4' @animation='shimmer' />
+      </div>
+      <div>
+        <p class='mb-1 text-body-2xs text-neutral-soft'>pulse</p>
+        <Skeleton @class='h-4' @animation='pulse' />
+      </div>
+      <div>
+        <p class='mb-1 text-body-2xs text-neutral-soft'>none</p>
+        <Skeleton @class='h-4' @animation='none' />
+      </div>
     </div>
   </div>
 </template>

--- a/site/app/styles/docfy-demo.css
+++ b/site/app/styles/docfy-demo.css
@@ -35,6 +35,15 @@
   @apply w-full;
 }
 
+/* Wide demos — data tables, side-by-side comparisons — need more than the
+   `max-w-xl` reading measure that suits a column of form controls. This
+   modifier is declared after `.demo-stack` so, at equal specificity, its
+   `max-width` deterministically wins; it is used as `class='demo-stack
+   demo-stack--wide'` so the `:has()` opt-in above still applies. */
+.demo-stack--wide {
+  @apply max-w-none;
+}
+
 .docfy-demo__description {
   @apply pb-5;
 }


### PR DESCRIPTION
Follow-up to #555, which added `.demo-stack` and fixed the Alert page. This sweeps the
convention across the rest of the co-located component docs.

## The bug

`.docfy-demo__example__container` is a centered flex container, and its child
`.docfy-demo__example` is the real flex item, so it shrink-wraps to its content. Any demo
sizing itself with `w-full` resolved that `100%` against a content-derived box, and demos
whose content changes on interaction changed width as you used them.

Fixed demo-side, as shadcn/ui and HeroUI do: each demo declares its own width.

## What changed

232 demo wrappers across 26 pages now opt in. Three ingredients, combined per page:

| Variant | Count | Used for |
| --- | --- | --- |
| `demo-stack` | 138 | Block content — form controls, Command, ProgressBar, Autocomplete |
| `demo-stack items-center` | 34 | Content that should stay shrink-wrapped and centered — Tabs, TabNav, Skeleton, and the Listbox/Dropdown demos with live readouts |
| `demo-stack demo-stack--wide` | 37 | Table and SimpleTable, which want the whole stage |
| `demo-stack demo-stack--wide items-center` | 23 | Modal, Drawer, Overlay — trigger rows up to 774px wide, kept centered |

`.demo-stack--wide` is a new modifier in `site/app/styles/docfy-demo.css` that drops the
`max-w-xl` cap. It is declared after `.demo-stack` so it wins on `max-width` at equal
specificity, and it is applied alongside `.demo-stack` so the `:has(> .demo-stack)` opt-in
still matches.

`items-center` exists because some demos shrink-wrap on purpose: the default Tabs list hugs
its labels, which is exactly what the `@isFullWidth` demo contrasts against. Pinning the box
while leaving contents centered fixes the width jump without changing what the demo shows.

## Left alone deliberately

Buttons, Chip, CloseButton, ToggleButton, ButtonGroup, SegmentedControl, Avatar, Kbd,
Spinner, Divider, VisuallyHidden, Collapsible, Popover, Portal, Notifications, and the
fixed-width Listbox boxes and single-trigger Dropdown demos. These are rows of small
intrinsic controls or already declare their own width; they measure as centered and do not
resize on interaction, and converting them would left-align them.

## Verification

Measured per page in a real browser at 1440px, comparing each stage's content box against
the demo wrapper's `getBoundingClientRect()`.

- Block demos render at 576px, wide demos at the full 782px stage — previously as narrow as
  75px (ProgressBar) and 113px (Listbox Groups).
- Every converted demo is centered: left and right gaps equal to within 1px.
- No demo changes width on interaction. Real jumps fixed, measured before and after:
  vertical Tabs 406→395px and 407→396px on panel switch, plus the Dropdown and Listbox
  selection readouts.
- Modal/Drawer/Overlay/Skeleton content measures at exactly its pre-change width on all 30
  demos, so those pages render identically to before — only the box around them is now
  independent of content.
- No new console errors on any page.
- `:has()` scoping still holds: 0 matches across 100 demos on ten unconverted pages,
  18/18 on a converted one.

`site && pnpm build` renders 83 pages, 0 failed. Tests 1458 total / 1455 passing / 3 skipped
/ 0 failing, matching the baseline. `pnpm lint:js` 0 errors. Docs linter 0 errors.

Layout wrappers only — no demo's content, arguments, or prose changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)