### PR TITLE
Animate overlays that render already open, after first paint

### DIFF
--- a/packages/frontile/src/components/overlays/drawer.gts
+++ b/packages/frontile/src/components/overlays/drawer.gts
@@ -40,6 +40,7 @@ export interface DrawerArgs extends Pick<
   | 'transitionDuration'
   | 'backdrop'
   | 'disableTransitions'
+  | 'animateOnMount'
   | 'disableFocusTrap'
   | 'focusTrapOptions'
   | 'closeOnOutsideClick'
@@ -317,6 +318,7 @@ export default class Drawer extends Component<DrawerSignature> {
       @transitionDuration={{@transitionDuration}}
       @backdrop={{@backdrop}}
       @disableTransitions={{@disableTransitions}}
+      @animateOnMount={{@animateOnMount}}
       @disableFocusTrap={{@disableFocusTrap}}
       @focusTrapOptions={{@focusTrapOptions}}
       @closeOnOutsideClick={{if this.preventClosing false @closeOnOutsideClick}}

--- a/packages/frontile/src/components/overlays/drawer.md
+++ b/packages/frontile/src/components/overlays/drawer.md
@@ -961,6 +961,14 @@ export default class NonDismissibleDrawer extends Component {
 }
 ```
 
+### Drawers that start open
+
+A drawer whose `@isOpen` is already true the first time it renders — deep-linked open, or
+restored by a page refresh — waits for the browser's first paint before appearing, so its
+animation plays against the page rather than starting before anything has been drawn. Pass
+`@animateOnMount={{false}}` when an already-open drawer should simply be there, with no
+reveal.
+
 ## Patterns
 
 ### Form in Drawer

--- a/packages/frontile/src/components/overlays/drawer.md
+++ b/packages/frontile/src/components/overlays/drawer.md
@@ -1202,6 +1202,8 @@ put focus. `@allowClosing={{false}}` disables Escape, backdrop click and the clo
 once, leaving a keyboard user no way out — the Non-Dismissible example above pairs it with
 explicit footer actions for that reason.
 
+Under `prefers-reduced-motion: reduce`, the drawer fades in place instead of sliding.
+
 Note that `@placement` is purely visual: a drawer sliding in from the left is announced no
 differently from one on the right, and nothing about the placement reaches assistive
 technology. Frontile also does not set `aria-describedby`.

--- a/packages/frontile/src/components/overlays/modal.gts
+++ b/packages/frontile/src/components/overlays/modal.gts
@@ -31,6 +31,7 @@ export interface ModalArgs extends Pick<
   | 'transitionDuration'
   | 'backdrop'
   | 'disableTransitions'
+  | 'animateOnMount'
   | 'disableFocusTrap'
   | 'focusTrapOptions'
   | 'closeOnOutsideClick'
@@ -228,6 +229,7 @@ export default class Modal extends Component<ModalSignature> {
       @transitionDuration={{@transitionDuration}}
       @backdrop={{@backdrop}}
       @disableTransitions={{@disableTransitions}}
+      @animateOnMount={{@animateOnMount}}
       @disableFocusTrap={{@disableFocusTrap}}
       @focusTrapOptions={{@focusTrapOptions}}
       @closeOnOutsideClick={{if this.preventClosing false @closeOnOutsideClick}}

--- a/packages/frontile/src/components/overlays/modal.md
+++ b/packages/frontile/src/components/overlays/modal.md
@@ -866,6 +866,8 @@ put focus. Note that `@allowClosing={{false}}` disables Escape, backdrop click a
 button together, which leaves a keyboard user no way out — reserve it for flows that provide
 their own explicit resolution.
 
+Under `prefers-reduced-motion: reduce`, the modal fades in without the zoom.
+
 Frontile does not set `aria-describedby`. Add it yourself if your dialog needs it.
 
 ## API

--- a/packages/frontile/src/components/overlays/modal.md
+++ b/packages/frontile/src/components/overlays/modal.md
@@ -797,6 +797,14 @@ export default class NestedModals extends Component {
 }
 ```
 
+### Modals that start open
+
+A modal whose `@isOpen` is already true the first time it renders — deep-linked open, or
+restored by a page refresh — waits for the browser's first paint before appearing, so its
+animation plays against the page rather than starting before anything has been drawn. Pass
+`@animateOnMount={{false}}` when an already-open modal should simply be there, with no
+reveal.
+
 ## Anatomy
 
 Modal yields the pieces you assemble the dialog from:

--- a/packages/frontile/src/components/overlays/mount-animation.ts
+++ b/packages/frontile/src/components/overlays/mount-animation.ts
@@ -42,17 +42,24 @@ interface MountAnimationState {
 }
 
 /**
+ * Whether a mount animation is in question at all. Everything below is a
+ * choice about how to treat one, so an overlay opened by interaction, or one
+ * whose transitions are off, is none of their business.
+ */
+function hasMountAnimation(state: MountAnimationState): boolean {
+  return state.isFirstOpen && state.animationsEnabled;
+}
+
+/**
  * Whether to hold the overlay out of the DOM until the browser has painted.
  *
- * Turning the animation off, by argument or because animations are disabled
- * entirely, means rendering immediately: there is nothing to make visible, and
- * in tests a deferred mount would expose a frame of empty DOM that `settled`
- * does not wait for.
+ * Turning the animation off means rendering immediately: there is nothing to
+ * make visible, and in tests a deferred mount would expose a frame of empty
+ * DOM that `settled` does not wait for.
  */
 function shouldDeferMount(state: MountAnimationState): boolean {
   return (
-    state.isFirstOpen &&
-    state.animationsEnabled &&
+    hasMountAnimation(state) &&
     state.animateOnMount !== false &&
     state.canWaitForFrame &&
     !state.hasPainted
@@ -61,11 +68,7 @@ function shouldDeferMount(state: MountAnimationState): boolean {
 
 /** Whether the enter half of the transition is neutered for this mount. */
 function shouldSkipEnterTransition(state: MountAnimationState): boolean {
-  return (
-    state.isFirstOpen &&
-    state.animationsEnabled &&
-    state.animateOnMount === false
-  );
+  return hasMountAnimation(state) && state.animateOnMount === false;
 }
 
 // How long to wait for a paint that may never come: a page loaded in a
@@ -73,13 +76,18 @@ function shouldSkipEnterTransition(state: MountAnimationState): boolean {
 // has to exist in the DOM before then.
 const FIRST_PAINT_TIMEOUT = 300;
 
+// Detection is cached: it cannot change within a page, and every overlay ever
+// constructed asks.
+let paintTimingSupport: boolean | undefined;
+
 /** Whether the browser records paint timings, which Safari does not. */
 function supportsPaintTiming(): boolean {
-  return (
+  paintTimingSupport ??=
     typeof PerformanceObserver === 'function' &&
     Array.isArray(PerformanceObserver.supportedEntryTypes) &&
-    PerformanceObserver.supportedEntryTypes.includes('paint')
-  );
+    PerformanceObserver.supportedEntryTypes.includes('paint');
+
+  return paintTimingSupport;
 }
 
 /** Whether the browser has painted already. */
@@ -177,6 +185,7 @@ function withoutEnterTransition<T extends object>(
 
 export {
   afterFirstPaint,
+  FIRST_PAINT_TIMEOUT,
   hasPainted,
   shouldDeferMount,
   shouldSkipEnterTransition,

--- a/packages/frontile/src/components/overlays/mount-animation.ts
+++ b/packages/frontile/src/components/overlays/mount-animation.ts
@@ -2,25 +2,20 @@
  * When an overlay's enter animation is worth playing, and what to do when it
  * is not.
  *
- * An overlay that is already open the first time it renders -- one that is
- * deep-linked open, or that a page refresh restored -- has nothing to animate
- * away from. Its enter transition starts before the browser has painted
- * anything at all, so the first pixels the user ever sees already contain a
- * half-faded overlay, and the backdrop fades in at the same moment as the page
- * it is meant to be dimming. Measured on a cold load, the transition ran from
- * 126ms to 311ms while first paint landed at 152ms: technically animated,
- * perceptually absent -- and on a heavier app the whole 200ms can be spent
- * before first paint, at which point it really is invisible.
- *
- * So the overlay waits for that first paint before mounting, and the animation
- * then plays against a page the user has already seen. Consumers who would
- * rather an already-open overlay simply be there can opt out with
- * `@animateOnMount={{false}}`.
+ * An overlay that is already open the first time it renders -- deep-linked
+ * open, or restored by a page refresh -- starts its enter transition before
+ * the browser has painted anything, so the first pixels the user sees already
+ * contain a half-faded overlay over a page that is itself only appearing. It
+ * waits for that first paint instead, and animates against a page the user has
+ * already seen.
  */
 
 interface MountAnimationState {
-  /** Whether `@isOpen` was already true the first time the overlay rendered. */
-  isOpenAtMount: boolean;
+  /**
+   * Whether this is the overlay's first open *and* it was already open when
+   * the overlay first rendered.
+   */
+  isFirstOpen: boolean;
 
   /**
    * Whether transitions run at all -- false in tests and when
@@ -33,15 +28,15 @@ interface MountAnimationState {
 
   /**
    * Whether there is a frame to wait for. False without
-   * `requestAnimationFrame` (prerendering), where there is no paint to animate
-   * against and waiting would mean never rendering.
+   * `requestAnimationFrame` (prerendering), where waiting would mean never
+   * rendering.
    */
   canWaitForFrame: boolean;
 
   /**
-   * Whether the browser has already painted. True for the overlay of a slow
-   * boot that rendered well after the page appeared -- there is nothing left
-   * to wait for, and its animation is already visible.
+   * Whether the browser had already painted. True for the overlay of a boot
+   * slow enough to render after the page appeared, which has nothing left to
+   * wait for.
    */
   hasPainted: boolean;
 }
@@ -49,17 +44,14 @@ interface MountAnimationState {
 /**
  * Whether to hold the overlay out of the DOM until the browser has painted.
  *
- * Only the mount-open case waits, and only before the first paint: an overlay
- * opened by interaction, or rendered by a boot slow enough that the page is
- * already on screen, is animating against something the user can see.
  * Turning the animation off, by argument or because animations are disabled
- * entirely, means rendering immediately -- there is nothing to make visible,
- * and in tests a deferred mount would expose a frame of empty DOM that
- * `settled` does not wait for.
+ * entirely, means rendering immediately: there is nothing to make visible, and
+ * in tests a deferred mount would expose a frame of empty DOM that `settled`
+ * does not wait for.
  */
 function shouldDeferMount(state: MountAnimationState): boolean {
   return (
-    state.isOpenAtMount &&
+    state.isFirstOpen &&
     state.animationsEnabled &&
     state.animateOnMount !== false &&
     state.canWaitForFrame &&
@@ -67,22 +59,18 @@ function shouldDeferMount(state: MountAnimationState): boolean {
   );
 }
 
-/**
- * Whether the enter half of the transition should be neutered for this mount.
- */
+/** Whether the enter half of the transition is neutered for this mount. */
 function shouldSkipEnterTransition(state: MountAnimationState): boolean {
   return (
-    state.isOpenAtMount &&
+    state.isFirstOpen &&
     state.animationsEnabled &&
     state.animateOnMount === false
   );
 }
 
-/**
- * How long to wait for a paint that may never be recorded -- a page loaded in
- * a background tab paints nothing until it is looked at, and the overlay still
- * has to exist in the DOM before then.
- */
+// How long to wait for a paint that may never come: a page loaded in a
+// background tab paints nothing until it is looked at, and the overlay still
+// has to exist in the DOM before then.
 const FIRST_PAINT_TIMEOUT = 300;
 
 /** Whether the browser records paint timings, which Safari does not. */
@@ -107,11 +95,10 @@ function hasPainted(): boolean {
  * Runs `callback` once the browser has painted, and returns a function that
  * cancels the wait.
  *
- * Where paint timings exist they are the honest signal, because a frame is
- * not a paint: two frames can pass on a page that has drawn nothing yet, which
- * puts the overlay back in the very first painted frame -- exactly what the
- * wait is for avoiding. Browsers without paint timings fall back to two
- * frames, which is the best approximation available there.
+ * Paint timings are the signal where they exist, because a frame is not a
+ * paint: two frames can pass on a page that has drawn nothing yet, which puts
+ * the overlay back in the very first painted frame. Browsers without them fall
+ * back to two frames.
  */
 function afterFirstPaint(callback: () => void): () => void {
   let isDone = false;
@@ -122,10 +109,14 @@ function afterFirstPaint(callback: () => void): () => void {
       return;
     }
     isDone = true;
+    clearTimeout(timer);
     observer?.disconnect();
     callback();
   };
 
+  // Deliberately left running by `settle`: the frame it waits on never arrives
+  // in a hidden tab, and the overlay cannot be left unrendered until the tab
+  // is looked at. `finish` runs once, for whichever gets there first.
   const timer = setTimeout(finish, FIRST_PAINT_TIMEOUT);
 
   const nextFrame = (fn: () => void): void => {
@@ -136,10 +127,9 @@ function afterFirstPaint(callback: () => void): () => void {
     }
   };
 
-  // One frame past the paint, so the overlay mounts into a frame after the one
-  // the user saw the page in.
+  // One frame past the paint, so the overlay mounts after the frame the user
+  // saw the page in.
   const settle = (): void => {
-    clearTimeout(timer);
     nextFrame(finish);
   };
 

--- a/packages/frontile/src/components/overlays/mount-animation.ts
+++ b/packages/frontile/src/components/overlays/mount-animation.ts
@@ -1,0 +1,196 @@
+/**
+ * When an overlay's enter animation is worth playing, and what to do when it
+ * is not.
+ *
+ * An overlay that is already open the first time it renders -- one that is
+ * deep-linked open, or that a page refresh restored -- has nothing to animate
+ * away from. Its enter transition starts before the browser has painted
+ * anything at all, so the first pixels the user ever sees already contain a
+ * half-faded overlay, and the backdrop fades in at the same moment as the page
+ * it is meant to be dimming. Measured on a cold load, the transition ran from
+ * 126ms to 311ms while first paint landed at 152ms: technically animated,
+ * perceptually absent -- and on a heavier app the whole 200ms can be spent
+ * before first paint, at which point it really is invisible.
+ *
+ * So the overlay waits for that first paint before mounting, and the animation
+ * then plays against a page the user has already seen. Consumers who would
+ * rather an already-open overlay simply be there can opt out with
+ * `@animateOnMount={{false}}`.
+ */
+
+interface MountAnimationState {
+  /** Whether `@isOpen` was already true the first time the overlay rendered. */
+  isOpenAtMount: boolean;
+
+  /**
+   * Whether transitions run at all -- false in tests and when
+   * `@disableTransitions` is set.
+   */
+  animationsEnabled: boolean;
+
+  /** The `@animateOnMount` argument, `undefined` when not passed. */
+  animateOnMount: boolean | undefined;
+
+  /**
+   * Whether there is a frame to wait for. False without
+   * `requestAnimationFrame` (prerendering), where there is no paint to animate
+   * against and waiting would mean never rendering.
+   */
+  canWaitForFrame: boolean;
+
+  /**
+   * Whether the browser has already painted. True for the overlay of a slow
+   * boot that rendered well after the page appeared -- there is nothing left
+   * to wait for, and its animation is already visible.
+   */
+  hasPainted: boolean;
+}
+
+/**
+ * Whether to hold the overlay out of the DOM until the browser has painted.
+ *
+ * Only the mount-open case waits, and only before the first paint: an overlay
+ * opened by interaction, or rendered by a boot slow enough that the page is
+ * already on screen, is animating against something the user can see.
+ * Turning the animation off, by argument or because animations are disabled
+ * entirely, means rendering immediately -- there is nothing to make visible,
+ * and in tests a deferred mount would expose a frame of empty DOM that
+ * `settled` does not wait for.
+ */
+function shouldDeferMount(state: MountAnimationState): boolean {
+  return (
+    state.isOpenAtMount &&
+    state.animationsEnabled &&
+    state.animateOnMount !== false &&
+    state.canWaitForFrame &&
+    !state.hasPainted
+  );
+}
+
+/**
+ * Whether the enter half of the transition should be neutered for this mount.
+ */
+function shouldSkipEnterTransition(state: MountAnimationState): boolean {
+  return (
+    state.isOpenAtMount &&
+    state.animationsEnabled &&
+    state.animateOnMount === false
+  );
+}
+
+/**
+ * How long to wait for a paint that may never be recorded -- a page loaded in
+ * a background tab paints nothing until it is looked at, and the overlay still
+ * has to exist in the DOM before then.
+ */
+const FIRST_PAINT_TIMEOUT = 300;
+
+/** Whether the browser records paint timings, which Safari does not. */
+function supportsPaintTiming(): boolean {
+  return (
+    typeof PerformanceObserver === 'function' &&
+    Array.isArray(PerformanceObserver.supportedEntryTypes) &&
+    PerformanceObserver.supportedEntryTypes.includes('paint')
+  );
+}
+
+/** Whether the browser has painted already. */
+function hasPainted(): boolean {
+  if (typeof performance === 'undefined' || !supportsPaintTiming()) {
+    return false;
+  }
+
+  return performance.getEntriesByType('paint').length > 0;
+}
+
+/**
+ * Runs `callback` once the browser has painted, and returns a function that
+ * cancels the wait.
+ *
+ * Where paint timings exist they are the honest signal, because a frame is
+ * not a paint: two frames can pass on a page that has drawn nothing yet, which
+ * puts the overlay back in the very first painted frame -- exactly what the
+ * wait is for avoiding. Browsers without paint timings fall back to two
+ * frames, which is the best approximation available there.
+ */
+function afterFirstPaint(callback: () => void): () => void {
+  let isDone = false;
+  let observer: PerformanceObserver | undefined;
+
+  const finish = (): void => {
+    if (isDone) {
+      return;
+    }
+    isDone = true;
+    observer?.disconnect();
+    callback();
+  };
+
+  const timer = setTimeout(finish, FIRST_PAINT_TIMEOUT);
+
+  const nextFrame = (fn: () => void): void => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => fn());
+    } else {
+      fn();
+    }
+  };
+
+  // One frame past the paint, so the overlay mounts into a frame after the one
+  // the user saw the page in.
+  const settle = (): void => {
+    clearTimeout(timer);
+    nextFrame(finish);
+  };
+
+  if (supportsPaintTiming()) {
+    observer = new PerformanceObserver(() => {
+      settle();
+    });
+    observer.observe({ type: 'paint', buffered: true });
+  } else {
+    nextFrame(() => nextFrame(settle));
+  }
+
+  return () => {
+    isDone = true;
+    clearTimeout(timer);
+    observer?.disconnect();
+  };
+}
+
+/**
+ * Class names that deliberately carry no CSS.
+ *
+ * `ember-css-transitions` decides whether an element animates *out* from
+ * whether its enter transition ran (`finishedTransitionIn`), so skipping the
+ * mount animation cannot be done by disabling the modifier -- that would take
+ * the close animation with it. Pointing the enter half at inert class names
+ * instead lets the modifier run its enter sequence and mark itself as entered,
+ * while `computeTimeout` finds no duration to wait for and nothing moves.
+ */
+const INERT_ENTER_TRANSITION = {
+  enterClass: 'overlay-transition--none-enter',
+  enterActiveClass: 'overlay-transition--none-enter-active',
+  enterToClass: 'overlay-transition--none-enter-to'
+} as const;
+
+/**
+ * The given transition options with their enter half made inert, overriding
+ * any enter classes the consumer supplied.
+ */
+function withoutEnterTransition<T extends object>(
+  options: T
+): T & typeof INERT_ENTER_TRANSITION {
+  return { ...options, ...INERT_ENTER_TRANSITION };
+}
+
+export {
+  afterFirstPaint,
+  hasPainted,
+  shouldDeferMount,
+  shouldSkipEnterTransition,
+  withoutEnterTransition,
+  INERT_ENTER_TRANSITION,
+  type MountAnimationState
+};

--- a/packages/frontile/src/components/overlays/overlay.gts
+++ b/packages/frontile/src/components/overlays/overlay.gts
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-runloop */
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 import { on } from '@ember/modifier';
@@ -262,13 +262,15 @@ class Overlay extends Component<OverlaySignature> {
   // consulted while the mount is being deferred; see `mount-animation.ts`.
   @tracked hasWaitedForPaint = false;
 
-  // Whether the page had already painted when this overlay was created.
-  hadPaintedAtMount = false;
-
   // Whether `@isOpen` was already true on the very first render. Captured once
   // rather than derived, because the whole question is about what the args
   // looked like at mount.
   isOpenAtMount = this.args.isOpen === true;
+
+  // Whether the page had already painted when this overlay was created, which
+  // only an overlay that mounts open ever has to know -- and every Dropdown,
+  // Select and Tooltip in the app builds an Overlay too.
+  hadPaintedAtMount = this.isOpenAtMount ? hasPainted() : false;
 
   // Latched when the first open closes, so a *reopen* of the same overlay
   // animates normally. Only a genuine close counts: the content element is
@@ -292,11 +294,6 @@ class Overlay extends Component<OverlaySignature> {
 
   constructor(owner: Owner, args: Args) {
     super(owner, args);
-
-    // Captured once, before any waiting: whether the page had painted at the
-    // moment this overlay was created is what decides if there is anything to
-    // wait for.
-    this.hadPaintedAtMount = hasPainted();
 
     if (!this.shouldDeferMount) {
       return;
@@ -418,6 +415,7 @@ class Overlay extends Component<OverlaySignature> {
     };
   });
 
+  @cached
   get mountAnimationState() {
     return {
       isFirstOpen: this.isOpenAtMount && !this.hasClosedOnce,
@@ -485,16 +483,16 @@ class Overlay extends Component<OverlaySignature> {
     return modifier(() => {});
   }
 
+  // Applied to both the content and the backdrop, so they never disagree about
+  // whether this mount animates.
+  maybeWithoutEnter<T extends object>(options: T): T {
+    return this.skipEnterTransition ? withoutEnterTransition(options) : options;
+  }
+
   get backdropTransition() {
-    const options = this.args.backdropTransition || {
-      isEnabled: this.isAnimationEnabled
-    };
-
-    if (this.skipEnterTransition) {
-      return withoutEnterTransition(options);
-    }
-
-    return options;
+    return this.maybeWithoutEnter(
+      this.args.backdropTransition || { isEnabled: this.isAnimationEnabled }
+    );
   }
 
   get transition() {
@@ -507,11 +505,7 @@ class Overlay extends Component<OverlaySignature> {
       options = { ...options, ...this.args.transition };
     }
 
-    if (this.skipEnterTransition) {
-      return withoutEnterTransition(options);
-    }
-
-    return options;
+    return this.maybeWithoutEnter(options);
   }
 
   <template>

--- a/packages/frontile/src/components/overlays/overlay.gts
+++ b/packages/frontile/src/components/overlays/overlay.gts
@@ -18,6 +18,7 @@ import {
   withoutEnterTransition
 } from './mount-animation';
 import { Portal, findParentPortal, type PortalSignature } from './portal';
+import type Owner from '@ember/owner';
 import type { ModifierLike } from '@glint/template';
 import type { CssTransitionSignature } from 'ember-css-transitions/modifiers/css-transition';
 import { isTesting, macroCondition } from '@embroider/macros';
@@ -139,10 +140,9 @@ interface Args extends Pick<
    *
    * When true (the default) the overlay waits for the browser's first paint
    * before mounting, so the animation plays against a page the user has
-   * already seen instead of starting before anything has been painted. Set it
-   * to false for an already-open overlay that should simply be there, with no
-   * reveal. Either way, an overlay opened later by interaction animates
-   * normally, and the close animation is unaffected.
+   * already seen. Set it to false for an already-open overlay that should
+   * simply be there, with no reveal. An overlay opened later by interaction
+   * animates either way, and so does closing.
    *
    * @defaultValue true
    */
@@ -270,13 +270,13 @@ class Overlay extends Component<OverlaySignature> {
   // looked like at mount.
   isOpenAtMount = this.args.isOpen === true;
 
-  // Latched when the first open tears down, so a *reopen* of the same overlay
-  // animates normally. It is written from the content modifier's destructor,
-  // which runs after the render transaction has closed, rather than during the
-  // first open: flipping it while the overlay is still up would swap the enter
-  // class names out from under the running modifier, which cleans up using
-  // whatever names it holds when the transition ends.
-  @tracked hasMountedOnce = false;
+  // Latched when the first open closes, so a *reopen* of the same overlay
+  // animates normally. Only a genuine close counts: the content element is
+  // also torn down and rebuilt when the portal destination changes under an
+  // open overlay, and flipping this then would swap the enter class names out
+  // from under the running modifier, which cleans up using whatever names it
+  // holds when the transition ends.
+  @tracked hasClosedOnce = false;
 
   contentElement: HTMLElement | undefined;
   focusedElement: Element | null | undefined;
@@ -290,8 +290,8 @@ class Overlay extends Component<OverlaySignature> {
 
   cancelPaintWait: (() => void) | undefined;
 
-  constructor(owner: unknown, args: Args) {
-    super(owner as never, args);
+  constructor(owner: Owner, args: Args) {
+    super(owner, args);
 
     // Captured once, before any waiting: whether the page had painted at the
     // moment this overlay was created is what decides if there is anything to
@@ -388,7 +388,10 @@ class Overlay extends Component<OverlaySignature> {
     }
     return () => {
       this.contentElement = undefined;
-      this.hasMountedOnce = true;
+
+      if (this.args.isOpen !== true) {
+        this.hasClosedOnce = true;
+      }
 
       if (this.didLockBodyScroll) {
         this.didLockBodyScroll = false;
@@ -417,7 +420,7 @@ class Overlay extends Component<OverlaySignature> {
 
   get mountAnimationState() {
     return {
-      isOpenAtMount: this.isOpenAtMount && !this.hasMountedOnce,
+      isFirstOpen: this.isOpenAtMount && !this.hasClosedOnce,
       animationsEnabled: this.isAnimationEnabled,
       animateOnMount: this.args.animateOnMount,
       canWaitForFrame: typeof requestAnimationFrame === 'function',

--- a/packages/frontile/src/components/overlays/overlay.gts
+++ b/packages/frontile/src/components/overlays/overlay.gts
@@ -10,6 +10,13 @@ import { modifier } from 'ember-modifier';
 import { focusTrap, type FocusTrapModifierSignature } from 'ember-focus-trap';
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 import { Backdrop, type BackdropSignature } from './backdrop';
+import {
+  afterFirstPaint,
+  hasPainted,
+  shouldDeferMount,
+  shouldSkipEnterTransition,
+  withoutEnterTransition
+} from './mount-animation';
 import { Portal, findParentPortal, type PortalSignature } from './portal';
 import type { ModifierLike } from '@glint/template';
 import type { CssTransitionSignature } from 'ember-css-transitions/modifiers/css-transition';
@@ -127,6 +134,21 @@ interface Args extends Pick<
   disableTransitions?: boolean;
 
   /**
+   * Whether an overlay that is *already open the first time it renders* --
+   * deep-linked open, or restored by a page refresh -- animates in.
+   *
+   * When true (the default) the overlay waits for the browser's first paint
+   * before mounting, so the animation plays against a page the user has
+   * already seen instead of starting before anything has been painted. Set it
+   * to false for an already-open overlay that should simply be there, with no
+   * reveal. Either way, an overlay opened later by interaction animates
+   * normally, and the close animation is unaffected.
+   *
+   * @defaultValue true
+   */
+  animateOnMount?: boolean;
+
+  /**
    * Whether the focus trap is disabled or not
    *
    * @defaultValue false
@@ -236,6 +258,26 @@ interface OverlaySignature {
 class Overlay extends Component<OverlaySignature> {
   @tracked keepOpen = false;
 
+  // Whether the browser has painted since this overlay was created. Only ever
+  // consulted while the mount is being deferred; see `mount-animation.ts`.
+  @tracked hasWaitedForPaint = false;
+
+  // Whether the page had already painted when this overlay was created.
+  hadPaintedAtMount = false;
+
+  // Whether `@isOpen` was already true on the very first render. Captured once
+  // rather than derived, because the whole question is about what the args
+  // looked like at mount.
+  isOpenAtMount = this.args.isOpen === true;
+
+  // Latched when the first open tears down, so a *reopen* of the same overlay
+  // animates normally. It is written from the content modifier's destructor,
+  // which runs after the render transaction has closed, rather than during the
+  // first open: flipping it while the overlay is still up would swap the enter
+  // class names out from under the running modifier, which cleans up using
+  // whatever names it holds when the transition ends.
+  @tracked hasMountedOnce = false;
+
   contentElement: HTMLElement | undefined;
   focusedElement: Element | null | undefined;
   mouseDownContentElement: EventTarget | null = null;
@@ -245,6 +287,32 @@ class Overlay extends Component<OverlaySignature> {
   // teardown, because the args can change while the overlay is open and an
   // asymmetric lock/unlock would leak the reference count.
   didLockBodyScroll = false;
+
+  cancelPaintWait: (() => void) | undefined;
+
+  constructor(owner: unknown, args: Args) {
+    super(owner as never, args);
+
+    // Captured once, before any waiting: whether the page had painted at the
+    // moment this overlay was created is what decides if there is anything to
+    // wait for.
+    this.hadPaintedAtMount = hasPainted();
+
+    if (!this.shouldDeferMount) {
+      return;
+    }
+
+    this.cancelPaintWait = afterFirstPaint(() => {
+      if (!this.isDestroying && !this.isDestroyed) {
+        this.hasWaitedForPaint = true;
+      }
+    });
+  }
+
+  willDestroy(): void {
+    super.willDestroy();
+    this.cancelPaintWait?.();
+  }
 
   handleClose(): void {
     if (this.args.isOpen && typeof this.args.onClose === 'function') {
@@ -320,6 +388,7 @@ class Overlay extends Component<OverlaySignature> {
     }
     return () => {
       this.contentElement = undefined;
+      this.hasMountedOnce = true;
 
       if (this.didLockBodyScroll) {
         this.didLockBodyScroll = false;
@@ -346,7 +415,29 @@ class Overlay extends Component<OverlaySignature> {
     };
   });
 
+  get mountAnimationState() {
+    return {
+      isOpenAtMount: this.isOpenAtMount && !this.hasMountedOnce,
+      animationsEnabled: this.isAnimationEnabled,
+      animateOnMount: this.args.animateOnMount,
+      canWaitForFrame: typeof requestAnimationFrame === 'function',
+      hasPainted: this.hadPaintedAtMount
+    };
+  }
+
+  get shouldDeferMount(): boolean {
+    return shouldDeferMount(this.mountAnimationState);
+  }
+
+  get skipEnterTransition(): boolean {
+    return shouldSkipEnterTransition(this.mountAnimationState);
+  }
+
   get isVisible(): boolean {
+    if (this.shouldDeferMount && !this.hasWaitedForPaint) {
+      return false;
+    }
+
     return this.args.isOpen || this.keepOpen;
   }
 
@@ -392,11 +483,15 @@ class Overlay extends Component<OverlaySignature> {
   }
 
   get backdropTransition() {
-    if (this.args.backdropTransition) {
-      return this.args.backdropTransition;
+    const options = this.args.backdropTransition || {
+      isEnabled: this.isAnimationEnabled
+    };
+
+    if (this.skipEnterTransition) {
+      return withoutEnterTransition(options);
     }
 
-    return { isEnabled: this.isAnimationEnabled };
+    return options;
   }
 
   get transition() {
@@ -406,7 +501,11 @@ class Overlay extends Component<OverlaySignature> {
     };
 
     if (typeof this.args.transition === 'object') {
-      return { ...options, ...this.args.transition };
+      options = { ...options, ...this.args.transition };
+    }
+
+    if (this.skipEnterTransition) {
+      return withoutEnterTransition(options);
     }
 
     return options;

--- a/packages/frontile/src/components/overlays/overlay.md
+++ b/packages/frontile/src/components/overlays/overlay.md
@@ -489,8 +489,7 @@ before appearing, so its animation plays against the page rather than starting b
 anything has been drawn.
 
 Pass `@animateOnMount={{false}}` when an already-open overlay should simply be there, with
-no reveal. Overlays opened later by interaction animate either way, and the close animation
-is never affected.
+no reveal. An overlay opened later by interaction animates either way, and so does closing.
 
 ```gts preview
 import Component from '@glimmer/component';
@@ -532,7 +531,7 @@ export default class OverlaysThatStartOpen extends Component {
 
       {{#if this.showAnimated}}
         <Overlay @isOpen={{true}} @onClose={{this.closeAnimated}}>
-          <div class='bg-content1 p-6 rounded-lg shadow-lg'>
+          <div class='bg-surface-modal p-6 rounded-lg shadow-lg'>
             <h3 class='font-semibold mb-2'>Animated</h3>
             <p class='mb-4'>Rendered with @isOpen already true.</p>
             <Button @onPress={{this.closeAnimated}}>Close</Button>
@@ -546,7 +545,7 @@ export default class OverlaysThatStartOpen extends Component {
           @onClose={{this.closeImmediate}}
           @animateOnMount={{false}}
         >
-          <div class='bg-content1 p-6 rounded-lg shadow-lg'>
+          <div class='bg-surface-modal p-6 rounded-lg shadow-lg'>
             <h3 class='font-semibold mb-2'>No mount animation</h3>
             <p class='mb-4'>It is simply there. Closing still animates.</p>
             <Button @onPress={{this.closeImmediate}}>Close</Button>
@@ -682,6 +681,11 @@ Overlays that block scroll are reference counted, so a Modal that opens a Drawer
 locked until the last of them closes. Whatever inline `overflow` the page had before the
 first lock is restored, rather than blanked. Overlays rendered with `@renderInPlace={{true}}`
 or `@blockScroll={{false}}` never take part in that count.
+
+Under `prefers-reduced-motion: reduce`, the built-in transitions drop their movement and
+keep only the fade: `fade` is unchanged, `zoom` and `scale` stop scaling, and the
+`slideFrom*` transitions fade in place instead of travelling. A custom `@transition` is
+yours to adapt.
 
 Frontile does not set `aria-modal`, `aria-labelledby` or `aria-describedby` at this level.
 

--- a/packages/frontile/src/components/overlays/overlay.md
+++ b/packages/frontile/src/components/overlays/overlay.md
@@ -489,7 +489,8 @@ before appearing, so its animation plays against the page rather than starting b
 anything has been drawn.
 
 Pass `@animateOnMount={{false}}` when an already-open overlay should simply be there, with
-no reveal. An overlay opened later by interaction animates either way, and so does closing.
+no reveal — Modal and Drawer forward it too. An overlay opened later by interaction animates
+either way, and so does closing.
 
 ```gts preview
 import Component from '@glimmer/component';

--- a/packages/frontile/src/components/overlays/overlay.md
+++ b/packages/frontile/src/components/overlays/overlay.md
@@ -481,6 +481,83 @@ export default class AnimationsAndTransitions extends Component {
 }
 ```
 
+### Overlays that start open
+
+An overlay whose `@isOpen` is already true the first time it renders — one that is
+deep-linked open, or that a page refresh restored — waits for the browser's first paint
+before appearing, so its animation plays against the page rather than starting before
+anything has been drawn.
+
+Pass `@animateOnMount={{false}}` when an already-open overlay should simply be there, with
+no reveal. Overlays opened later by interaction animate either way, and the close animation
+is never affected.
+
+```gts preview
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { Overlay } from 'frontile';
+import { Button } from 'frontile';
+
+export default class OverlaysThatStartOpen extends Component {
+  @tracked showAnimated = false;
+  @tracked showImmediate = false;
+
+  @action mountAnimated() {
+    this.showAnimated = true;
+  }
+
+  @action mountImmediate() {
+    this.showImmediate = true;
+  }
+
+  @action closeAnimated() {
+    this.showAnimated = false;
+  }
+
+  @action closeImmediate() {
+    this.showImmediate = false;
+  }
+
+  <template>
+    <div class='demo-stack demo-stack--wide items-center'>
+      <div class='flex gap-2'>
+        <Button @onPress={{this.mountAnimated}}>
+          Render already open
+        </Button>
+        <Button @onPress={{this.mountImmediate}}>
+          Render already open, no animation
+        </Button>
+      </div>
+
+      {{#if this.showAnimated}}
+        <Overlay @isOpen={{true}} @onClose={{this.closeAnimated}}>
+          <div class='bg-content1 p-6 rounded-lg shadow-lg'>
+            <h3 class='font-semibold mb-2'>Animated</h3>
+            <p class='mb-4'>Rendered with @isOpen already true.</p>
+            <Button @onPress={{this.closeAnimated}}>Close</Button>
+          </div>
+        </Overlay>
+      {{/if}}
+
+      {{#if this.showImmediate}}
+        <Overlay
+          @isOpen={{true}}
+          @onClose={{this.closeImmediate}}
+          @animateOnMount={{false}}
+        >
+          <div class='bg-content1 p-6 rounded-lg shadow-lg'>
+            <h3 class='font-semibold mb-2'>No mount animation</h3>
+            <p class='mb-4'>It is simply there. Closing still animates.</p>
+            <Button @onPress={{this.closeImmediate}}>Close</Button>
+          </div>
+        </Overlay>
+      {{/if}}
+    </div>
+  </template>
+}
+```
+
 ### Outside Click vs Overlay Element Click
 
 The Overlay component has two different click-to-close mechanisms that work together:

--- a/packages/theme/src/components/overlays.ts
+++ b/packages/theme/src/components/overlays.ts
@@ -295,11 +295,21 @@ const drawer = tv({
 
 const slideTransition = {
   enterActive: {
-    transition: 'transform 0.2s cubic-bezier(0.37, 0, 0.63, 1)'
+    transition: 'transform 0.2s cubic-bezier(0.37, 0, 0.63, 1)',
+    // A slide is *only* travel, so there is no fade left to keep once the
+    // translate is dropped. Reduced motion therefore swaps the movement for
+    // the fade the other transitions keep, instead of leaving the drawer to
+    // appear with no transition at all.
+    '@media (prefers-reduced-motion: reduce)': {
+      transition: 'opacity 0.2s linear'
+    }
   },
 
   leaveActive: {
-    transition: 'transform 0.2s cubic-bezier(0.37, 0, 0.63, 1)'
+    transition: 'transform 0.2s cubic-bezier(0.37, 0, 0.63, 1)',
+    '@media (prefers-reduced-motion: reduce)': {
+      transition: 'opacity 0.2s linear'
+    }
   }
 };
 
@@ -318,6 +328,12 @@ const overlayArrow = tv({
 });
 
 const overlayTransitions = {
+  /**
+   * Deliberately has no `prefers-reduced-motion` branch: a cross-fade is not
+   * motion. Reduced motion asks for movement to be removed, not for state
+   * changes to become instant, so the other transitions below drop their
+   * travel and keep exactly this fade.
+   */
   fade: {
     enter: {
       opacity: '0'
@@ -335,53 +351,92 @@ const overlayTransitions = {
   zoom: {
     enter: {
       opacity: '0',
-      transform: 'scale(0.8)'
+      transform: 'scale(0.8)',
+      // Reduced motion keeps the fade and drops the scale, rather than
+      // removing the transition -- the overlay should still read as appearing.
+      '@media (prefers-reduced-motion: reduce)': {
+        transform: 'none'
+      }
     },
     enterActive: {
-      transition: 'all 0.2s ease-in-out'
+      transition: 'all 0.2s ease-in-out',
+      '@media (prefers-reduced-motion: reduce)': {
+        transition: 'opacity 0.2s ease-in-out'
+      }
     },
     leave: {
       opacity: '1',
       transform: 'scale(1)'
     },
     leaveActive: {
-      transition: 'all 0.2s ease-in-out'
+      transition: 'all 0.2s ease-in-out',
+      '@media (prefers-reduced-motion: reduce)': {
+        transition: 'opacity 0.2s ease-in-out'
+      }
     }
   },
   slideFromLeft: {
     enter: {
-      transform: 'translateX(-100%)'
+      transform: 'translateX(-100%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        transform: 'none',
+        opacity: '0'
+      }
     },
     leave: {
-      transform: 'translateX(0%)'
+      transform: 'translateX(0%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        opacity: '1'
+      }
     },
     ...slideTransition
   },
   slideFromRight: {
     enter: {
-      transform: 'translateX(100%)'
+      transform: 'translateX(100%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        transform: 'none',
+        opacity: '0'
+      }
     },
     leave: {
-      transform: 'translateX(0%)'
+      transform: 'translateX(0%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        opacity: '1'
+      }
     },
     ...slideTransition
   },
 
   slideFromTop: {
     enter: {
-      transform: 'translateY(-100%)'
+      transform: 'translateY(-100%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        transform: 'none',
+        opacity: '0'
+      }
     },
     leave: {
-      transform: 'translateY(0%)'
+      transform: 'translateY(0%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        opacity: '1'
+      }
     },
     ...slideTransition
   },
   slideFromBottom: {
     enter: {
-      transform: 'translateY(100%)'
+      transform: 'translateY(100%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        transform: 'none',
+        opacity: '0'
+      }
     },
     leave: {
-      transform: 'translateY(0%)'
+      transform: 'translateY(0%)',
+      '@media (prefers-reduced-motion: reduce)': {
+        opacity: '1'
+      }
     },
     ...slideTransition
   },
@@ -485,12 +540,19 @@ const overlayTransitions = {
   scale: {
     enter: {
       opacity: '0',
-      transform: 'scale(0.95)'
+      transform: 'scale(0.95)',
+      // Reduced motion keeps the fade and drops the scale, as in `zoom`.
+      '@media (prefers-reduced-motion: reduce)': {
+        transform: 'none'
+      }
     },
     enterActive: {
       transitionProperty: 'transform, opacity',
       transitionDuration: '200ms',
-      transitionTimingFunction: 'cubic-bezier(0, 0, 0.2, 1)'
+      transitionTimingFunction: 'cubic-bezier(0, 0, 0.2, 1)',
+      '@media (prefers-reduced-motion: reduce)': {
+        transitionProperty: 'opacity'
+      }
     },
     enterTo: {
       opacity: '1',
@@ -503,11 +565,17 @@ const overlayTransitions = {
     leaveActive: {
       transitionProperty: 'transform, opacity',
       transitionDuration: '100ms',
-      transitionTimingFunction: 'cubic-bezier(0.4, 0, 1, 1)'
+      transitionTimingFunction: 'cubic-bezier(0.4, 0, 1, 1)',
+      '@media (prefers-reduced-motion: reduce)': {
+        transitionProperty: 'opacity'
+      }
     },
     leaveTo: {
       opacity: '0',
-      transform: 'scale(0.95)'
+      transform: 'scale(0.95)',
+      '@media (prefers-reduced-motion: reduce)': {
+        transform: 'none'
+      }
     }
   }
 };

--- a/packages/theme/src/components/overlays.ts
+++ b/packages/theme/src/components/overlays.ts
@@ -293,19 +293,27 @@ const drawer = tv({
   ]
 });
 
-// A slide is *only* travel, so there is no fade left to keep once the
-// translate is dropped. Reduced motion therefore swaps the movement for the
-// fade the other transitions keep, instead of leaving the drawer to appear
-// with no transition at all. `addTransitions` derives `-leave-to` from `enter`
-// and `-enter-to` from `leave`, so these two cover all four state classes.
-const slideReducedMotion = {
-  hidden: {
+// One policy, spelled once: reduced motion drops the travel and keeps the
+// fade. `addTransitions` derives `-leave-to` from `enter` and `-enter-to` from
+// `leave`, so a state block covers two of the four generated classes.
+//
+// A slide is *only* travel, so it has no fade to keep -- `slideHidden` and
+// `slideShown` supply one rather than leaving the drawer to appear with no
+// transition at all. The `-active` blocks stay written per transition, because
+// each has to override its own timing in its own spelling.
+const reducedMotion = {
+  dropTransform: {
+    '@media (prefers-reduced-motion: reduce)': {
+      transform: 'none'
+    }
+  },
+  slideHidden: {
     '@media (prefers-reduced-motion: reduce)': {
       transform: 'none',
       opacity: '0'
     }
   },
-  shown: {
+  slideShown: {
     '@media (prefers-reduced-motion: reduce)': {
       opacity: '1'
     }
@@ -367,11 +375,7 @@ const overlayTransitions = {
     enter: {
       opacity: '0',
       transform: 'scale(0.8)',
-      // Reduced motion keeps the fade and drops the scale, rather than
-      // removing the transition -- the overlay should still read as appearing.
-      '@media (prefers-reduced-motion: reduce)': {
-        transform: 'none'
-      }
+      ...reducedMotion.dropTransform
     },
     enterActive: {
       transition: 'all 0.2s ease-in-out',
@@ -393,22 +397,22 @@ const overlayTransitions = {
   slideFromLeft: {
     enter: {
       transform: 'translateX(-100%)',
-      ...slideReducedMotion.hidden
+      ...reducedMotion.slideHidden
     },
     leave: {
       transform: 'translateX(0%)',
-      ...slideReducedMotion.shown
+      ...reducedMotion.slideShown
     },
     ...slideTransition
   },
   slideFromRight: {
     enter: {
       transform: 'translateX(100%)',
-      ...slideReducedMotion.hidden
+      ...reducedMotion.slideHidden
     },
     leave: {
       transform: 'translateX(0%)',
-      ...slideReducedMotion.shown
+      ...reducedMotion.slideShown
     },
     ...slideTransition
   },
@@ -416,22 +420,22 @@ const overlayTransitions = {
   slideFromTop: {
     enter: {
       transform: 'translateY(-100%)',
-      ...slideReducedMotion.hidden
+      ...reducedMotion.slideHidden
     },
     leave: {
       transform: 'translateY(0%)',
-      ...slideReducedMotion.shown
+      ...reducedMotion.slideShown
     },
     ...slideTransition
   },
   slideFromBottom: {
     enter: {
       transform: 'translateY(100%)',
-      ...slideReducedMotion.hidden
+      ...reducedMotion.slideHidden
     },
     leave: {
       transform: 'translateY(0%)',
-      ...slideReducedMotion.shown
+      ...reducedMotion.slideShown
     },
     ...slideTransition
   },
@@ -536,10 +540,7 @@ const overlayTransitions = {
     enter: {
       opacity: '0',
       transform: 'scale(0.95)',
-      // Reduced motion keeps the fade and drops the scale, as in `zoom`.
-      '@media (prefers-reduced-motion: reduce)': {
-        transform: 'none'
-      }
+      ...reducedMotion.dropTransform
     },
     enterActive: {
       transitionProperty: 'transform, opacity',
@@ -568,9 +569,7 @@ const overlayTransitions = {
     leaveTo: {
       opacity: '0',
       transform: 'scale(0.95)',
-      '@media (prefers-reduced-motion: reduce)': {
-        transform: 'none'
-      }
+      ...reducedMotion.dropTransform
     }
   }
 };

--- a/packages/theme/src/components/overlays.ts
+++ b/packages/theme/src/components/overlays.ts
@@ -293,13 +293,28 @@ const drawer = tv({
   ]
 });
 
+// A slide is *only* travel, so there is no fade left to keep once the
+// translate is dropped. Reduced motion therefore swaps the movement for the
+// fade the other transitions keep, instead of leaving the drawer to appear
+// with no transition at all. `addTransitions` derives `-leave-to` from `enter`
+// and `-enter-to` from `leave`, so these two cover all four state classes.
+const slideReducedMotion = {
+  hidden: {
+    '@media (prefers-reduced-motion: reduce)': {
+      transform: 'none',
+      opacity: '0'
+    }
+  },
+  shown: {
+    '@media (prefers-reduced-motion: reduce)': {
+      opacity: '1'
+    }
+  }
+};
+
 const slideTransition = {
   enterActive: {
     transition: 'transform 0.2s cubic-bezier(0.37, 0, 0.63, 1)',
-    // A slide is *only* travel, so there is no fade left to keep once the
-    // translate is dropped. Reduced motion therefore swaps the movement for
-    // the fade the other transitions keep, instead of leaving the drawer to
-    // appear with no transition at all.
     '@media (prefers-reduced-motion: reduce)': {
       transition: 'opacity 0.2s linear'
     }
@@ -378,32 +393,22 @@ const overlayTransitions = {
   slideFromLeft: {
     enter: {
       transform: 'translateX(-100%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        transform: 'none',
-        opacity: '0'
-      }
+      ...slideReducedMotion.hidden
     },
     leave: {
       transform: 'translateX(0%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        opacity: '1'
-      }
+      ...slideReducedMotion.shown
     },
     ...slideTransition
   },
   slideFromRight: {
     enter: {
       transform: 'translateX(100%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        transform: 'none',
-        opacity: '0'
-      }
+      ...slideReducedMotion.hidden
     },
     leave: {
       transform: 'translateX(0%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        opacity: '1'
-      }
+      ...slideReducedMotion.shown
     },
     ...slideTransition
   },
@@ -411,32 +416,22 @@ const overlayTransitions = {
   slideFromTop: {
     enter: {
       transform: 'translateY(-100%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        transform: 'none',
-        opacity: '0'
-      }
+      ...slideReducedMotion.hidden
     },
     leave: {
       transform: 'translateY(0%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        opacity: '1'
-      }
+      ...slideReducedMotion.shown
     },
     ...slideTransition
   },
   slideFromBottom: {
     enter: {
       transform: 'translateY(100%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        transform: 'none',
-        opacity: '0'
-      }
+      ...slideReducedMotion.hidden
     },
     leave: {
       transform: 'translateY(0%)',
-      '@media (prefers-reduced-motion: reduce)': {
-        opacity: '1'
-      }
+      ...slideReducedMotion.shown
     },
     ...slideTransition
   },

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -9452,6 +9452,19 @@ const data: ComponentDoc[] = [
           '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8"> for </span><span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF">`top`/</span><span style="--shiki-light:#032F62;--shiki-dark:#DBEDFF">`bottom`, false for `left`</span><span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF">/`right`</span></span>',
       },
       {
+        identifier: 'animateOnMount',
+        type: {
+          type: '<span class="shiki"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">boolean</span></span>',
+        },
+        isRequired: false,
+        isInternal: false,
+        description:
+          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen instead of starting before anything has been painted. Set it\nto false for an already-open overlay that should simply be there, with no\nreveal. Either way, an overlay opened later by interaction animates\nnormally, and the close animation is unaffected.</p>",
+        tags: { defaultValue: { name: 'defaultValue', value: 'true' } },
+        defaultValue:
+          '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span></span>',
+      },
+      {
         identifier: 'appearance',
         type: {
           type: '<span class="shiki"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">enum</span></span>',
@@ -10071,6 +10084,19 @@ const data: ComponentDoc[] = [
           '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span></span>',
       },
       {
+        identifier: 'animateOnMount',
+        type: {
+          type: '<span class="shiki"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">boolean</span></span>',
+        },
+        isRequired: false,
+        isInternal: false,
+        description:
+          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen instead of starting before anything has been painted. Set it\nto false for an already-open overlay that should simply be there, with no\nreveal. Either way, an overlay opened later by interaction animates\nnormally, and the close animation is unaffected.</p>",
+        tags: { defaultValue: { name: 'defaultValue', value: 'true' } },
+        defaultValue:
+          '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span></span>',
+      },
+      {
         identifier: 'backdrop',
         type: {
           type: '<span class="shiki"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">enum</span></span>',
@@ -10643,6 +10669,19 @@ const data: ComponentDoc[] = [
         isInternal: false,
         description: 'Whether it is open or not',
         tags: {},
+      },
+      {
+        identifier: 'animateOnMount',
+        type: {
+          type: '<span class="shiki"><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">boolean</span></span>',
+        },
+        isRequired: false,
+        isInternal: false,
+        description:
+          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen instead of starting before anything has been painted. Set it\nto false for an already-open overlay that should simply be there, with no\nreveal. Either way, an overlay opened later by interaction animates\nnormally, and the close animation is unaffected.</p>",
+        tags: { defaultValue: { name: 'defaultValue', value: 'true' } },
+        defaultValue:
+          '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span></span>',
       },
       {
         identifier: 'backdrop',

--- a/site/app/components/signature-data.ts
+++ b/site/app/components/signature-data.ts
@@ -9459,7 +9459,7 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen instead of starting before anything has been painted. Set it\nto false for an already-open overlay that should simply be there, with no\nreveal. Either way, an overlay opened later by interaction animates\nnormally, and the close animation is unaffected.</p>",
+          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen. Set it to false for an already-open overlay that should\nsimply be there, with no reveal. An overlay opened later by interaction\nanimates either way, and so does closing.</p>",
         tags: { defaultValue: { name: 'defaultValue', value: 'true' } },
         defaultValue:
           '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span></span>',
@@ -10091,7 +10091,7 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen instead of starting before anything has been painted. Set it\nto false for an already-open overlay that should simply be there, with no\nreveal. Either way, an overlay opened later by interaction animates\nnormally, and the close animation is unaffected.</p>",
+          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen. Set it to false for an already-open overlay that should\nsimply be there, with no reveal. An overlay opened later by interaction\nanimates either way, and so does closing.</p>",
         tags: { defaultValue: { name: 'defaultValue', value: 'true' } },
         defaultValue:
           '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span></span>',
@@ -10678,7 +10678,7 @@ const data: ComponentDoc[] = [
         isRequired: false,
         isInternal: false,
         description:
-          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen instead of starting before anything has been painted. Set it\nto false for an already-open overlay that should simply be there, with no\nreveal. Either way, an overlay opened later by interaction animates\nnormally, and the close animation is unaffected.</p>",
+          "<p>Whether an overlay that is <em>already open the first time it renders</em> --\ndeep-linked open, or restored by a page refresh -- animates in.</p>\n<p>When true (the default) the overlay waits for the browser's first paint\nbefore mounting, so the animation plays against a page the user has\nalready seen. Set it to false for an already-open overlay that should\nsimply be there, with no reveal. An overlay opened later by interaction\nanimates either way, and so does closing.</p>",
         tags: { defaultValue: { name: 'defaultValue', value: 'true' } },
         defaultValue:
           '<span class="shiki"><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF">true</span></span>',

--- a/test-app/tests/unit/overlays/mount-animation-test.ts
+++ b/test-app/tests/unit/overlays/mount-animation-test.ts
@@ -1,0 +1,151 @@
+import { module, test } from 'qunit';
+import {
+  shouldDeferMount,
+  shouldSkipEnterTransition,
+  withoutEnterTransition,
+  INERT_ENTER_TRANSITION,
+  type MountAnimationState
+} from 'frontile/components/overlays/mount-animation';
+
+// The situation this feature exists for: an overlay that is already open the
+// first time it renders, in a real browser, with animations on.
+const openAtMount: MountAnimationState = {
+  isOpenAtMount: true,
+  animationsEnabled: true,
+  animateOnMount: undefined,
+  canWaitForFrame: true,
+  hasPainted: false
+};
+
+module('Unit | Overlays | mount-animation', function () {
+  module('shouldDeferMount', function () {
+    test('defers an overlay that renders already open', function (assert) {
+      assert.true(shouldDeferMount(openAtMount));
+    });
+
+    test('does not defer an overlay that opens later', function (assert) {
+      assert.false(
+        shouldDeferMount({ ...openAtMount, isOpenAtMount: false }),
+        'an overlay opened by interaction already animates against a painted page'
+      );
+    });
+
+    test('does not defer when animations are off', function (assert) {
+      assert.false(
+        shouldDeferMount({ ...openAtMount, animationsEnabled: false }),
+        'nothing to wait for, and tests would see a frame of empty DOM'
+      );
+    });
+
+    test('does not defer when the mount animation is opted out of', function (assert) {
+      assert.false(
+        shouldDeferMount({ ...openAtMount, animateOnMount: false }),
+        'skipping the animation means rendering immediately, not later'
+      );
+    });
+
+    test('does not defer without a frame to wait for', function (assert) {
+      assert.false(
+        shouldDeferMount({ ...openAtMount, canWaitForFrame: false }),
+        'no requestAnimationFrame (prerender) means no paint to wait for'
+      );
+    });
+
+    test('animateOnMount={{true}} is the default, not an override', function (assert) {
+      assert.true(shouldDeferMount({ ...openAtMount, animateOnMount: true }));
+    });
+
+    test('does not defer once the page has painted', function (assert) {
+      assert.false(
+        shouldDeferMount({ ...openAtMount, hasPainted: true }),
+        'a boot slow enough to render after the page appeared is already visible'
+      );
+    });
+  });
+
+  module('shouldSkipEnterTransition', function () {
+    test('skips only when opted out while mounting open', function (assert) {
+      assert.true(
+        shouldSkipEnterTransition({ ...openAtMount, animateOnMount: false })
+      );
+      assert.false(
+        shouldSkipEnterTransition(openAtMount),
+        'the default animates'
+      );
+      assert.false(
+        shouldSkipEnterTransition({
+          ...openAtMount,
+          isOpenAtMount: false,
+          animateOnMount: false
+        }),
+        'an overlay opened by interaction is not a mount, so it still animates'
+      );
+    });
+
+    test('is irrelevant when animations are already off', function (assert) {
+      assert.false(
+        shouldSkipEnterTransition({
+          ...openAtMount,
+          animationsEnabled: false,
+          animateOnMount: false
+        })
+      );
+    });
+
+    test('opting out still skips after the page has painted', function (assert) {
+      assert.true(
+        shouldSkipEnterTransition({
+          ...openAtMount,
+          hasPainted: true,
+          animateOnMount: false
+        }),
+        'the opt-out is about the mount, not about when the mount happens'
+      );
+    });
+  });
+
+  module('withoutEnterTransition', function () {
+    test('replaces the enter half and keeps everything else', function (assert) {
+      const result = withoutEnterTransition({
+        name: 'overlay-transition--zoom',
+        isEnabled: true,
+        leaveClass: 'my-leave'
+      });
+
+      assert.strictEqual(result.name, 'overlay-transition--zoom');
+      assert.true(result.isEnabled, 'the modifier stays enabled');
+      assert.strictEqual(
+        result.leaveClass,
+        'my-leave',
+        'the close animation is untouched'
+      );
+      assert.strictEqual(result.enterClass, INERT_ENTER_TRANSITION.enterClass);
+      assert.strictEqual(
+        result.enterActiveClass,
+        INERT_ENTER_TRANSITION.enterActiveClass
+      );
+      assert.strictEqual(
+        result.enterToClass,
+        INERT_ENTER_TRANSITION.enterToClass
+      );
+    });
+
+    test('overrides consumer-provided enter classes', function (assert) {
+      const result = withoutEnterTransition({
+        enterClass: 'my-enter',
+        enterActiveClass: 'my-enter-active',
+        enterToClass: 'my-enter-to'
+      });
+
+      assert.strictEqual(result.enterClass, INERT_ENTER_TRANSITION.enterClass);
+      assert.strictEqual(
+        result.enterActiveClass,
+        INERT_ENTER_TRANSITION.enterActiveClass
+      );
+      assert.strictEqual(
+        result.enterToClass,
+        INERT_ENTER_TRANSITION.enterToClass
+      );
+    });
+  });
+});

--- a/test-app/tests/unit/overlays/mount-animation-test.ts
+++ b/test-app/tests/unit/overlays/mount-animation-test.ts
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import {
+  afterFirstPaint,
   shouldDeferMount,
   shouldSkipEnterTransition,
   withoutEnterTransition,
@@ -10,7 +11,7 @@ import {
 // The situation this feature exists for: an overlay that is already open the
 // first time it renders, in a real browser, with animations on.
 const openAtMount: MountAnimationState = {
-  isOpenAtMount: true,
+  isFirstOpen: true,
   animationsEnabled: true,
   animateOnMount: undefined,
   canWaitForFrame: true,
@@ -25,7 +26,7 @@ module('Unit | Overlays | mount-animation', function () {
 
     test('does not defer an overlay that opens later', function (assert) {
       assert.false(
-        shouldDeferMount({ ...openAtMount, isOpenAtMount: false }),
+        shouldDeferMount({ ...openAtMount, isFirstOpen: false }),
         'an overlay opened by interaction already animates against a painted page'
       );
     });
@@ -75,7 +76,7 @@ module('Unit | Overlays | mount-animation', function () {
       assert.false(
         shouldSkipEnterTransition({
           ...openAtMount,
-          isOpenAtMount: false,
+          isFirstOpen: false,
           animateOnMount: false
         }),
         'an overlay opened by interaction is not a mount, so it still animates'
@@ -101,6 +102,68 @@ module('Unit | Overlays | mount-animation', function () {
         }),
         'the opt-out is about the mount, not about when the mount happens'
       );
+    });
+  });
+
+  module('afterFirstPaint', function (hooks) {
+    // The page under test has already painted, so a `buffered: true` paint
+    // observer resolves immediately -- which is exactly the ordering that used
+    // to strand the wait: it cancelled its own timeout and then waited on a
+    // frame.
+    let restoreFrame: (() => void) | undefined;
+
+    hooks.afterEach(function () {
+      restoreFrame?.();
+      restoreFrame = undefined;
+    });
+
+    function withoutFrames(): void {
+      const original = window.requestAnimationFrame;
+      window.requestAnimationFrame = (() => 0) as typeof original;
+      restoreFrame = (): void => {
+        window.requestAnimationFrame = original;
+      };
+    }
+
+    test('still runs when frames never arrive, as in a hidden tab', async function (assert) {
+      withoutFrames();
+
+      let ran = false;
+      afterFirstPaint(() => {
+        ran = true;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      assert.true(
+        ran,
+        'the timeout is the backstop for a page that never paints a frame'
+      );
+    });
+
+    test('runs its callback once', async function (assert) {
+      let calls = 0;
+      afterFirstPaint(() => {
+        calls += 1;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      assert.strictEqual(calls, 1);
+    });
+
+    test('cancelling prevents the callback', async function (assert) {
+      withoutFrames();
+
+      let ran = false;
+      const cancel = afterFirstPaint(() => {
+        ran = true;
+      });
+      cancel();
+
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      assert.false(ran, 'a destroyed overlay must not be woken up later');
     });
   });
 

--- a/test-app/tests/unit/overlays/mount-animation-test.ts
+++ b/test-app/tests/unit/overlays/mount-animation-test.ts
@@ -1,6 +1,8 @@
 import { module, test } from 'qunit';
+import { waitUntil } from '@ember/test-helpers';
 import {
   afterFirstPaint,
+  FIRST_PAINT_TIMEOUT,
   shouldDeferMount,
   shouldSkipEnterTransition,
   withoutEnterTransition,
@@ -125,6 +127,10 @@ module('Unit | Overlays | mount-animation', function () {
       };
     }
 
+    // Long enough for the backstop to have fired, whatever it is set to.
+    const pastTheBackstop = (): Promise<void> =>
+      new Promise((resolve) => setTimeout(resolve, FIRST_PAINT_TIMEOUT + 50));
+
     test('still runs when frames never arrive, as in a hidden tab', async function (assert) {
       withoutFrames();
 
@@ -133,7 +139,7 @@ module('Unit | Overlays | mount-animation', function () {
         ran = true;
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 400));
+      await waitUntil(() => ran, { timeout: FIRST_PAINT_TIMEOUT * 3 });
 
       assert.true(
         ran,
@@ -147,9 +153,14 @@ module('Unit | Overlays | mount-animation', function () {
         calls += 1;
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 400));
+      await waitUntil(() => calls > 0, { timeout: FIRST_PAINT_TIMEOUT * 3 });
+      await pastTheBackstop();
 
-      assert.strictEqual(calls, 1);
+      assert.strictEqual(
+        calls,
+        1,
+        'the paint and the backstop do not both fire'
+      );
     });
 
     test('cancelling prevents the callback', async function (assert) {
@@ -161,7 +172,7 @@ module('Unit | Overlays | mount-animation', function () {
       });
       cancel();
 
-      await new Promise((resolve) => setTimeout(resolve, 400));
+      await pastTheBackstop();
 
       assert.false(ran, 'a destroyed overlay must not be woken up later');
     });


### PR DESCRIPTION
## The report

A Modal or Drawer that is open when the page loads — deep-linked open, or restored by a refresh — appears with no animation.

## What's actually happening

It *does* animate. The enter transition just runs before the browser has painted anything. Measured on a cold load:

| | before | after |
|---|---|---|
| first paint | 152 ms | 244 ms |
| overlay mounts | 126 ms (pre-paint) | 249 ms (post-paint) |
| enter animation | 126 → 311 ms | 267 → 468 ms |

Those are two separate runs on a dev server, so what matters is the ordering within each column, not the absolute times: before, the animation started 26 ms *before* the first paint; after, it starts 23 ms after a mount that follows the paint.

The first frame the user ever sees already contains a part-faded overlay, and the backdrop dims a page that is itself only just appearing — so there is no "before" state for the animation to read against. On a heavier app the whole 200 ms can be spent before first paint, at which point it really is invisible.

Two things ruled out along the way: a busy main thread only *delays* the transition (checked with a 400 ms synthetic long task — it still plays in full), and reduced motion wasn't involved.

## The change

**Wait for the paint.** An overlay that renders already open holds out of the DOM until the browser has painted, then mounts and animates against a page the user has seen. The wait keys off paint timings (`PerformanceObserver({type: 'paint'})`) rather than a frame count — a first attempt using a double `requestAnimationFrame` measurably failed, because two frames can elapse on a page that has drawn nothing yet, putting the overlay right back in the first painted frame. Where paint timings don't exist it falls back to two frames, and a 300 ms timeout backstops a page that paints no frame at all, such as one loaded in a background tab. An overlay created after a paint has already been recorded (a slow boot) doesn't wait.

**`@animateOnMount={{false}}`** opts out, for an already-open overlay that should simply be there. Forwarded through Modal and Drawer. It can't be done by disabling the transition modifier — `ember-css-transitions` gates the leave transition on whether the enter one ran, so that would silently take the close animation with it. The enter half is pointed at inert class names instead, which keeps the modifier marked as entered.

**Reduced motion** for `zoom` (Modal), `scale` and the four `slideFrom*` (Drawer), matching what `command` and `tooltip` already did: drop the travel, keep the fade. Slides have no fade to keep, so under reduce they trade the translate for one rather than appearing with no transition. `fade` is deliberately unchanged — a cross-fade is not motion. Each affected component's `## Accessibility` section says what `reduce` does to it.

## Verification

Behaviour confirmed in a real browser, since transitions are disabled under `isTesting()`:

- default mount-open: page paints, *then* the reveal runs — see the table above
- `@animateOnMount={{false}}`: zero transition events at mount, opacity 1, no leftover transition classes
- close animates in both modes; a reopen after close animates normally
- generated CSS carries the `prefers-reduced-motion` rules for zoom, scale and the slides

`afterFirstPaint` has unit tests, including one that stubs `requestAnimationFrame` away to stand in for a hidden tab. It was confirmed as a genuine regression guard by reintroducing the old ordering and watching it fail.

Gates: full suite **1766 tests, 1763 pass, 3 skip, 0 fail** · 15 unit tests for the new module · `glint` clean on `frontile` and `@frontile/theme` · `lint:js` 0 errors · docs linter 0 errors, no demo loss · `site build` 89 rendered, 0 failed · signature data regenerated after a full root build.

## Review round

The second commit is the outcome of a review of the first, and fixes a real defect it shipped: `afterFirstPaint` cleared its own timeout before waiting on a frame, so a page that painted and was then hidden could leave an already-open overlay unrendered — no focus trap, no scroll lock, no `onOpen` — until the tab was looked at again. The reopen latch also fired on any content teardown, not only a close. The rest of that commit is naming, deduplication, doc coverage and prose cleanups. A third commit is cleanup only — shared helpers for the duplicated predicate and transition-wrapping code, a cached capability check, `@cached` on the per-render state object, one `reducedMotion` object in the theme, and `waitUntil` in the new tests. The generated transition data and the measured behaviour are unchanged.

## Known trade-off

Deferring the mount defers the whole portal: `focusTrap`, `lockBodyScroll()` and `onOpen()` land with it, normally a frame later and at worst after the 300 ms backstop. Deferring only the transition would keep those on time but paint the overlay at full opacity for a frame before animating, which is the flash this is trying to avoid.

## Not included

`CommandDialog` doesn't forward `@animateOnMount` (shortcut-opened, and it has its own `command` transition), and Popover/Tooltip/Dropdown get the paint deferral automatically but no opt-out argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


