### PR TITLE
fix(lint): stop `lint:hbs --fix` from stripping aria attributes

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -3,7 +3,28 @@
 module.exports = {
   extends: ['recommended'],
   rules: {
-    quotes: 'double',
+    // Only the html half. Every template in this repo lives in a .gts/.gjs
+    // template tag (there are no .hbs files), so prettier, via
+    // prettier-plugin-ember-template-tag, already formats all of them: it
+    // quotes HTML attributes with double quotes and string literals inside
+    // mustaches with single quotes. Plain `quotes: 'double'` also demands
+    // double quotes inside mustaches, which prettier/prettier then reports as
+    // an error and rewrites back, so `pnpm lint:hbs --fix` and
+    // `pnpm lint:js --fix` would rewrite the same files forever.
+    //
+    // The curlies half is not merely noisy, it is lossy: to change a quote the
+    // fixer reprints the surrounding attribute through ember-template-recast,
+    // which drops whitespace-only text nodes between mustaches. That silently
+    // turned `aria-describedby="{{a}} {{b}}"` into `"{{a}}{{b}}"` in
+    // forms-legacy/src/components/form-select.gts, joining id lists and class
+    // lists into single run-together tokens.
+    //
+    // Note that the `templateSingleQuote: false` override in .prettierrc.js
+    // does not currently take effect (its `*.{js,ts,gjs,gts}` glob has no
+    // `**/` and so matches nothing), and it would not help if it did: it
+    // flips both halves, giving single-quoted HTML attributes and
+    // double-quoted mustache literals.
+    quotes: { curlies: false, html: 'double' },
     'eol-last': false,
     'no-builtin-form-components': false,
     'no-unknown-arguments-for-builtin-components': false,

--- a/packages/frontile/src/components/forms/input-otp.gts
+++ b/packages/frontile/src/components/forms/input-otp.gts
@@ -605,6 +605,17 @@ class InputOtp extends Component<InputOtpSignature> {
           </div>
         {{/each}}
 
+        {{! False positive in no-unsupported-role-attributes
+            (ember-template-lint 7.9.3). Its getImplicitRole helper matches an
+            aria-query key on the type attribute alone and ignores that key's
+            other constraints, so a plain text input resolves to the
+            list-bearing combobox entry instead of textbox. This input has no
+            list attribute, so textbox is its real implicit role, and textbox
+            does support aria-placeholder. The rule is disabled for this
+            element only, so its autofixer cannot silently delete
+            aria-placeholder when someone runs pnpm lint:hbs --fix. See the
+            @placeholder test in input-otp-test.gts. }}
+        {{! template-lint-disable no-unsupported-role-attributes }}
         <input
           {{this.inputRef.setup}}
           {{this.syncFromValueArg @value}}
@@ -630,6 +641,7 @@ class InputOtp extends Component<InputOtpSignature> {
           spellcheck="false"
           ...attributes
         />
+        {{! template-lint-enable no-unsupported-role-attributes }}
       </div>
     </FormControl>
   </template>

--- a/packages/frontile/src/components/forms/radio.gts
+++ b/packages/frontile/src/components/forms/radio.gts
@@ -93,6 +93,17 @@ class Radio<T extends string | boolean | number> extends Component<
       @preventErrorFeedback={{true}}
       as |c|
     >
+      {{! Under ARIA 1.2 aria-invalid is not in role=radio's supported
+          property set: invalidity for a radio group formally belongs on a
+          role="radiogroup" ancestor, which FormControl does not currently
+          render (see RadioGroup). We keep it on the input anyway, because
+          Radio is a public component that is usable standalone, browsers and
+          screen readers do expose aria-invalid on a radio input, and
+          radio-test.gts asserts it. The rule is disabled for this element
+          only, so its autofixer cannot silently delete the attribute when
+          someone runs pnpm lint:hbs --fix. Revisit if RadioGroup grows a real
+          role="radiogroup" wrapper. }}
+      {{! template-lint-disable no-unsupported-role-attributes }}
       <input
         {{on "change" this.handleChange}}
         {{on "blur" this.handleBlur}}
@@ -108,9 +119,10 @@ class Radio<T extends string | boolean | number> extends Component<
         aria-describedby={{c.describedBy @description c.isInvalid}}
         ...attributes
       />
+      {{! template-lint-enable no-unsupported-role-attributes }}
       <div class={{this.classes.labelContainer class=@classes.labelContainer}}>
         {{#if @label}}
-          <c.Label @class={{(this.classes.label class=@classes.label)}}>
+          <c.Label @class={{this.classes.label class=@classes.label}}>
             {{@label}}
           </c.Label>
         {{/if}}

--- a/test-app/tests/integration/components/forms/from-test.gts
+++ b/test-app/tests/integration/components/forms/from-test.gts
@@ -1823,7 +1823,7 @@ module('Integration | Component | @frontile/forms/Form', function (hooks) {
       <template>
         <Form
           @schema={{schema}}
-          @validateOn={{(array "submit")}}
+          @validateOn={{array "submit"}}
           @onSubmit={{onSubmitSpy}}
           as |form|
         >

--- a/test-app/tests/integration/components/forms/native-select-test.gts
+++ b/test-app/tests/integration/components/forms/native-select-test.gts
@@ -44,7 +44,7 @@ module(
           <NativeSelect
             @onSelectionChange={{onSelectionChange}}
             @selectedKey={{selectedKey.current}}
-            @disabledKeys={{(array "item-3" "item-4")}}
+            @disabledKeys={{array "item-3" "item-4"}}
             @allowEmpty={{true}}
             as |l|
           >

--- a/test-app/tests/integration/components/status/progress-bar-test.gts
+++ b/test-app/tests/integration/components/status/progress-bar-test.gts
@@ -431,7 +431,7 @@ module(
               data-test-id="progress-bar"
               @progress={{50}}
               @label="Progress"
-              @formatOptions={{(hash style="currency" currency="USD")}}
+              @formatOptions={{hash style="currency" currency="USD"}}
             />
           </template>
         );
@@ -449,7 +449,7 @@ module(
               @label="Progress"
               @minValue={{10}}
               @maxValue={{30}}
-              @formatOptions={{(hash style="currency" currency="USD")}}
+              @formatOptions={{hash style="currency" currency="USD"}}
             />
           </template>
         );
@@ -467,7 +467,7 @@ module(
               data-test-id="progress-bar"
               @progress={{50}}
               @label="Progress"
-              @formatOptions={{(hash style="percent")}}
+              @formatOptions={{hash style="percent"}}
             />
           </template>
         );
@@ -485,7 +485,7 @@ module(
               @label="Progress"
               @minValue={{10}}
               @maxValue={{30}}
-              @formatOptions={{(hash style="percent")}}
+              @formatOptions={{hash style="percent"}}
             />
           </template>
         );

--- a/test-app/tests/integration/components/utilities/roving-focus-test.gts
+++ b/test-app/tests/integration/components/utilities/roving-focus-test.gts
@@ -27,6 +27,7 @@ module(
           <div>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >A</button>
@@ -72,6 +73,7 @@ module(
           <div>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >A</button>
@@ -107,6 +109,7 @@ module(
             <button type="button" disabled {{roving.setupItem}}>A</button>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >B</button>
@@ -142,6 +145,7 @@ module(
           <div>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >A</button>
@@ -171,6 +175,7 @@ module(
             <button type="button" {{roving.setupItem}}>A</button>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >B</button>
@@ -220,6 +225,7 @@ module(
           <div>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >A</button>
@@ -253,6 +259,7 @@ module(
             <div>
               <button
                 type="button"
+                role="radio"
                 aria-checked="true"
                 {{horizontal.setupItem}}
               >A</button>
@@ -262,6 +269,7 @@ module(
             <div>
               <button
                 type="button"
+                role="radio"
                 aria-checked="true"
                 {{vertical.setupItem}}
               >D</button>
@@ -363,6 +371,7 @@ module(
           <div>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >A</button>
@@ -409,6 +418,7 @@ module(
           <div>
             <button
               type="button"
+              role="radio"
               aria-checked="true"
               {{roving.setupItem}}
             >A</button>


### PR DESCRIPTION
## The problem

Running the pre-commit checklist from `CLAUDE.md` on a clean `main` rewrote **12 files nobody had touched**, and three of those edits **deleted accessibility attributes**. Every agent working the drawer-restyle branch had to `git checkout` the collateral before committing.

`pnpm lint:js --fix` turns out to be innocent — it changes nothing. All of it came from `pnpm lint:hbs --fix` (`ember-template-lint` 7.9.3), via two independent defects.

## Defect 1 — `no-unsupported-role-attributes` deletes attributes

The rule is in `recommended`, is auto-fixable, and its fix is literally `node.attributes.filter(...)`. It fired in three places for three different reasons:

| File | Attribute | Verdict |
|---|---|---|
| `forms/input-otp.gts` | `aria-placeholder` | **False positive** |
| `forms/radio.gts` | `aria-invalid` | Technically right, deliberately wrong |
| `utilities/roving-focus-test.gts` | `aria-checked` ×10 | **True positive** |

**The false positive is an upstream bug.** `getImplicitRole` matches an `aria-query` key on the `type` attribute alone and ignores the key's other constraints. `aria-query` has two keys for `input[type=text]` — one gated on `list` being *set* (→ `combobox`), one on `list` being *undefined* (→ `textbox`) — and the rule returns whichever comes first. So **every plain `<input type="text">` in the repo resolves as `combobox`**, which doesn't support `aria-placeholder`. `textbox`, its real role, does.

**`radio.gts` is a judgement call.** The role resolves correctly, and ARIA 1.2 genuinely puts invalidity on a `role="radiogroup"` ancestor rather than on the radio itself. But `Radio` is public and usable standalone, `FormControl` renders no radiogroup, browsers and screen readers do expose the attribute, and `radio-test.gts` asserts it. Keeping it.

**`roving-focus-test.gts` is a real finding**, and it's fixed rather than suppressed: the ten buttons get `role="radio"`, which *does* support `aria-checked`. The rule goes quiet with no disable, and the tests still exercise `roving-focus.ts`'s `[aria-checked="true"]` selector instead of going vacuous.

The other two get element-scoped `template-lint-disable`/`enable` pairs with the reasoning inline — narrow enough that the rule still guards the rest of both files.

## Defect 2 — the `quotes` fixer silently eats whitespace

Separate, and worse. Changing a quote makes `ember-template-recast` reprint the whole attribute, and it drops whitespace-only text nodes between mustaches:

```
- @triggerClass="{{@triggerClass}} {{if @size (concat 'ember-power-select-trigger-' @size)}} {{this.classes.select}}"
+ @triggerClass="{{@triggerClass}}{{if @size (concat "ember-power-select-trigger-" @size)}}{{this.classes.select}}"
```

Three class fragments become one token. The same thing happened to `aria-describedby` and `aria-labelledby` id lists in `forms-legacy/form-select.gts`.

The rule is also redundant. There are **zero `.hbs` files** — all 261 templates are `.gts`/`.gjs`, every one formatted by prettier via `prettier-plugin-ember-template-tag`, which quotes HTML attributes double and mustache literals single. `quotes: 'double'` demanded double in *both*, so `prettier/prettier` rewrote the literals straight back.

**That 2-cycle is why this was hard to pin down.** Checksumming the tree *after running both* commands showed zero drift, while each command on its own dirtied five files.

Narrowed to `{ curlies: false, html: 'double' }` — the `html` half agrees with prettier and stays on; only the conflicting, lossy `curlies` half is off. With that in place `forms-legacy/form-select.gts` and the `site/` components need **no change at all**.

I also checked the `templateSingleQuote: false` override in `.prettierrc.js`: its glob has no `**/` so it matches nothing, and enabling it would make things worse — it flips *both* halves, giving single-quoted HTML attributes. Left alone and documented.

## Also included

The seven genuinely-correct pending autofixes (redundant parens in `radio.gts` and three test files), so no backlog is left to land on the next person.

## Verification

- `lint:hbs --fix` **and** `lint:js --fix` each checked **independently** with per-file checksums across all 773 tracked files: zero changes, twice through.
- Fixable violations 33 → **0**. Unfixable stays 57, identical to `main`.
- `pnpm build` exit 0; `pnpm --filter frontile lint:types` and `@frontile/forms-legacy lint:types` clean.
- `CI=true pnpm ember test` — **1458 tests, 1455 pass, 3 skip, 0 fail.**
- `test-app lint:types` still fails on a pre-existing `resolveRegistration` error in `notifications-test.ts`, untouched here.

## Follow-ups (deliberately not in scope)

- The dead `templateSingleQuote` override in `.prettierrc.js`.
- Moving `aria-invalid` onto a real `role="radiogroup"` wrapper in `RadioGroup` — the properly correct ARIA fix, with its own tests.
- Worth reporting both upstream bugs to `ember-template-lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)