### PR TITLE
fix(utilities): defer SegmentedControl's initial indicator measurement

### DIFF
--- a/packages/frontile/src/utils/selection-indicator.ts
+++ b/packages/frontile/src/utils/selection-indicator.ts
@@ -25,6 +25,12 @@ class SelectionIndicator {
   #resize = deferredWork('@frontile/utils:selection-indicator:resize');
   #isReady = false;
 
+  // Whether a real measurement has ever landed. Only the very first one is
+  // forced-layout-sensitive (see `setupContainer`); once it has happened, a
+  // click that moves the selection is no longer racing an ancestor's own
+  // mount-time transition, so there is no reason to defer those.
+  #hasMeasuredOnce = false;
+
   /**
    * Modifier to place on the container element. Observes its size and, once
    * a target is selected, publishes that target's geometry as CSS custom
@@ -45,7 +51,22 @@ class SelectionIndicator {
     if (this.#target) {
       this.#observer.observe(this.#target);
     }
-    this.#measure();
+
+    // Before the first real measurement, this call is happening during the
+    // control's own initial mount -- the same render pass that can be
+    // mounting an ancestor overlay's enter transition. Forcing layout here
+    // lands at an arbitrary point in `ember-css-transitions`' own
+    // reflow-then-swap sequence for that transition, which is enough to make
+    // the browser skip it entirely. `ResizeObserver.observe()` above already
+    // guarantees an initial, asynchronous notification for `element` (and for
+    // the target, if already claimed), so leaving it to that -- deferred
+    // through `#resize` like any other resize -- gets the same measurement
+    // without the synchronous reflow. Once a first measurement has actually
+    // landed, later remounts of this same container are no longer racing
+    // anything, so measure immediately as before.
+    if (this.#hasMeasuredOnce) {
+      this.#measure();
+    }
 
     return (): void => {
       this.#shutDown();
@@ -57,11 +78,17 @@ class SelectionIndicator {
    * so a consumer composing its own modifier -- a navigation bar that also has
    * to write `aria-current` -- can delegate here rather than reimplement the
    * handover rules below.
+   *
+   * Measures synchronously once a first measurement has already landed --
+   * see `setupContainer` -- so a click that moves the selection updates the
+   * indicator immediately rather than a frame later.
    */
   claim(element: HTMLElement): void {
     this.#target = element;
     this.#observer?.observe(element);
-    this.#measure();
+    if (this.#hasMeasuredOnce) {
+      this.#measure();
+    }
   }
 
   /**
@@ -138,6 +165,8 @@ class SelectionIndicator {
     container.style.setProperty('--fr-si-y', `${target.offsetTop}px`);
     container.style.setProperty('--fr-si-width', `${width}px`);
     container.style.setProperty('--fr-si-height', `${height}px`);
+
+    this.#hasMeasuredOnce = true;
 
     if (!this.#isReady) {
       this.#isReady = true;

--- a/test-app/tests/integration/components/buttons/segmented-control-test.gts
+++ b/test-app/tests/integration/components/buttons/segmented-control-test.gts
@@ -408,6 +408,8 @@ module(
       const container = find('[role="radiogroup"]') as HTMLElement;
       const items = findAll('[role="radio"]') as HTMLButtonElement[];
 
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
+
       assert.strictEqual(
         container.style.getPropertyValue('--fr-si-width'),
         `${items[0]!.offsetWidth}px`,
@@ -461,6 +463,8 @@ module(
 
       const container = find('[role="radiogroup"]') as HTMLElement;
       const indicator = find('[aria-hidden="true"]') as HTMLElement;
+
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
 
       assert.ok(
         container.hasAttribute('data-fr-si-ready'),
@@ -674,6 +678,8 @@ module(
 
       const container = find('[role="radiogroup"]') as HTMLElement;
       const items = findAll('[role="radio"]') as HTMLButtonElement[];
+
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
 
       assert.ok(
         container.hasAttribute('data-fr-si-ready'),
@@ -1363,6 +1369,8 @@ module(
       const container = find('[role="radiogroup"]') as HTMLElement;
       const selected = findAll('[role="radio"]')[1] as HTMLElement;
 
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
+
       const indicatorBox = indicator.getBoundingClientRect();
       const containerBox = container.getBoundingClientRect();
       const selectedBox = selected.getBoundingClientRect();
@@ -1506,6 +1514,7 @@ module(
       );
 
       const container = find('[role="radiogroup"]') as HTMLElement;
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
       assert.ok(
         container.hasAttribute('data-fr-si-ready'),
         'ready while a real item is selected'
@@ -1690,6 +1699,8 @@ module(
       const container = find('[role="radiogroup"]') as HTMLElement;
       const indicator = find('[aria-hidden="true"]') as HTMLElement;
 
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
+
       assert.ok(
         container.matches('.my-control[data-fr-si-ready]'),
         'the ready attribute is on the container, which is what the rule keys off'
@@ -1777,7 +1788,10 @@ module(
       );
 
       const indicator = find('[aria-hidden="true"]') as HTMLElement;
+      const container = find('[role="radiogroup"]') as HTMLElement;
       const selected = findAll('[role="radio"]')[0] as HTMLElement;
+
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
 
       const computed = window.getComputedStyle(indicator);
       assert.strictEqual(
@@ -1843,6 +1857,8 @@ module(
       const items = findAll('[role="radio"]') as HTMLElement[];
       const indicator = find('[aria-hidden="true"]') as HTMLElement;
       const selected = items[2]!;
+
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
 
       assert.strictEqual(
         window.getComputedStyle(container).direction,

--- a/test-app/tests/integration/components/navigation/tabs-test.gts
+++ b/test-app/tests/integration/components/navigation/tabs-test.gts
@@ -633,6 +633,10 @@ module(
         'span[aria-hidden="true"]'
       ) as HTMLElement;
 
+      await waitUntil(() => list.hasAttribute('data-fr-si-ready'), {
+        timeout: 1000
+      });
+
       assert
         .dom(list)
         .hasAttribute(

--- a/test-app/tests/integration/components/utilities/selection-indicator-test.gts
+++ b/test-app/tests/integration/components/utilities/selection-indicator-test.gts
@@ -1,12 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, find } from '@ember/test-helpers';
+import { render, settled, waitUntil, find } from '@ember/test-helpers';
 import { selectionIndicator } from 'frontile';
 import { cell } from 'ember-resources';
-
-function nextFrame(): Promise<void> {
-  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
-}
 
 module(
   'Integration | Utility | selection-indicator | @frontile/utilities',
@@ -41,6 +37,13 @@ module(
 
       const container = find('[data-test-container]') as HTMLElement;
       const b = find('[data-test-item="b"]') as HTMLElement;
+
+      // The initial measurement is left to `ResizeObserver`'s own guaranteed
+      // first notification rather than forced synchronously during setup (a
+      // synchronous forced reflow there can land mid-sequence in an
+      // ancestor's own CSS transition and make the browser skip it), so it
+      // takes a frame to land.
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
 
       assert.strictEqual(
         container.style.getPropertyValue('--fr-si-width'),
@@ -90,6 +93,7 @@ module(
       );
 
       const container = find('[data-test-container]') as HTMLElement;
+      await waitUntil(() => container.hasAttribute('data-fr-si-ready'));
       assert.ok(
         container.hasAttribute('data-fr-si-ready'),
         'ready once a real measurement has landed and a frame has passed'
@@ -181,9 +185,10 @@ module(
       width.current = '500px';
       await settled();
       // ResizeObserver delivers off the microtask queue, which `settled()`
-      // does not await; give it a frame.
-      await nextFrame();
-      await nextFrame();
+      // does not await; poll for it instead of guessing a frame count.
+      await waitUntil(
+        () => container.style.getPropertyValue('--fr-si-width') !== before
+      );
 
       assert.notStrictEqual(
         container.style.getPropertyValue('--fr-si-width'),


### PR DESCRIPTION
## Summary
- `SelectionIndicator` (used by `SegmentedControl` and `Tabs`) forced a synchronous layout read/write during modifier setup, to measure the initially-selected item. When a `SegmentedControl` sits inside a `Drawer`/`Modal`, that forced reflow happens in the exact same render pass as the overlay's own `ember-css-transitions`-driven enter animation, and lands at an arbitrary point in that library's reflow-then-swap sequence — enough to make the browser skip the transition outright. The drawer would snap open instead of sliding in.
- Fix: leave the *first* measurement to `ResizeObserver.observe()`'s own guaranteed async initial notification instead of forcing it. A `#hasMeasuredOnce` flag scopes this to only the initial mount — once a real measurement has landed, a click that moves the selection still measures synchronously, so the indicator keeps tracking selection immediately with no added lag.
- Updated the existing `selection-indicator` and `SegmentedControl` integration tests to `waitUntil` the ready attribute rather than asserting synchronously, since the very first measurement is now genuinely async.

## Test plan
- [x] `ember test --filter selection-indicator` — 5/5 pass
- [x] `ember test --filter SegmentedControl` — 50/50 pass (3 consecutive runs, no flakiness)
- [x] `ember test --filter Tabs` / `TabNav` — pass (share the same utility)
- [x] Full `ember test` suite — 1826 pass, 3 pre-existing skips, 0 fail
- [x] Manually verified in a sandbox: a Drawer containing two `SegmentedControl`s now slides in correctly, and clicking between items still moves the indicator immediately (no stale-selection regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)