### PR TITLE
fix(listbox): handle keys on keydown instead of deprecated keypress

### DIFF
--- a/packages/frontile/src/components/collections/listbox/listbox.gts
+++ b/packages/frontile/src/components/collections/listbox/listbox.gts
@@ -93,6 +93,54 @@ const isInputElement = (
 
 const isUndefined = (a: unknown) => typeof a === 'undefined';
 
+const NAVIGATION_KEYS = [
+  'ArrowUp',
+  'ArrowDown',
+  'PageUp',
+  'PageDown',
+  'Home',
+  'End'
+];
+
+/**
+ * Whether a command-style modifier is held.
+ *
+ * Enter, Space and type-ahead moved here from the deprecated `keypress`,
+ * which largely did not deliver modifier combinations at all. `keydown` does,
+ * and it reports an unchanged `key`: Cmd+K arrives as `key === 'k'`, Cmd+Space
+ * (Spotlight) as `key === ' '`. Acting on those would swallow the user's and
+ * the OS's shortcuts -- typing them into the search buffer, or selecting an
+ * option nobody asked for -- so a modifier combo is not ours to handle.
+ *
+ * Shift is deliberately absent: a capital letter is legitimate type-ahead.
+ * `Popover`'s open-on-letter handler makes the same check for the same
+ * reason.
+ *
+ * Arrow and Home/End navigation is exempt, because it always lived on
+ * `keydown` and so already had to tolerate these combinations.
+ */
+const hasCommandModifier = (event: KeyboardEvent): boolean => {
+  return event.metaKey || event.ctrlKey || event.altKey;
+};
+
+/**
+ * Whether a keystroke should extend the type-ahead search buffer.
+ *
+ * Any single printable character qualifies. Unlike `Popover`'s letter check
+ * this deliberately does not require `event.code === 'Key' + key`, which
+ * restricts matching to A-Z: a listbox types ahead with digits and
+ * punctuation too, and the WAI-ARIA APG requires Space to extend an active
+ * search.
+ *
+ * Autorepeat is dropped. `search()` accumulates a prefix rather than cycling
+ * between same-initial items, so a leaned-on 'a' would build "aaaa" and match
+ * nothing -- a hazard `keypress` never surfaced here. Keystrokes mid-IME
+ * composition belong to the input method, not to type-ahead.
+ */
+const isTypeAheadKey = (event: KeyboardEvent): boolean => {
+  return event.key.length === 1 && !event.repeat && !event.isComposing;
+};
+
 class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
   listManager = new ListManager({
     selectionMode: this.args.selectionMode,
@@ -107,42 +155,19 @@ class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
       : this.args.autoActivateMode
   });
 
-  handleKeyPress = (event: KeyboardEvent) => {
-    if (isInputElement(event.target)) {
-      if (event.key === 'Enter') {
-        this.listManager.selectActiveItem();
-        return;
-      }
-    } else {
-      if (event.key === 'Enter') {
-        // Enter always selects the active item, even mid-search — unlike
-        // Space, Enter is never itself a type-ahead character (its length is
-        // 5, not 1), so gating it on an empty search buffer just drops the
-        // keystroke while `search()`'s 500ms debounce is still pending. Do
-        // not fold this back into the Space branch below.
-        this.listManager.selectActiveItem();
-        this.listManager.clearSearch();
-        event.preventDefault();
-        event.stopPropagation();
-        return;
-      } else if (event.key === ' ' && this.listManager.searchKeys == '') {
-        this.listManager.selectActiveItem();
-        event.preventDefault();
-        event.stopPropagation();
-        return;
-      } else if (event.key.length === 1) {
-        this.listManager.search(event.key);
-        return;
-      }
-    }
-  };
-
+  /**
+   * All keyboard behaviour lands on `keydown`.
+   *
+   * Selection and type-ahead used to live on a separate `keypress` listener.
+   * A browser fires `keypress` only when the preceding `keydown` was not
+   * canceled, so any co-located `keydown` handler calling `preventDefault()`
+   * -- `Dropdown`'s submenu keys, a consuming app's shortcut handler --
+   * silently deleted the event this component depended on, and Enter
+   * selection stopped working with no error at all. `keypress` is also absent
+   * from current spec guidance and inconsistent for non-printable keys.
+   */
   handleKeyDown = (event: KeyboardEvent) => {
-    if (
-      ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'].includes(
-        event.key
-      )
-    ) {
+    if (NAVIGATION_KEYS.includes(event.key)) {
       event.preventDefault();
 
       if (event.key === 'ArrowDown') {
@@ -154,12 +179,54 @@ class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
       } else if (event.key === 'End' || event.key === 'PageDown') {
         this.listManager.setLastOptionActive();
       }
-    }
-  };
 
-  onKeyPress = (event: KeyboardEvent) => {
-    if (this.args.isKeyboardEventsEnabled) {
-      this.handleKeyPress(event);
+      return;
+    }
+
+    if (hasCommandModifier(event)) {
+      return;
+    }
+
+    // Navigation above applies wherever the keystroke came from, but text
+    // entry does not: when the events are forwarded from a real input (an
+    // Autocomplete or Select trigger), the input owns the typing and only
+    // Enter is ours to act on.
+    if (isInputElement(event.target)) {
+      if (event.key === 'Enter') {
+        this.listManager.selectActiveItem();
+      }
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      // Enter always selects the active item, even mid-search — unlike
+      // Space, Enter is never itself a type-ahead character (its length is
+      // 5, not 1), so gating it on an empty search buffer just drops the
+      // keystroke while `search()`'s 500ms debounce is still pending. Do
+      // not fold this back into the Space branch below.
+      this.listManager.selectActiveItem();
+      this.listManager.clearSearch();
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (event.key === ' ' && this.listManager.searchKeys == '') {
+      this.listManager.selectActiveItem();
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (isTypeAheadKey(event)) {
+      if (event.key === ' ') {
+        // Space extends an active search rather than selecting, but it must
+        // still not scroll the page. Only `keydown` can prevent that; the
+        // old `keypress` listener fired too late to stop it.
+        event.preventDefault();
+      }
+
+      this.listManager.search(event.key);
     }
   };
 
@@ -180,10 +247,6 @@ class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
           'keydown',
           this.handleKeyDown
         );
-        args.elementToAddKeyboardEvents.addEventListener(
-          'keypress',
-          this.handleKeyPress
-        );
       }
 
       return () => {
@@ -191,10 +254,6 @@ class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
           args.elementToAddKeyboardEvents.removeEventListener(
             'keydown',
             this.handleKeyDown
-          );
-          args.elementToAddKeyboardEvents.removeEventListener(
-            'keypress',
-            this.handleKeyPress
           );
         }
       };
@@ -245,7 +304,6 @@ class Listbox<T = unknown> extends Component<ListboxSignature<T>> {
           (isUndefined @autoActivateMode) "first" @autoActivateMode
         )
       }}
-      {{on "keypress" this.onKeyPress}}
       {{on "keydown" this.onKeyDown}}
       {{this.setupEvents
         elementToAddKeyboardEvents=@elementToAddKeyboardEvents

--- a/packages/frontile/src/components/forms/autocomplete.gts
+++ b/packages/frontile/src/components/forms/autocomplete.gts
@@ -353,9 +353,6 @@ class Autocomplete<T = unknown> extends Component<AutocompleteSignature<T>> {
   /** Element id of the currently active (highlighted) option, for aria-activedescendant. */
   @tracked activeDescendant?: string;
 
-  /** The currently active (highlighted) option. */
-  activeItem?: ListItem;
-
   /**
    * Label of the selected key, captured at selection time. Needed in async
    * mode, where the selected item may no longer be present in the currently
@@ -469,12 +466,10 @@ class Autocomplete<T = unknown> extends Component<AutocompleteSignature<T>> {
 
   onKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Enter' && this.isOpen) {
-      // Prevent form submission while the dropdown is open. Canceling
-      // keydown also suppresses the keypress event the Listbox listens to,
-      // so select the active option directly.
+      // Prevent form submission while the dropdown is open. Selecting the
+      // active option is the Listbox's job: it handles Enter on keydown, so
+      // canceling this event no longer suppresses the one it listens to.
       event.preventDefault();
-
-      this.activeItem?.el.click();
     }
   };
 
@@ -533,7 +528,6 @@ class Autocomplete<T = unknown> extends Component<AutocompleteSignature<T>> {
       this._inputValue = undefined;
     }
     this.activeDescendant = undefined;
-    this.activeItem = undefined;
 
     // Reset async results so reopening shows the default `@items` again.
     if (typeof this.args.onSearch === 'function') {
@@ -544,7 +538,6 @@ class Autocomplete<T = unknown> extends Component<AutocompleteSignature<T>> {
   };
 
   onActiveItemChange = (_key?: string, item?: ListItem) => {
-    this.activeItem = item;
     this.activeDescendant = item?.el.id || undefined;
   };
 

--- a/test-app/tests/integration/components/collections/command-test.gts
+++ b/test-app/tests/integration/components/collections/command-test.gts
@@ -206,7 +206,7 @@ module(
       // Down twice, crossing from one group into the next where relevant.
       await triggerKeyEvent(input, 'keydown', 'ArrowDown');
       await triggerKeyEvent(input, 'keydown', 'ArrowDown');
-      await triggerKeyEvent(input, 'keypress', 'Enter');
+      await triggerKeyEvent(input, 'keydown', 'Enter');
 
       assert.strictEqual(selected.length, 1, 'Enter selected exactly one item');
       assert.notStrictEqual(selected[0], undefined, 'and reported which one');

--- a/test-app/tests/integration/components/collections/dropdown-test.gts
+++ b/test-app/tests/integration/components/collections/dropdown-test.gts
@@ -570,7 +570,7 @@ module(
 
       await click('[data-test-id="dropdown-trigger"]');
       await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'ArrowDown');
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Enter');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Enter');
 
       assert.dom('[data-key="nested"]').exists('Enter opened the submenu');
     });
@@ -680,10 +680,10 @@ module(
       ) as HTMLElement;
 
       listbox.dispatchEvent(
-        new KeyboardEvent('keypress', { key: 'm', bubbles: true })
+        new KeyboardEvent('keydown', { key: 'm', bubbles: true })
       );
       listbox.dispatchEvent(
-        new KeyboardEvent('keypress', { key: 'Enter', bubbles: true })
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
       );
       await settled();
 

--- a/test-app/tests/integration/components/collections/listbox-test.gts
+++ b/test-app/tests/integration/components/collections/listbox-test.gts
@@ -9,6 +9,26 @@ import { array, get } from '@ember/helper';
 import { cell } from 'ember-resources';
 import { settled } from '@ember/test-helpers';
 
+/**
+ * Press a key the way a browser does.
+ *
+ * A browser dispatches `keydown` and only follows it with `keypress` when the
+ * keydown was not canceled. Tests that dispatch `keypress` directly therefore
+ * describe an event sequence that cannot happen when any handler calls
+ * `preventDefault()`, which is exactly the fragility this models.
+ */
+function pressKey(el: HTMLElement, key: string) {
+  const notCanceled = el.dispatchEvent(
+    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+  );
+
+  if (notCanceled) {
+    el.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+    );
+  }
+}
+
 module(
   'Integration | Component | Listbox | @frontile/collections',
   function (hooks) {
@@ -375,23 +395,23 @@ module(
       assert.dom('[data-key="elephant"]').hasAttribute('data-active', 'false');
 
       // select active item
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Enter');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Enter');
       assert.equal(selectedKeys.current.length, 1);
       assert.equal(selectedKeys.current[0], 'cheetah');
 
       // search
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'E');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'E');
       assert.dom('[data-key="cheetah"]').hasAttribute('data-active', 'false');
       assert.dom('[data-key="crocodile"]').hasAttribute('data-active', 'false');
       assert.dom('[data-key="elephant"]').hasAttribute('data-active', 'true');
 
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'C');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'C');
       assert.dom('[data-key="cheetah"]').hasAttribute('data-active', 'true');
       assert.dom('[data-key="crocodile"]').hasAttribute('data-active', 'false');
       assert.dom('[data-key="elephant"]').hasAttribute('data-active', 'false');
 
-      triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'C');
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'R');
+      triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'C');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'R');
 
       assert.dom('[data-key="cheetah"]').hasAttribute('data-active', 'false');
       assert
@@ -399,7 +419,7 @@ module(
         .hasAttribute(
           'data-active',
           'true',
-          'should have selected crocodile due to two keypress'
+          'should have selected crocodile due to two keydown'
         );
       assert.dom('[data-key="elephant"]').hasAttribute('data-active', 'false');
     });
@@ -438,13 +458,13 @@ module(
       ) as HTMLElement;
 
       listbox.dispatchEvent(
-        new KeyboardEvent('keypress', { key: 'c', bubbles: true })
+        new KeyboardEvent('keydown', { key: 'c', bubbles: true })
       );
       listbox.dispatchEvent(
-        new KeyboardEvent('keypress', { key: 'r', bubbles: true })
+        new KeyboardEvent('keydown', { key: 'r', bubbles: true })
       );
       listbox.dispatchEvent(
-        new KeyboardEvent('keypress', { key: 'Enter', bubbles: true })
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
       );
       await settled();
 
@@ -486,7 +506,7 @@ module(
 
       for (const key of ['b', 'i', 'g', ' ', 'd']) {
         listbox.dispatchEvent(
-          new KeyboardEvent('keypress', { key, bubbles: true })
+          new KeyboardEvent('keydown', { key, bubbles: true })
         );
       }
       await settled();
@@ -499,6 +519,273 @@ module(
           'Space extended the search buffer to "big d", matching Big Dog'
         );
       assert.dom('[data-key="big-cat"]').hasAttribute('data-active', 'false');
+    });
+
+    test('Enter still selects when another keydown handler calls preventDefault', async function (assert) {
+      // The whole justification for handling keys on `keydown` instead of the
+      // deprecated `keypress`. A browser only fires `keypress` when the
+      // preceding `keydown` was NOT canceled, so any co-located handler that
+      // calls `preventDefault()` on keydown -- Dropdown's submenu keys, a
+      // consuming app's own shortcut handler, Autocomplete's form-submission
+      // guard -- silently deletes the `keypress` event Listbox used to rely
+      // on, and Enter selection just stops working with no error.
+      //
+      // `pressKey` reproduces that browser behaviour faithfully rather than
+      // dispatching a `keypress` that a real browser would never have
+      // delivered. Dispatch stays synchronous and native: no `await` between
+      // keystrokes, so a pending type-ahead debounce cannot make this
+      // vacuously pass. See the regression test above for the full rationale.
+      const animals = ['cheetah', 'crocodile', 'elephant'];
+      const selected: string[] = [];
+      const onAction = (key: string) => selected.push(key);
+
+      // Stands in for any sibling keydown listener on the same <ul>, the way
+      // Dropdown's Menu attaches its submenu keys through `...attributes`.
+      const cancelKeydown = modifier((el: HTMLElement) => {
+        const handler = (event: KeyboardEvent) => event.preventDefault();
+        el.addEventListener('keydown', handler);
+        return () => el.removeEventListener('keydown', handler);
+      });
+
+      await render(
+        <template>
+          <Listbox
+            @isKeyboardEventsEnabled={{true}}
+            @selectionMode="none"
+            @items={{animals}}
+            @onAction={{onAction}}
+            {{cancelKeydown}}
+          />
+        </template>
+      );
+
+      const listbox = document.querySelector(
+        '[data-test-id="listbox"]'
+      ) as HTMLElement;
+
+      pressKey(listbox, 'Enter');
+      await settled();
+
+      assert.deepEqual(
+        selected,
+        ['cheetah'],
+        'Enter selected the active item even though keydown was canceled'
+      );
+    });
+
+    test('modifier-combo shortcuts do not leak into the type-ahead buffer', async function (assert) {
+      // `keypress` largely did not fire for modifier combinations; `keydown`
+      // does, and it reports a printable `key`: Cmd+K arrives as
+      // `key === 'k'`. A bare `key.length === 1` check would type that into
+      // the search buffer and steal the user's shortcut. Shift is exempt --
+      // a capital letter is legitimate type-ahead, asserted below.
+      const animals = ['cheetah', 'crocodile', 'elephant'];
+
+      await render(
+        <template>
+          <Listbox
+            @isKeyboardEventsEnabled={{true}}
+            @selectionMode="none"
+            @items={{animals}}
+          />
+        </template>
+      );
+
+      const listbox = document.querySelector(
+        '[data-test-id="listbox"]'
+      ) as HTMLElement;
+
+      for (const modifier of ['metaKey', 'ctrlKey', 'altKey']) {
+        listbox.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'e',
+            code: 'KeyE',
+            bubbles: true,
+            [modifier]: true
+          })
+        );
+      }
+      await settled();
+
+      assert
+        .dom('[data-key="elephant"]')
+        .hasAttribute(
+          'data-active',
+          'false',
+          'Cmd+E / Ctrl+E / Alt+E did not type-ahead to elephant'
+        );
+      assert
+        .dom('[data-key="cheetah"]')
+        .hasAttribute('data-active', 'true', 'the active item never moved');
+
+      // Shift must still reach type-ahead, or capital letters stop working.
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'E',
+          code: 'KeyE',
+          bubbles: true,
+          shiftKey: true
+        })
+      );
+      await settled();
+
+      assert
+        .dom('[data-key="elephant"]')
+        .hasAttribute(
+          'data-active',
+          'true',
+          'Shift+E is a legitimate type-ahead character'
+        );
+    });
+
+    test('modifier combos do not trigger Enter or Space selection', async function (assert) {
+      // The same leak as type-ahead, on the selection paths. `keypress`
+      // filtered modifier combos out for free; `keydown` delivers Cmd+Enter,
+      // Ctrl+Space and Cmd+Space (Spotlight) with an unchanged `key`, and
+      // acting on those both steals an OS/app shortcut and selects something
+      // the user never asked for.
+      const animals = ['cheetah', 'crocodile'];
+      const selected: string[] = [];
+      const onAction = (key: string) => selected.push(key);
+
+      await render(
+        <template>
+          <Listbox
+            @isKeyboardEventsEnabled={{true}}
+            @selectionMode="none"
+            @items={{animals}}
+            @onAction={{onAction}}
+          />
+        </template>
+      );
+
+      const listbox = document.querySelector(
+        '[data-test-id="listbox"]'
+      ) as HTMLElement;
+
+      for (const key of ['Enter', ' ']) {
+        for (const modifier of ['metaKey', 'ctrlKey', 'altKey']) {
+          listbox.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key,
+              bubbles: true,
+              [modifier]: true
+            })
+          );
+        }
+      }
+      await settled();
+
+      assert.deepEqual(selected, [], 'no modifier combo selected anything');
+
+      // Unmodified Enter still selects, so the guard is not simply inert.
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+      await settled();
+
+      assert.deepEqual(selected, ['cheetah'], 'plain Enter still selects');
+    });
+
+    test('autorepeat from a held key does not extend the search buffer', async function (assert) {
+      // A held key autorepeats under `keydown`, which `keypress` never
+      // exposed here. `search()` accumulates a prefix rather than cycling
+      // between same-initial items, so honouring repeats would turn a
+      // leaned-on 'a' into the buffer "aa" and jump the user elsewhere.
+      //
+      // The item labels make that jump observable: "a" matches Apple (first
+      // in DOM order) while "aa" matches Aardvark. Asserting only that Apple
+      // stays active would pass vacuously, because a buffer matching nothing
+      // leaves the active item exactly where it already was.
+      const items = ['Apple', 'Aardvark'];
+
+      await render(
+        <template>
+          <Listbox
+            @isKeyboardEventsEnabled={{true}}
+            @selectionMode="none"
+            @items={{items}}
+          />
+        </template>
+      );
+
+      const listbox = document.querySelector(
+        '[data-test-id="listbox"]'
+      ) as HTMLElement;
+
+      // Synchronous and native: an `await` here would let the 500ms
+      // type-ahead debounce clear the buffer between keystrokes and hide a
+      // regression. See the Enter-after-type-ahead test above.
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+      );
+      for (let i = 0; i < 2; i++) {
+        listbox.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'a',
+            bubbles: true,
+            repeat: true
+          })
+        );
+      }
+      await settled();
+
+      assert
+        .dom('[data-key="Apple"]')
+        .hasAttribute(
+          'data-active',
+          'true',
+          'the buffer stayed "a" and kept matching Apple'
+        );
+      assert
+        .dom('[data-key="Aardvark"]')
+        .hasAttribute(
+          'data-active',
+          'false',
+          'autorepeat did not extend the buffer to "aa"'
+        );
+    });
+
+    test('IME composition keystrokes are left to the input method', async function (assert) {
+      // A mid-composition `keydown` still reports a printable `key`, but the
+      // keystroke belongs to the IME, not to type-ahead. Same observable
+      // labels as the autorepeat test above, for the same reason.
+      const items = ['Apple', 'Aardvark'];
+
+      await render(
+        <template>
+          <Listbox
+            @isKeyboardEventsEnabled={{true}}
+            @selectionMode="none"
+            @items={{items}}
+          />
+        </template>
+      );
+
+      const listbox = document.querySelector(
+        '[data-test-id="listbox"]'
+      ) as HTMLElement;
+
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+      );
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'a',
+          bubbles: true,
+          isComposing: true
+        })
+      );
+      await settled();
+
+      assert
+        .dom('[data-key="Apple"]')
+        .hasAttribute(
+          'data-active',
+          'true',
+          'the composing keystroke did not extend the buffer to "aa"'
+        );
+      assert.dom('[data-key="Aardvark"]').hasAttribute('data-active', 'false');
     });
 
     test('Space selects the active item when no search is active', async function (assert) {
@@ -521,7 +808,7 @@ module(
 
       // `@autoActivateMode` defaults to "first", so item-1 is already active
       // without any navigation.
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', ' ');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', ' ');
 
       assert.deepEqual(
         onAction,
@@ -555,7 +842,7 @@ module(
         </template>
       );
 
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Z');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Z');
       assert
         .dom('[data-key="item-1"]')
         .hasAttribute(
@@ -564,7 +851,7 @@ module(
           'should have matched the external label text'
         );
 
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Y');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Y');
       assert
         .dom('[data-key="item-2"]')
         .hasAttribute(
@@ -593,10 +880,10 @@ module(
 
       // A search that matches nothing leaves the previously active item
       // active, so match the other item first to make this discriminating.
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Y');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Y');
       assert.dom('[data-key="item-2"]').hasAttribute('data-active', 'true');
 
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Z');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Z');
       assert
         .dom('[data-key="item-1"]')
         .hasAttribute('data-active', 'true', 'should have used its own text');
@@ -626,12 +913,12 @@ module(
         </template>
       );
 
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Z');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Z');
       assert
         .dom('[data-key="item-1"]')
         .hasAttribute('data-active', 'true', 'should have used @textValue');
 
-      await triggerKeyEvent('[data-test-id="listbox"]', 'keypress', 'Y');
+      await triggerKeyEvent('[data-test-id="listbox"]', 'keydown', 'Y');
       assert
         .dom('[data-key="item-2"]')
         .hasAttribute(
@@ -872,7 +1159,7 @@ module(
       assert.dom('[data-key="cheetah"]').hasAttribute('data-active', 'false');
       await triggerKeyEvent('[data-test-input]', 'keydown', 'ArrowDown');
       assert.dom('[data-key="cheetah"]').hasAttribute('data-active', 'true');
-      await triggerKeyEvent('[data-test-input]', 'keypress', 'E');
+      await triggerKeyEvent('[data-test-input]', 'keydown', 'E');
       assert.dom('[data-key="cheetah"]').hasAttribute('data-active', 'true');
       await fillIn('[data-test-input]', 'e');
       assert.dom('[data-key="cheetah"]').hasAttribute('data-active', 'true');

--- a/test-app/tests/integration/components/forms/autocomplete-test.gts
+++ b/test-app/tests/integration/components/forms/autocomplete-test.gts
@@ -693,6 +693,29 @@ module(
       assert.dom('[data-test-id="trigger"]').hasValue('Apple');
     });
 
+    test('Enter selects the active item exactly once', async function (assert) {
+      // Autocomplete used to select by clicking the active item's element,
+      // because its own `preventDefault()` on keydown (the form-submission
+      // guard above) suppressed the `keypress` event Listbox listened to.
+      // Listbox now handles Enter on keydown itself, so the click was a
+      // second, redundant selection path -- this pins the count so neither
+      // path can be reintroduced alongside the other.
+      const items = ['Apple', 'Banana'];
+      const actions: string[] = [];
+      const onAction = (key: string) => actions.push(key);
+
+      await render(
+        <template>
+          <Autocomplete @items={{items}} @onAction={{onAction}} />
+        </template>
+      );
+
+      await fillIn('[data-test-id="trigger"]', 'App');
+      await triggerKeyEvent('[data-test-id="trigger"]', 'keydown', 'Enter');
+
+      assert.deepEqual(actions, ['Apple'], 'onAction fired once, not twice');
+    });
+
     test('it renders named blocks startContent and endContent', async function (assert) {
       const items = ['Apple'];
       const classes = { innerContainer: 'input-container' };

--- a/test-app/tests/integration/components/forms/select-test.gts
+++ b/test-app/tests/integration/components/forms/select-test.gts
@@ -355,7 +355,7 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
       .hasAttribute('data-active', 'false');
 
     await triggerKeyEvent('[data-component="listbox"]', 'keydown', 'ArrowDown');
-    await triggerKeyEvent('[data-component="listbox"]', 'keypress', 'Enter');
+    await triggerKeyEvent('[data-component="listbox"]', 'keydown', 'Enter');
     assert.dom('[data-component="listbox"]').doesNotExist();
 
     assert.equal(selectedKey.current, 'item-2');
@@ -2134,7 +2134,7 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
   });
 
   /**
-   * Bug B. Driven through a real keypress on the trigger — the event the
+   * Bug B. Driven through a real keydown on the trigger — the event the
    * Listbox actually listens to for Enter — rather than by calling internals.
    */
   test('Filterable multiple mode: Enter on a filtered option adds to the selection', async function (assert) {
@@ -2165,7 +2165,7 @@ module('Integration | Component | Select | @frontile/forms', function (hooks) {
 
     await triggerKeyEvent(
       '[data-component="select-trigger"]',
-      'keypress',
+      'keydown',
       'Enter'
     );
 


### PR DESCRIPTION
Stacked on #558 — please merge that first.

`Listbox` handled Enter/Space selection and A-Z type-ahead in a `keypress` listener while arrow navigation was already on `keydown`. A browser fires `keypress` only when the preceding `keydown` was **not** canceled, so any co-located keydown handler calling `preventDefault()` silently deleted the event `Listbox` depended on — Enter selection just stopped working, with no error. `keypress` is also absent from current spec guidance.

The first commit's failing test pins exactly that: a sibling keydown handler calls `preventDefault()` and Enter selection dies. It models real browser semantics (`keypress` only follows an uncanceled `keydown`) rather than dispatching a `keypress` a browser would never have delivered.

## What changed

Both listener paths moved — the template modifier and the `setupEvents` listeners on `@elementToAddKeyboardEvents`. No `keypress` listener remains.

`keydown` delivers what `keypress` filtered out for free, so two guards **restore** the old filtering rather than widening behaviour:

- **Command modifiers** (meta/ctrl/alt) are not ours to handle. `Cmd+K` arrives as `key === 'k'` and `Cmd+Space` as `key === ' '`, so without this they would type into the search buffer *or select an option*. Shift stays allowed — a capital letter is legitimate type-ahead — the same check `Popover`'s open-on-letter handler makes. Arrow/Home/End navigation is exempt, having always been on `keydown`.
- **Autorepeat and IME composition** no longer feed type-ahead. `search()` accumulates a prefix rather than cycling, so a leaned-on `a` would build `"aaaa"` and match nothing.

Space now also `preventDefault()`s on the type-ahead path, stopping page scroll — the old `keypress` listener fired too late to do that.

Enter-always-selects and Space-extends-an-active-search are unchanged, and `Dropdown`'s submenu ArrowRight/ArrowLeft coexistence is preserved (ArrowLeft/Right stay unhandled here).

## Autocomplete workaround removed

It selected by clicking the active item's element *precisely because* its own `preventDefault()` suppressed the `keypress`. That is now a redundant second selection path — verified: `onAction` fired **twice** for one Enter (`Apple,Apple`). The click goes, and the write-only `activeItem` field with it. The `ListItem` parameter on `onActiveItemChange` stays — `aria-activedescendant` still needs it. The form-submission guard is kept.

## Verification

- Full suite **1477 tests, 0 failures** (baseline 1471 + 6 new).
- Five consumer suites green: Listbox 52, Dropdown 33, Autocomplete 37, Command 27, Select 226.
- Every new test proven to have teeth by unwiring the behaviour. One first draft of the autorepeat test passed against broken code — a buffer matching nothing leaves the active item where it was — so it was rebuilt around `Apple`/`Aardvark`, where `"a"` and `"aa"` match different items.
- Per-file eslint clean; `pnpm --filter frontile lint:types` clean; `cd site && pnpm build` → 82 rendered, 0 failed.

## One deviation from the brief

The two regression tests could not stay literally unmodified: they drove selection by dispatching a synthetic `keypress`, which by definition has no listener after this migration. Their **assertions and behaviour are untouched** — only the dispatched event name changed. Same for the equivalent `triggerKeyEvent` calls in the Dropdown/Select/Command suites.

No docs change: the docs don't document the event mechanism, and no public argument changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)