### PR TITLE
docs(press): document no click listener and Enter/Space propagation

### DIFF
--- a/packages/frontile/src/modifiers/press.md
+++ b/packages/frontile/src/modifiers/press.md
@@ -19,6 +19,18 @@ import { press } from 'frontile';
 - **Optimized** - Only adds event listeners for callbacks you provide
 - **Flexible** - Supports both positional and named arguments
 
+`press` listens on `pointerdown`/`mousedown`, `pointerup`/`mouseup`, `pointercancel`,
+`keydown`, and `keyup`. It registers no `click` listener, so a native `element.click()` never
+triggers `onPress`.
+
+> **Note:** In tests, an assertion that `onPress` did not fire after `element.click()` passes
+> against a broken implementation just as well as a working one. To check that a disabled
+> control suppresses `onPress`, use the `click` helper from `@ember/test-helpers`, which
+> refuses a disabled form control the way a browser does — `await assert.rejects(click(el),
+> /disabled/)` — and then assert the press count. Driving `pointerdown`/`pointerup` through
+> `triggerEvent` reports the opposite: `dispatchEvent` reaches listeners whatever the
+> element's `disabled` state, so a correct implementation still fires.
+
 ## Example
 
 ```gts preview
@@ -113,10 +125,18 @@ Press events are normalized across different input methods and provide consisten
 - **Performance**: Only adds the event listeners your callbacks require - a
   single callback can need more than one (e.g. `onPressChange` also needs
   `pointercancel`)
-- **Accessibility**: Automatically handles Enter and Space key interactions
+- **Accessibility**: Automatically handles Enter and Space key interactions. On a
+  `<button type="button">` press also calls `preventDefault()`, which suppresses the
+  browser's native activation click, so the element fires a single press per keypress
 - **Cross-platform**: Supports mouse, touch, and keyboard across all browsers
 - **Propagation**: By default a press stops propagation of the underlying
   event to parent elements. Call `continuePropagation()` on the `PressEvent` in
   any handler to let it through. Only events on the pressed element itself are
   stopped - a release that happens outside of the element is left untouched, so
   other listeners on the page (including document-level ones) still receive it.
+
+> **Note:** `preventDefault()` on the keyboard event does not stop it propagating. An
+> ancestor `keydown` handler that also treats Enter or Space as activation will act on the
+> same keypress a second time — a calendar grid handling Enter to select the focused day
+> selects twice once its day cells use `press`. Container-level key handlers above a
+> press-bearing element should check `event.defaultPrevented` before acting.


### PR DESCRIPTION
Docs-only change to `packages/frontile/src/modifiers/press.md`. No behavior change to `press.ts`.

Adds two behaviors that were previously only discoverable by reading the source:

1. **`press` registers no `click` listener.** It listens on `pointerdown`/`mousedown`, `pointerup`/`mouseup`, `pointercancel`, `keydown`, and `keyup` only, so a native `element.click()` can never fire `onPress`. The note spells out the test trap this creates: a "does not fire when X" test built on `element.click()` passes identically against a broken implementation. The faithful shape is `assert.rejects(click(el), /disabled/)` plus a press-count check, since `triggerEvent`'s `dispatchEvent` ignores `disabled`.
2. **`press` consumes Enter/Space and marks them handled.** It calls `preventDefault()` (suppressing the native activation click on a `<button type="button">`), but does not stop propagation — so an ancestor `keydown` handler treating Enter/Space as activation acts on the same keypress twice. Container-level key handlers should check `event.defaultPrevented`.

## Verification

- `node .claude/skills/frontile-docs/scripts/lint-docs.mjs` — 0 errors, 15 warnings, all pre-existing in other files; none in `press.md`.
- Prose-only: fence count in `press.md` is unchanged (4 → 4) and no demo was touched, so the site build was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)