### PR TITLE
Centre a title-only drawer header's content

### DIFF
--- a/packages/frontile/src/components/overlays/drawer.md
+++ b/packages/frontile/src/components/overlays/drawer.md
@@ -213,6 +213,9 @@ export default class DrawerAppearancesIcon extends Component {
 `h.Title` and `h.Description` for when you need to place them yourself — a blockless
 `<h.Title />` or `<h.Description />` falls back to `@title` / `@description`.
 
+An icon tops out with the title when there is a description under it, and centers against
+the title when there isn't.
+
 ```gts preview
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/packages/frontile/src/components/overlays/drawer/header.gts
+++ b/packages/frontile/src/components/overlays/drawer/header.gts
@@ -18,8 +18,16 @@ export interface DrawerHeaderIconSignature {
   Blocks: { default: [] };
 }
 
+// `data-drawer-header-icon` and `data-drawer-header-description` are what the
+// theme's header grid keys its icon alignment off: the icon spans both text
+// rows only when a description is actually rendered (see `headerContent` in
+// `overlays.ts`). They are structural hooks, not state, so they are always on.
 const DrawerHeaderIcon: TOC<DrawerHeaderIconSignature> = <template>
-  <div class={{twMerge @classFromParent @class}} ...attributes>
+  <div
+    class={{twMerge @classFromParent @class}}
+    data-drawer-header-icon
+    ...attributes
+  >
     {{yield}}
   </div>
 </template>;
@@ -68,7 +76,11 @@ export interface DrawerHeaderDescriptionSignature {
 
 class DrawerHeaderDescription extends Component<DrawerHeaderDescriptionSignature> {
   <template>
-    <div class={{twMerge @classFromParent @class}} ...attributes>
+    <div
+      class={{twMerge @classFromParent @class}}
+      data-drawer-header-description
+      ...attributes
+    >
       {{#if (has-block)}}{{yield}}{{else}}{{@value}}{{/if}}
     </div>
   </template>
@@ -198,7 +210,9 @@ export default class DrawerHeader extends Component<DrawerHeaderSignature> {
             <div class={{@titleClass}}>{{@title}}</div>
           {{/if}}
           {{#if @description}}
-            <div class={{@descriptionClass}}>{{@description}}</div>
+            <div class={{@descriptionClass}} data-drawer-header-description>
+              {{@description}}
+            </div>
           {{/if}}
         {{/if}}
       </div>

--- a/packages/theme/src/components/overlays.ts
+++ b/packages/theme/src/components/overlays.ts
@@ -89,7 +89,21 @@ const drawer = tv({
     // `min-w-0` lets a long title shrink (and truncate, if the consumer asks
     // for it) instead of shoving the actions past the edge -- a flex item's
     // default `min-width: auto` refuses to shrink below its content.
-    headerContent: 'grid grid-cols-[auto_1fr] items-center grow min-w-0',
+    headerContent: [
+      'grid grid-cols-[auto_1fr] items-center grow min-w-0',
+      // The icon only spans two rows when there are two rows of text to span.
+      // A spanning grid item's height is distributed across every track it
+      // covers, so a 40px icon spanning rows in a header with only a title
+      // pushed half its height into a phantom second row: the title (and the
+      // close button, centred against the band) ended up ~10px above the
+      // band's centre with dead space underneath. Keyed off the description
+      // element's own presence with `:has()` -- the same trick `pagination.ts`
+      // and `table.ts` use -- so it follows the rendered structure rather than
+      // a variant the header has to compute and thread through, and it holds
+      // for `@description` and a yielded `<h.Description />` alike.
+      '[&:has([data-drawer-header-description])_[data-drawer-header-icon]]:row-span-2',
+      '[&:has([data-drawer-header-description])_[data-drawer-header-icon]]:self-start'
+    ],
     // Actions are in flow, deliberately, unlike the close button. The close
     // button is chrome this component owns and should not dictate the band's
     // height; whatever a consumer puts here is content, so a taller control
@@ -107,15 +121,18 @@ const drawer = tv({
     body: 'grow overflow-y-auto touch-pan-y',
     footer: 'flex justify-end items-center relative gap-4',
     // Sized from the design: a 40px icon box with a 16px gap to the text.
-    // `self-start` matches the design's `align-items: flex-start` -- the icon
-    // tops out with the title rather than centring across both text rows.
+    //
+    // With a title and a description the icon tops out with the title rather
+    // than centring across both text rows, matching the design's
+    // `align-items: flex-start`; that pairing lives on `headerContent`, which
+    // can see whether a description exists. Title-only, it centres.
     //
     // The gap between the icon column and the text column lives here rather
     // than as `gap-x-*` on the header grid. A column gap applies between the
     // two tracks whether or not the icon track has anything in it, so a
     // header with no icon still had its title indented past the body text
     // below it. As a margin it only exists when an icon does.
-    icon: 'row-span-2 col-start-1 self-start mr-4 size-10 shrink-0 flex items-center justify-center',
+    icon: 'col-start-1 self-center mr-4 size-10 shrink-0 flex items-center justify-center',
     title: 'col-start-2 font-header',
     description: 'col-start-2',
     dragHandle:

--- a/test-app/tests/integration/components/overlays/drawer/header-test.gts
+++ b/test-app/tests/integration/components/overlays/drawer/header-test.gts
@@ -167,6 +167,52 @@ module(
         .hasText('Supporting text');
     });
 
+    // The theme centres a title-only header's icon and only spans it across
+    // both text rows when a description is there, keyed off these attributes
+    // with `:has()`. A template cannot bind an attribute's *name*, so renaming
+    // one here would silently break that alignment -- hence asserting on the
+    // rendered markup, the same way `drawer-selectors-test` does.
+    test('the icon and description carry the hooks the theme aligns them by', async function (assert) {
+      await render(
+        <template>
+          <Header @labelledById="hello" data-test-id="block" as |h|>
+            <h.Icon>icon</h.Icon>
+            <h.Title>Block title</h.Title>
+            <h.Description>Block description</h.Description>
+          </Header>
+
+          <Header
+            @labelledById="hello"
+            @title="Arg title"
+            @description="Arg description"
+            data-test-id="args"
+          />
+
+          <Header
+            @labelledById="hello"
+            @title="Title only"
+            data-test-id="titleOnly"
+          />
+        </template>
+      );
+
+      assert
+        .dom('[data-test-id="block"] [data-drawer-header-icon]')
+        .hasText('icon');
+      assert
+        .dom('[data-test-id="block"] [data-drawer-header-description]')
+        .hasText('Block description');
+      assert
+        .dom('[data-test-id="args"] [data-drawer-header-description]')
+        .hasText('Arg description');
+
+      // Nothing marks a description that was never rendered, which is what
+      // lets the theme tell the two shapes apart.
+      assert
+        .dom('[data-test-id="titleOnly"] [data-drawer-header-description]')
+        .doesNotExist();
+    });
+
     test('a block suppresses the args form', async function (assert) {
       await render(
         <template>


### PR DESCRIPTION
The drawer header's icon was `row-span-2 self-start`, and a spanning grid item's height is distributed across every track it covers. With only a title to span, the 40px icon pushed half its height into a phantom second row — the title sat ~10px above the band's centre with dead space underneath, and the close button (centred against the band) sat that far below the title.

## Fix

The icon now centres by default, and `headerContent` re-applies `row-span-2 self-start` to it only when a description is actually rendered, keyed off a `data-drawer-header-description` hook with `:has()` — the same trick `pagination.ts` and `table.ts` use, so it follows the rendered structure rather than a variant the header has to compute and thread through. It covers `@description` and a yielded `<h.Description />` alike.

## Verification

Measured in the site's "default with an icon" drawer:

| | band centre | icon | title | close |
| --- | --- | --- | --- | --- |
| title + description (unchanged) | 47.3 | 44 (spans 2 rows, `flex-start`) | 36.8 | 47.3 |
| title only (fixed) | 44 | 44 (`center`) | 44 | 44 |

- `pnpm build` — green
- `cd test-app && pnpm ember test` — 1767 tests, 0 failures (including a new one asserting the structural hooks render in both the block and blockless forms; a template can't bind an attribute *name*, so that's what keeps a rename from silently breaking the alignment)
- `pnpm lint:js`, `frontile`/`@frontile/theme` `lint:types` — clean. `pnpm lint:hbs` and test-app `lint:types` are red on `main` already, unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)