### PR TITLE
docs(site): register recently merged components in the inventory

### DIFF
--- a/packages/frontile/src/components/utilities/index.ts
+++ b/packages/frontile/src/components/utilities/index.ts
@@ -13,3 +13,4 @@ export * from '../../utils/toggle';
 export * from '../../utils/selection-indicator';
 export * from '../../utils/roving-focus';
 export * from '../../modifiers/press';
+export * from '../../modifiers/drag-to-dismiss';

--- a/packages/frontile/src/modifiers/drag-to-dismiss.md
+++ b/packages/frontile/src/modifiers/drag-to-dismiss.md
@@ -1,4 +1,5 @@
 ---
+label: New
 ---
 
 # dragToDismiss

--- a/packages/frontile/src/modifiers/drag-to-dismiss.md
+++ b/packages/frontile/src/modifiers/drag-to-dismiss.md
@@ -16,7 +16,7 @@ draggable-to-dismiss surface.
 ## Import
 
 ```js
-import { dragToDismiss } from 'frontile/modifiers/drag-to-dismiss';
+import { dragToDismiss } from 'frontile';
 ```
 
 ## Example
@@ -25,7 +25,7 @@ import { dragToDismiss } from 'frontile/modifiers/drag-to-dismiss';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
-import { dragToDismiss } from 'frontile/modifiers/drag-to-dismiss';
+import { dragToDismiss } from 'frontile';
 
 export default class DragToDismissExample extends Component {
   @tracked isOpen = true;

--- a/site/app/components/component-inventory.ts
+++ b/site/app/components/component-inventory.ts
@@ -157,6 +157,12 @@ export const inventory: InventoryCategory[] = [
           'A modifier that normalizes press interactions across mouse, touch, keyboard, and screen readers.',
       },
       {
+        name: 'dragToDismiss',
+        path: '/docs/components/utilities/drag-to-dismiss',
+        description:
+          'A modifier that turns pointer drags into a dismiss gesture along a single axis.',
+      },
+      {
         name: 'Ref',
         path: '/docs/components/utilities/ref',
         description:

--- a/site/app/components/component-inventory.ts
+++ b/site/app/components/component-inventory.ts
@@ -145,6 +145,12 @@ export const inventory: InventoryCategory[] = [
           'A lightweight helper for tracking boolean state with a toggle() method.',
       },
       {
+        name: 'Kbd',
+        path: '/docs/components/utilities/kbd',
+        description:
+          'Renders keyboard keys and shortcuts, correct on every platform.',
+      },
+      {
         name: 'Press',
         path: '/docs/components/utilities/press',
         description:
@@ -249,6 +255,12 @@ export const inventory: InventoryCategory[] = [
         description:
           'Renders content into a different part of the DOM tree, escaping clipped or stacked parents.',
       },
+      {
+        name: 'Tooltip',
+        path: '/docs/components/overlays/tooltip',
+        description:
+          'A short, non-interactive hint shown next to whatever a user hovers or focuses.',
+      },
     ],
   },
   {
@@ -279,12 +291,30 @@ export const inventory: InventoryCategory[] = [
         description:
           'Combines a trigger button with a floating panel of actions or options.',
       },
+      {
+        name: 'Calendar',
+        path: '/docs/components/collections/calendar',
+        description:
+          'A month-grid date picker for choosing a single day or a range, with full keyboard navigation.',
+      },
+      {
+        name: 'Command',
+        path: '/docs/components/collections/command',
+        description:
+          'A command palette: a search field over a ranked, optionally grouped list of commands.',
+      },
     ],
   },
   {
     name: 'Feedback',
     summary: 'Progress and notifications, with the live regions wired up.',
     items: [
+      {
+        name: 'Alert',
+        path: '/docs/components/status/alert',
+        description:
+          'Displays an important message inline in the page until removed.',
+      },
       {
         name: 'ProgressBar',
         path: '/docs/components/status/progress-bar',


### PR DESCRIPTION
## Summary
- Add Calendar, Command, Tooltip, Alert, and Kbd to the homepage/overview component inventory — all shipped in recent merged PRs but were missing from `site/app/components/component-inventory.ts`.
- Flag the `dragToDismiss` modifier doc with `label: New`, matching its recently-added siblings (Calendar, Command, Tooltip, Alert, Kbd all already had it).
- Reviewed all other recently-added docs pages (Pagination, NativeSelect, Autocomplete, InputOtp, FormControl, SegmentedControl, Accordion) — no other `label: New` gaps found.

## Test plan
- [x] `pnpm --filter frontile lint:types`
- [x] `cd site && pnpm build` and spot-check `/docs/components/overview` renders the new entries correctly