### PR TITLE
Fix Switch thumb contrast for light-track intents (e.g. success)

### DIFF
--- a/packages/theme/src/components/forms/forms.ts
+++ b/packages/theme/src/components/forms/forms.ts
@@ -617,42 +617,76 @@ const switchInput = tv({
         wrapper: [
           'group-data-[selected=true]:bg-neutral-firm',
           'group-data-[selected=true]:text-on-neutral-firm'
+        ],
+        thumb: [
+          'group-data-[selected=true]:ring-1',
+          'group-data-[selected=true]:ring-on-neutral-firm'
         ]
       },
       primary: {
         wrapper: [
           'group-data-[selected=true]:bg-primary',
           'group-data-[selected=true]:text-on-primary'
+        ],
+        thumb: [
+          'group-data-[selected=true]:ring-1',
+          'group-data-[selected=true]:ring-on-primary'
         ]
       },
       secondary: {
         wrapper: [
           'group-data-[selected=true]:bg-secondary',
           'group-data-[selected=true]:text-on-secondary'
+        ],
+        thumb: [
+          'group-data-[selected=true]:ring-1',
+          'group-data-[selected=true]:ring-on-secondary'
         ]
       },
       tertiary: {
         wrapper: [
           'group-data-[selected=true]:bg-tertiary',
           'group-data-[selected=true]:text-on-tertiary'
+        ],
+        thumb: [
+          'group-data-[selected=true]:ring-1',
+          'group-data-[selected=true]:ring-on-tertiary'
         ]
       },
       success: {
         wrapper: [
           'group-data-[selected=true]:bg-success',
           'group-data-[selected=true]:text-on-success'
+        ],
+        // `success` DEFAULT (green-400) is close enough in luminance to white
+        // that a plain white thumb almost disappears into the track -- ~1.3:1
+        // contrast, far under the 3:1 UI-component minimum. The ring reuses
+        // the same on-success contrast token the wrapper's text already
+        // relies on, so it only becomes visible where the track is too light
+        // for the thumb to read on its own.
+        thumb: [
+          'group-data-[selected=true]:ring-1',
+          'group-data-[selected=true]:ring-on-success'
         ]
       },
       warning: {
         wrapper: [
           'group-data-[selected=true]:bg-warning',
           'group-data-[selected=true]:text-on-warning'
+        ],
+        thumb: [
+          'group-data-[selected=true]:ring-1',
+          'group-data-[selected=true]:ring-on-warning'
         ]
       },
       danger: {
         wrapper: [
           'group-data-[selected=true]:bg-danger',
           'group-data-[selected=true]:text-on-danger'
+        ],
+        thumb: [
+          'group-data-[selected=true]:ring-1',
+          'group-data-[selected=true]:ring-on-danger'
         ]
       }
     }

--- a/test-app/tests/integration/components/forms/switch-test.gts
+++ b/test-app/tests/integration/components/forms/switch-test.gts
@@ -182,6 +182,21 @@ module('Integration | Component | @frontile/forms/Switch', function (hooks) {
     assert.dom('[data-component="form-feedback"]').doesNotExist();
   });
 
+  test('the thumb gets a contrast ring for intents whose track color is too light for a plain white knob (e.g. success)', async function (assert) {
+    await render(
+      <template>
+        <Switch @label="Name" @intent="success" @defaultSelected={{true}} />
+      </template>
+    );
+
+    const thumb = find('[data-test-id="switch-thumb-content"]') as HTMLElement;
+
+    assert.ok(
+      thumb.className.includes('ring-on-success'),
+      `thumb should include a ring class using the on-success contrast token (classes: ${thumb.className})`
+    );
+  });
+
   test('it add classes to all slots', async function (assert) {
     const classes = {
       base: 'my-base-class',


### PR DESCRIPTION
## Summary
- The Switch thumb (knob) was hardcoded to `bg-white` regardless of `intent`, so against the `success` track (`green-400`, ~1.3:1 contrast with white) the knob nearly disappears — most visible in dark mode where the track reads lighter/pastel.
- Each intent's thumb now gets a `ring-1 ring-on-{intent}` when selected, reusing the same `on-{intent}` contrast token the track's own text already relies on. For darker tracks (primary, danger, etc.) `on-{intent}` is white, so the ring is invisible and nothing changes visually. For light tracks (`success`, and similarly `warning`/`secondary`), it resolves to black, giving the knob a defining outline exactly where it's needed.

## Test plan
- [x] Added a regression test (TDD: red before the fix, green after) in `test-app/tests/integration/components/forms/switch-test.gts`
- [x] Full suite: `cd test-app && CI=true pnpm ember test` — 1765 pass / 3 skip / 0 fail
- [x] `pnpm --filter @frontile/theme build` and `pnpm --filter @frontile/theme lint:types` clean
- [x] Verified in a live browser session that the success-intent thumb's computed `box-shadow` is a solid black 1px ring when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)