### PR TITLE
fix(theme): clip Alert's tonal tint to its rounded corners

### DIFF
--- a/packages/frontile/src/components/status/alert.md
+++ b/packages/frontile/src/components/status/alert.md
@@ -65,49 +65,63 @@ import { Alert } from 'frontile';
 
 ## Variants
 
+`@variant` decides how much of the alert the intent colors, from a neutral
+surface with a colored icon and title through to a fully filled one. Set it
+alongside `@intent` — the three below are shown across all five intents.
+
+### Default
+
+A neutral surface; the intent shows in the icon and title only. Quiet enough to
+sit in a page without competing with the content around it.
+
 ```gts preview
 import { Alert } from 'frontile';
 
 <template>
   <div class='demo-stack'>
-    <Alert
-      @variant='default'
-      @intent='info'
-      @title='Default'
-      @description='The outer surface carries the color.'
-    />
-    <Alert
-      @variant='default'
-      @intent='danger'
-      @title='Default'
-      @description='The outer surface carries the color.'
-    />
+    <Alert @intent='default' @title='Default' />
+    <Alert @intent='info' @title='Info' />
+    <Alert @intent='success' @title='Success' />
+    <Alert @intent='warning' @title='Warning' />
+    <Alert @intent='danger' @title='Danger' />
+  </div>
+</template>
+```
 
-    <Alert
-      @variant='tonal'
-      @intent='info'
-      @title='Tonal'
-      @description='A translucent tint fills the alert.'
-    />
-    <Alert
-      @variant='tonal'
-      @intent='danger'
-      @title='Tonal'
-      @description='A translucent tint fills the alert.'
-    />
+### Tonal
 
-    <Alert
-      @variant='solid'
-      @intent='info'
-      @title='Solid'
-      @description='A fully filled surface.'
-    />
-    <Alert
-      @variant='solid'
-      @intent='danger'
-      @title='Solid'
-      @description='A fully filled surface.'
-    />
+A translucent tint of the intent fills the alert, over an opaque surface. More
+presence than `default` without the weight of `solid`.
+
+```gts preview
+import { Alert } from 'frontile';
+
+<template>
+  <div class='demo-stack'>
+    <Alert @variant='tonal' @intent='default' @title='Default' />
+    <Alert @variant='tonal' @intent='info' @title='Info' />
+    <Alert @variant='tonal' @intent='success' @title='Success' />
+    <Alert @variant='tonal' @intent='warning' @title='Warning' />
+    <Alert @variant='tonal' @intent='danger' @title='Danger' />
+  </div>
+</template>
+```
+
+### Solid
+
+The intent fills the surface, with contrast ink on top. The loudest of the
+three — worth reserving for something the reader should not miss.
+
+```gts preview
+import { Alert } from 'frontile';
+
+<template>
+  <div class='demo-stack'>
+    <Alert @variant='solid' @intent='default' @title='Default' />
+    <Alert @variant='solid' @intent='info' @title='Info' />
+    <Alert @variant='solid' @intent='success' @title='Success' />
+    <Alert @variant='solid' @intent='warning' @title='Warning' />
+    <Alert @variant='solid' @intent='danger' @title='Danger' />
   </div>
 </template>
 ```

--- a/packages/theme/src/components/alert.ts
+++ b/packages/theme/src/components/alert.ts
@@ -21,11 +21,16 @@ const alert = tv({
   slots: {
     // The outer element: box treatment only (surface, border, radius).
     // No shadow and a tighter radius than `notificationCard` — an Alert
-    // sits in the page rather than floating over it. No transition
-    // machinery, no `stackPlacement`, no `overflow-hidden`: those exist on
-    // the card to serve the notification stack's geometry, which Alert has
-    // no part in.
-    base: 'w-full rounded-lg border',
+    // sits in the page rather than floating over it, and no transition
+    // machinery or `stackPlacement`, which exist on the card only to serve
+    // the notification stack's geometry.
+    //
+    // `overflow-hidden` is not optional: this element owns the radius, but
+    // the `tonal` variant paints its tint on `inner` (it needs an opaque
+    // surface underneath — see that slot). `inner` has square corners, so
+    // without clipping here its tint paints over all four rounded corners
+    // and the alert reads as a rectangle.
+    base: 'w-full rounded-lg border overflow-hidden',
     // The inner element carries the row layout. Alert has no
     // ResizeObserver, so unlike the card it does not need this split for
     // measurement — it needs it because the `tonal` variant's translucent

--- a/test-app/tests/integration/components/status/alert-test.gts
+++ b/test-app/tests/integration/components/status/alert-test.gts
@@ -293,6 +293,23 @@ module('Integration | Component | Alert | @frontile/status', function (hooks) {
         `expected the shipped icon slot to clamp yielded content with [&>*]:size-full, got: ${classes}`
       );
     });
+
+    test('the real base recipe clips the tonal tint to its rounded corners', function (assert) {
+      // `base` owns the radius, but `tonal` paints its tint on `inner`,
+      // which has square corners. Without `overflow-hidden` on `base` that
+      // tint paints over all four corners and a tonal Alert renders as a
+      // rectangle with a rounded border drawn through it. That regressed
+      // once already, and it is invisible to every other test here: they
+      // render against the placeholder recipe, so only the shipped string
+      // can be checked. Asserted against `shippedAlert` for the same reason
+      // the icon-clamp test above is.
+      const classes = shippedAlert().base();
+
+      assert.true(
+        classes.includes('overflow-hidden'),
+        `expected the shipped base slot to clip the tonal tint with overflow-hidden, got: ${classes}`
+      );
+    });
   });
 
   module('actions and closing', function () {


### PR DESCRIPTION
Follow-up to #555, which is already merged.

## The bug

`base` owns the radius, but the `tonal` variant paints its tint on `inner` — it needs an opaque surface underneath, which is the whole reason for the two-element structure. `inner` has square corners, so with nothing clipping it the tint painted straight over all four rounded corners: a tonal Alert read as a rectangle with a rounded border drawn through it.

`overflow-hidden` on `base` fixes it, which is exactly what `notificationCard` already does. #555's spec explicitly dropped it, reasoning it only existed to serve the notification stack's height clamp — that was wrong; it is also what keeps a rounded card's inner fill inside its corners.

Verified by hit-testing the corners in the browser (hit-testing respects both `border-radius` and overflow clipping): with the fix, a point 2px inside each bounding-box corner lands on the base or the page, never on the tint, while the centre and top-edge midpoint still land on the tint. Toggling `overflow: visible` on the live element flips the corners back to hitting the tint, so the probe discriminates rather than passing vacuously.

The close button's focus ring needs ~5px beyond its own box; it has 13px of headroom to the base edge and 17px vertically, so clipping does not eat it.

## Docs

The Variants section only showed `info` and `danger`, which left `tonal` and `solid` unillustrated for three of the five intents — including the `warning` and `success` inks that are the most contrast-sensitive. It now shows all five intents for each of the three variants, split into `### Default` / `### Tonal` / `### Solid` so each swatch stays scannable.

## Guard

`overflow-hidden` is a bare class in a theme string, easy to drop while tidying, and invisible to every existing test — they render against a placeholder recipe registered by the test file, so only the shipped recipe can be checked. Added a shipped-recipe assertion alongside the existing icon-clamp one. Confirmed it has teeth: removing the class turns it red, restoring it turns it green.

## Verification

- Full suite 1459 total, 1456 passing, 3 skipped, 0 failing, on top of current `main`.
- Type checks clean for `@frontile/theme` and `frontile`; `lint:js` 0 errors.
- Contrast re-measured on clean light and dark page loads over the real ancestor stack, now covering all 26 alerts on the page: 59 samples per theme, zero WCAG failures (light min 4.71:1, dark min 6.09:1; icons judged against the 3:1 non-text floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
